### PR TITLE
new design implemented

### DIFF
--- a/app/friends/page.tsx
+++ b/app/friends/page.tsx
@@ -1,94 +1,85 @@
 "use client";
 
 import { FriendsList } from "@/components/friends-list";
-import { UserPlus } from "lucide-react";
 import { useState, useEffect } from "react";
 import { AddFriendsModal } from "@/components/add-friends-modal";
-import { motion } from "framer-motion";
-import { fadeIn } from "@/utils/animations";
-import { useAuthStore } from "@/stores/authStore";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
+import { Card, Icons } from "@/lib/splito-design";
 
 export default function FriendsPage() {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { user } = useAuthStore();
-  const router = useRouter();
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [search, setSearch] = useState("");
 
-  // Listen for custom event to open the add friend modal
   useEffect(() => {
     const handleOpenModal = () => setIsModalOpen(true);
     document.addEventListener("open-add-friend-modal", handleOpenModal);
-
-    return () => {
-      document.removeEventListener("open-add-friend-modal", handleOpenModal);
-    };
+    return () => document.removeEventListener("open-add-friend-modal", handleOpenModal);
   }, []);
 
-  // Handle profile click to redirect to settings
-  const handleProfileClick = () => {
-    router.push("/settings");
-  };
-
   return (
-    <motion.div
-      variants={fadeIn}
-      initial="initial"
-      animate="animate"
-      className="w-full -mt-2"
-    >
-      <div className="flex items-center justify-between px-3 sm:px-5 py-3 sm:py-4">
-        <h1 className="text-mobile-base sm:text-xl font-medium text-white">
+    <div className="flex-1 flex flex-col min-w-0">
+      <div
+        className="border-b border-white/[0.07] px-4 sm:px-7 flex items-center h-14 sm:h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
+      >
+        <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
           Friends
         </h1>
-        <div className="flex items-center gap-3 sm:gap-4">
-          <button
-            onClick={() => setIsModalOpen(true)}
-            className="flex items-center justify-center gap-1 sm:gap-2 rounded-full bg-transparent border border-white/20 text-white h-10 sm:h-12 px-4 sm:px-6 text-mobile-sm sm:text-base font-medium hover:bg-white/5 transition-all"
-          >
-            <UserPlus className="h-4 w-4 sm:h-5 sm:w-5" strokeWidth={1.5} />
-            <span>Add Friend</span>
-          </button>
-          <button
-            onClick={handleProfileClick}
-            className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:from-purple-500/30 hover:to-blue-500/30 transition-all cursor-pointer"
-          >
-            <div className="h-full w-full rounded-full overflow-hidden bg-[#0f0f10]">
-              {user?.image ? (
-                <Image
-                  src={user.image}
-                  alt="Profile"
-                  width={56}
-                  height={56}
-                  className="h-full w-full object-cover"
-                />
-              ) : (
-                <Image
-                  src={`https://api.dicebear.com/9.x/identicon/svg?seed=${
-                    user?.id || user?.email || "user"
-                  }`}
-                  alt="Profile"
-                  width={56}
-                  height={56}
-                  className="h-full w-full"
-                  onError={(e) => {
-                    console.error(`Error loading identicon for user`);
-                    const target = e.target as HTMLImageElement;
-                    target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=user`;
-                  }}
-                />
-              )}
-            </div>
-          </button>
-        </div>
       </div>
-
-      <FriendsList />
-
-      <AddFriendsModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-      />
-    </motion.div>
+      <div className="flex-1 p-4 sm:p-7 overflow-y-auto">
+        <div
+          className="grid gap-4 sm:gap-5 mb-5 sm:mb-6"
+          style={{ gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))" }}
+        >
+          <Card className="p-4 sm:p-[22px]">
+            <p className="text-[15px] font-extrabold text-[#f5f5f5] mb-1 tracking-[-0.01em]">
+              Invite a Friend
+            </p>
+            <p className="text-[12px] font-medium mb-4" style={{ color: "#999" }}>
+              Share a link or invite by email
+            </p>
+            <div className="flex gap-2">
+              <input
+                placeholder="friend@email.com"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                className="flex-1 rounded-xl py-2.5 px-3.5 text-[13px] font-medium text-white outline-none border border-white/[0.09] bg-white/[0.05]"
+              />
+              <button
+                onClick={() => setIsModalOpen(true)}
+                className="rounded-xl py-2.5 px-4 text-[13px] font-extrabold text-[#0a0a0a] transition-all hover:opacity-90"
+                style={{ background: "#22D3EE" }}
+              >
+                Invite
+              </button>
+            </div>
+            <div className="flex items-center gap-2 mt-3.5">
+              <div className="flex-1 h-px bg-white/[0.07]" />
+              <span className="text-[11px] font-semibold" style={{ color: "#888" }}>or</span>
+              <div className="flex-1 h-px bg-white/[0.07]" />
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsModalOpen(true)}
+              className="splito-abtn w-full mt-3.5 py-2.5 rounded-xl text-[13px] font-semibold flex items-center justify-center gap-1.5 border border-white/[0.09] bg-white/[0.05] text-[#d4d4d4] transition-all"
+            >
+              <Icons.link /> Copy invite link
+            </button>
+          </Card>
+        </div>
+        <div
+          className="flex items-center gap-2 rounded-[14px] py-2.5 px-4 mb-4 sm:mb-5 border border-white/[0.08] bg-white/[0.04]"
+        >
+          <span className="text-[#999]">{Icons.search({})}</span>
+          <input
+            placeholder="Search friends…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="flex-1 bg-transparent border-none text-white text-[14px] outline-none font-medium"
+          />
+        </div>
+        <FriendsList search={search} />
+      </div>
+      <AddFriendsModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+    </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -199,3 +199,59 @@ input[type="number"] {
     @apply bg-background text-foreground;
   }
 }
+
+/* Splito design – personal view */
+.splito-page-wrap {
+  background: #0b0b0b;
+  min-height: 100vh;
+  font-family: var(--font-dm-sans), "DM Sans", "Segoe UI", sans-serif;
+}
+.splito-nav-item:hover {
+  background: rgba(255, 255, 255, 0.07) !important;
+  color: #e8e8e8 !important;
+}
+.splito-row-hover:hover {
+  background: rgba(255, 255, 255, 0.03) !important;
+}
+.splito-btn:hover {
+  opacity: 0.85;
+  transform: translateY(-1px);
+}
+.splito-abtn:hover {
+  border-color: rgba(34, 211, 238, 0.35) !important;
+  color: #22d3ee !important;
+  background: rgba(34, 211, 238, 0.08) !important;
+}
+.splito-sbtn:hover {
+  background: #22d3ee !important;
+  color: #0a0a0a !important;
+  border-color: #22d3ee !important;
+  box-shadow: 0 0 20px rgba(34, 211, 238, 0.4) !important;
+}
+.splito-back-btn:hover {
+  opacity: 0.9;
+}
+input::placeholder {
+  color: #555;
+}
+@keyframes splito-fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes splito-fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.font-dm-mono {
+  font-family: "DM Mono", monospace;
+}

--- a/app/groups/[id]/activity/page.tsx
+++ b/app/groups/[id]/activity/page.tsx
@@ -1,91 +1,170 @@
 "use client";
 
-import Image from "next/image";
+import { useMemo } from "react";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { useAuthStore } from "@/stores/authStore";
+import { formatRelativeTime } from "@/lib/utils";
+
+type ExpenseItem = {
+  id: string;
+  name: string;
+  amount: number;
+  currency: string | null;
+  paidBy: string;
+  createdAt: Date;
+  splitType: string;
+  expenseParticipants?: { userId: string; amount: number }[];
+};
+
+type JoinItem = {
+  type: "join";
+  id: string;
+  date: Date;
+  userName: string;
+};
+
+type ActivityItem =
+  | { type: "expense"; id: string; date: Date; expense: ExpenseItem; paidByName: string; settlementPayeeName: string | null; settlementPayeeId: string | null }
+  | JoinItem;
 
 export default function GroupActivityPage() {
   const { user } = useAuthStore();
   const { group, formatCurrency } = useGroupLayout();
 
+  const activities = useMemo((): ActivityItem[] => {
+    if (!group || !user) return [];
+
+    const list: ActivityItem[] = [];
+
+    for (const expense of group.expenses ?? []) {
+      const paidBy = group.groupUsers.find((u) => u.user.id === expense.paidBy)?.user;
+      const paidByName = paidBy?.name ?? "Someone";
+      let settlementPayeeName: string | null = null;
+      let settlementPayeeId: string | null = null;
+      if (expense.splitType === "SETTLEMENT" && expense.expenseParticipants) {
+        const payeeParticipant = expense.expenseParticipants.find((p: { amount: number }) => p.amount > 0);
+        if (payeeParticipant) {
+          const payeeUser = group.groupUsers.find((u) => u.user.id === payeeParticipant.userId)?.user;
+          settlementPayeeName = payeeUser?.name ?? null;
+          settlementPayeeId = payeeParticipant.userId ?? null;
+        }
+      }
+      list.push({
+        type: "expense",
+        id: expense.id,
+        date: new Date(expense.createdAt),
+        expense: expense as ExpenseItem,
+        paidByName,
+        settlementPayeeName,
+        settlementPayeeId,
+      });
+    }
+
+    for (const gu of group.groupUsers ?? []) {
+      const createdAt = (gu as { createdAt?: Date }).createdAt;
+      if (createdAt) {
+        list.push({
+          type: "join",
+          id: `join-${gu.userId}`,
+          date: createdAt instanceof Date ? createdAt : new Date(createdAt),
+          userName: gu.user?.name ?? "Someone",
+        });
+      }
+    }
+
+    list.sort((a, b) => b.date.getTime() - a.date.getTime());
+    return list;
+  }, [group, user]);
+
   if (!group || !user) return null;
 
-  const expenses = group.expenses;
-
   return (
-    <div className="p-4 sm:p-6 space-y-3 sm:space-y-4">
+    <div className="p-4 sm:p-6 space-y-0">
       <h3 className="text-mobile-lg sm:text-xl font-medium text-white mb-3 sm:mb-4">
         Recent Activity
       </h3>
 
-      {expenses && expenses.length > 0 ? (
-        expenses.map((expense, index) => {
-          const paidBy = group.groupUsers.find((u) => u.user.id === expense.paidBy)?.user;
-          if (!paidBy) return null;
-
-          let settlementPayee = null;
-          if (expense.splitType === "SETTLEMENT" && expense.expenseParticipants) {
-            const payeeParticipant = expense.expenseParticipants.find((p: { amount: number }) => p.amount > 0);
-            if (payeeParticipant) {
-              settlementPayee = group.groupUsers.find(
-                (u) => u.user.id === payeeParticipant.userId
-              )?.user;
+      {activities.length > 0 ? (
+        <ul className="divide-y divide-white/10">
+          {activities.map((item) => {
+            if (item.type === "join") {
+              return (
+                <li
+                  key={item.id}
+                  className="py-3 sm:py-3.5 flex items-center justify-between gap-4"
+                >
+                  <span className="text-mobile-base sm:text-base text-white">
+                    {item.userName} joined the group
+                  </span>
+                  <span className="text-mobile-sm sm:text-sm text-white/60 shrink-0">
+                    {formatRelativeTime(item.date)}
+                  </span>
+                </li>
+              );
             }
-          }
 
-          return (
-            <div
-              key={expense.id}
-              className="p-3 sm:p-4 rounded-xl flex items-center justify-between"
-            >
-              <div className="flex items-center gap-3">
-                <div className="h-8 w-8 sm:h-10 sm:w-10 overflow-hidden rounded-full">
-                  <Image
-                    src={
-                      paidBy.image ||
-                      `https://api.dicebear.com/9.x/identicon/svg?seed=${paidBy.id}`
-                    }
-                    alt={paidBy.name || "User"}
-                    width={40}
-                    height={40}
-                    className="h-full w-full object-cover"
-                    onError={(e) => {
-                      const target = e.target as HTMLImageElement;
-                      target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${paidBy.id}`;
-                    }}
-                  />
-                </div>
-                <div>
-                  {expense.splitType === "SETTLEMENT" && settlementPayee ? (
-                    <p className="text-mobile-base sm:text-base text-white">
-                      <span className="font-medium">
-                        {paidBy.id === user?.id ? "You" : paidBy.name}
-                      </span>{" "}
-                      marked payment to{" "}
-                      <span className="font-medium">
-                        {settlementPayee.id === user?.id ? "you" : settlementPayee.name}
-                      </span>{" "}
-                      as settled
-                    </p>
-                  ) : (
-                    <p className="text-mobile-base sm:text-base text-white">
-                      <span className="font-medium">
-                        {paidBy.id === user?.id ? "You" : paidBy.name}
-                      </span>{" "}
-                      added expense &quot;{expense.name}&quot;
-                    </p>
-                  )}
-                  <p className="text-mobile-xs sm:text-sm text-white/60">
-                    {new Date(expense.createdAt).toLocaleString()}
-                  </p>
-                </div>
-              </div>
-              <div className="text-mobile-base sm:text-base text-white font-medium">
-                {formatCurrency(expense.amount, expense.currency || "USD")}
-              </div>
-            </div>
-          );
-        })
+            const { expense, paidByName, settlementPayeeName, settlementPayeeId } = item;
+            const isYouPayer = expense.paidBy === user.id;
+            const payerLabel = isYouPayer ? "You" : paidByName;
+            const amountStr = formatCurrency(expense.amount, expense.currency || "USD");
+
+            // Red = money out, Green = money in (from current user's perspective)
+            let amountColor: "red" | "green" | "white" = "white";
+            if (expense.splitType === "SETTLEMENT" && settlementPayeeName && settlementPayeeId !== null) {
+              if (settlementPayeeId === user.id) amountColor = "green"; // payment to you as settled
+              else if (isYouPayer) amountColor = "red"; // you marked payment to someone as settled
+            } else {
+              if (isYouPayer) amountColor = "red"; // you added expense (you paid)
+              else {
+                const myPart = expense.expenseParticipants?.find((p: { userId: string }) => p.userId === user.id);
+                if (myPart) {
+                  if (myPart.amount < 0) amountColor = "red"; // you owe
+                  else if (myPart.amount > 0) amountColor = "green"; // they owe you
+                }
+              }
+            }
+
+            const amountStyle =
+              amountColor === "red"
+                ? { color: "#FF4444" }
+                : amountColor === "green"
+                  ? { color: "#53E45E" }
+                  : undefined;
+            const amountClass = amountColor === "white" ? "text-white" : undefined;
+
+            if (expense.splitType === "SETTLEMENT" && settlementPayeeName) {
+              const payeeLabel = settlementPayeeId === user.id ? "you" : settlementPayeeName;
+              return (
+                <li
+                  key={item.id}
+                  className="py-3 sm:py-3.5 flex items-center justify-between gap-4"
+                >
+                  <span className="text-mobile-base sm:text-base text-white">
+                    {payerLabel} marked payment to {payeeLabel} as settled{" "}
+                    <span style={amountStyle} className={amountClass}>({amountStr})</span>
+                  </span>
+                  <span className="text-mobile-sm sm:text-sm text-white/60 shrink-0">
+                    {formatRelativeTime(item.date)}
+                  </span>
+                </li>
+              );
+            }
+
+            return (
+              <li
+                key={item.id}
+                className="py-3 sm:py-3.5 flex items-center justify-between gap-4"
+              >
+                <span className="text-mobile-base sm:text-base text-white">
+                  {payerLabel} added {expense.name} <span style={amountStyle} className={amountClass}>({amountStr})</span>
+                </span>
+                <span className="text-mobile-sm sm:text-sm text-white/60 shrink-0">
+                  {formatRelativeTime(item.date)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
       ) : (
         <div className="text-center py-8 sm:py-12 text-mobile-base sm:text-base text-white/60">
           No activity yet

--- a/app/groups/[id]/activity/page.tsx
+++ b/app/groups/[id]/activity/page.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { useAuthStore } from "@/stores/authStore";
 import { formatRelativeTime } from "@/lib/utils";
+import { Card, SectionLabel, T, A, G } from "@/lib/splito-design";
 
 type ExpenseItem = {
   id: string;
@@ -24,8 +25,24 @@ type JoinItem = {
 };
 
 type ActivityItem =
-  | { type: "expense"; id: string; date: Date; expense: ExpenseItem; paidByName: string; settlementPayeeName: string | null; settlementPayeeId: string | null }
+  | {
+      type: "expense";
+      id: string;
+      date: Date;
+      expense: ExpenseItem;
+      paidByName: string;
+      settlementPayeeName: string | null;
+      settlementPayeeId: string | null;
+    }
   | JoinItem;
+
+const DOT_COLORS: Record<string, string> = {
+  paid: G,
+  added: A,
+  settled: "#A78BFA",
+  created: "#FB923C",
+  join: "#FB923C",
+};
 
 export default function GroupActivityPage() {
   const { user } = useAuthStore();
@@ -42,9 +59,13 @@ export default function GroupActivityPage() {
       let settlementPayeeName: string | null = null;
       let settlementPayeeId: string | null = null;
       if (expense.splitType === "SETTLEMENT" && expense.expenseParticipants) {
-        const payeeParticipant = expense.expenseParticipants.find((p: { amount: number }) => p.amount > 0);
+        const payeeParticipant = expense.expenseParticipants.find(
+          (p: { amount: number }) => p.amount > 0
+        );
         if (payeeParticipant) {
-          const payeeUser = group.groupUsers.find((u) => u.user.id === payeeParticipant.userId)?.user;
+          const payeeUser = group.groupUsers.find(
+            (u) => u.user.id === payeeParticipant.userId
+          )?.user;
           settlementPayeeName = payeeUser?.name ?? null;
           settlementPayeeId = payeeParticipant.userId ?? null;
         }
@@ -66,7 +87,8 @@ export default function GroupActivityPage() {
         list.push({
           type: "join",
           id: `join-${gu.userId}`,
-          date: createdAt instanceof Date ? createdAt : new Date(createdAt),
+          date:
+            createdAt instanceof Date ? createdAt : new Date(createdAt),
           userName: gu.user?.name ?? "Someone",
         });
       }
@@ -79,95 +101,228 @@ export default function GroupActivityPage() {
   if (!group || !user) return null;
 
   return (
-    <div className="p-4 sm:p-6 space-y-0">
-      <h3 className="text-mobile-lg sm:text-xl font-medium text-white mb-3 sm:mb-4">
-        Recent Activity
-      </h3>
+    <div style={{ padding: "0 0 24px" }}>
+      <SectionLabel>Recent Activity</SectionLabel>
 
       {activities.length > 0 ? (
-        <ul className="divide-y divide-white/10">
-          {activities.map((item) => {
+        <Card>
+          {activities.map((item, idx) => {
             if (item.type === "join") {
               return (
-                <li
+                <div
                   key={item.id}
-                  className="py-3 sm:py-3.5 flex items-center justify-between gap-4"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 14,
+                    padding: "15px 22px",
+                    borderBottom:
+                      idx < activities.length - 1
+                        ? "1px solid rgba(255,255,255,0.06)"
+                        : "none",
+                  }}
                 >
-                  <span className="text-mobile-base sm:text-base text-white">
+                  <div
+                    style={{
+                      width: 9,
+                      height: 9,
+                      borderRadius: "50%",
+                      background: DOT_COLORS.join,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <p
+                    style={{
+                      flex: 1,
+                      fontSize: 13,
+                      color: T.body,
+                      fontWeight: 500,
+                    }}
+                  >
                     {item.userName} joined the group
-                  </span>
-                  <span className="text-mobile-sm sm:text-sm text-white/60 shrink-0">
+                  </p>
+                  <span
+                    style={{
+                      color: T.sub,
+                      fontSize: 12,
+                      flexShrink: 0,
+                      fontWeight: 600,
+                    }}
+                  >
                     {formatRelativeTime(item.date)}
                   </span>
-                </li>
+                </div>
               );
             }
 
-            const { expense, paidByName, settlementPayeeName, settlementPayeeId } = item;
+            const {
+              expense,
+              paidByName,
+              settlementPayeeName,
+              settlementPayeeId,
+            } = item;
             const isYouPayer = expense.paidBy === user.id;
             const payerLabel = isYouPayer ? "You" : paidByName;
-            const amountStr = formatCurrency(expense.amount, expense.currency || "USD");
+            const amountStr = formatCurrency(
+              expense.amount,
+              expense.currency || "USD"
+            );
 
-            // Red = money out, Green = money in (from current user's perspective)
-            let amountColor: "red" | "green" | "white" = "white";
-            if (expense.splitType === "SETTLEMENT" && settlementPayeeName && settlementPayeeId !== null) {
-              if (settlementPayeeId === user.id) amountColor = "green"; // payment to you as settled
-              else if (isYouPayer) amountColor = "red"; // you marked payment to someone as settled
+            let activityType: keyof typeof DOT_COLORS = "added";
+            if (
+              expense.splitType === "SETTLEMENT" &&
+              settlementPayeeName &&
+              settlementPayeeId !== null
+            ) {
+              activityType = "paid";
+            } else if (expense.splitType === "SETTLEMENT") {
+              activityType = "settled";
+            }
+
+            let amountColor = T.bright;
+            if (
+              expense.splitType === "SETTLEMENT" &&
+              settlementPayeeName &&
+              settlementPayeeId !== null
+            ) {
+              if (settlementPayeeId === user.id) amountColor = G;
+              else if (isYouPayer) amountColor = "#F87171";
             } else {
-              if (isYouPayer) amountColor = "red"; // you added expense (you paid)
+              if (isYouPayer) amountColor = "#F87171";
               else {
-                const myPart = expense.expenseParticipants?.find((p: { userId: string }) => p.userId === user.id);
+                const myPart = expense.expenseParticipants?.find(
+                  (p: { userId: string }) => p.userId === user.id
+                );
                 if (myPart) {
-                  if (myPart.amount < 0) amountColor = "red"; // you owe
-                  else if (myPart.amount > 0) amountColor = "green"; // they owe you
+                  if (myPart.amount < 0) amountColor = "#F87171";
+                  else if (myPart.amount > 0) amountColor = G;
                 }
               }
             }
 
-            const amountStyle =
-              amountColor === "red"
-                ? { color: "#FF4444" }
-                : amountColor === "green"
-                  ? { color: "#53E45E" }
-                  : undefined;
-            const amountClass = amountColor === "white" ? "text-white" : undefined;
-
-            if (expense.splitType === "SETTLEMENT" && settlementPayeeName) {
-              const payeeLabel = settlementPayeeId === user.id ? "you" : settlementPayeeName;
+            if (
+              expense.splitType === "SETTLEMENT" &&
+              settlementPayeeName
+            ) {
+              const payeeLabel =
+                settlementPayeeId === user.id ? "you" : settlementPayeeName;
               return (
-                <li
+                <div
                   key={item.id}
-                  className="py-3 sm:py-3.5 flex items-center justify-between gap-4"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 14,
+                    padding: "15px 22px",
+                    borderBottom:
+                      idx < activities.length - 1
+                        ? "1px solid rgba(255,255,255,0.06)"
+                        : "none",
+                  }}
                 >
-                  <span className="text-mobile-base sm:text-base text-white">
+                  <div
+                    style={{
+                      width: 9,
+                      height: 9,
+                      borderRadius: "50%",
+                      background: DOT_COLORS[activityType],
+                      flexShrink: 0,
+                    }}
+                  />
+                  <p
+                    style={{
+                      flex: 1,
+                      fontSize: 13,
+                      color: T.body,
+                      fontWeight: 500,
+                    }}
+                  >
                     {payerLabel} marked payment to {payeeLabel} as settled{" "}
-                    <span style={amountStyle} className={amountClass}>({amountStr})</span>
-                  </span>
-                  <span className="text-mobile-sm sm:text-sm text-white/60 shrink-0">
+                    <span style={{ color: amountColor }}>({amountStr})</span>
+                  </p>
+                  <span
+                    style={{
+                      color: T.sub,
+                      fontSize: 12,
+                      flexShrink: 0,
+                      fontWeight: 600,
+                    }}
+                  >
                     {formatRelativeTime(item.date)}
                   </span>
-                </li>
+                </div>
               );
             }
 
             return (
-              <li
+              <div
                 key={item.id}
-                className="py-3 sm:py-3.5 flex items-center justify-between gap-4"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  padding: "15px 22px",
+                  borderBottom:
+                    idx < activities.length - 1
+                      ? "1px solid rgba(255,255,255,0.06)"
+                      : "none",
+                }}
               >
-                <span className="text-mobile-base sm:text-base text-white">
-                  {payerLabel} added {expense.name} <span style={amountStyle} className={amountClass}>({amountStr})</span>
-                </span>
-                <span className="text-mobile-sm sm:text-sm text-white/60 shrink-0">
+                <div
+                  style={{
+                    width: 9,
+                    height: 9,
+                    borderRadius: "50%",
+                    background: DOT_COLORS[activityType],
+                    flexShrink: 0,
+                  }}
+                />
+                <p
+                  style={{
+                    flex: 1,
+                    fontSize: 13,
+                    color: T.body,
+                    fontWeight: 500,
+                  }}
+                >
+                  {payerLabel} added {expense.name}{" "}
+                  <span style={{ color: amountColor }}>({amountStr})</span>
+                </p>
+                <span
+                  style={{
+                    color: T.sub,
+                    fontSize: 12,
+                    flexShrink: 0,
+                    fontWeight: 600,
+                  }}
+                >
                   {formatRelativeTime(item.date)}
                 </span>
-              </li>
+              </div>
             );
           })}
-        </ul>
+        </Card>
       ) : (
-        <div className="text-center py-8 sm:py-12 text-mobile-base sm:text-base text-white/60">
-          No activity yet
+        <div
+          style={{
+            textAlign: "center",
+            padding: "80px 20px",
+          }}
+        >
+          <p style={{ fontSize: 48, marginBottom: 18 }}>💸</p>
+          <p
+            style={{
+              fontSize: 18,
+              fontWeight: 800,
+              color: T.body,
+              marginBottom: 8,
+            }}
+          >
+            No activity yet
+          </p>
+          <p style={{ fontSize: 14, color: T.sub }}>
+            Expenses and settlements will show here
+          </p>
         </div>
       )}
     </div>

--- a/app/groups/[id]/layout.tsx
+++ b/app/groups/[id]/layout.tsx
@@ -201,7 +201,9 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
           group={group}
         />
 
-        <div className="bg-[#101012] rounded-xl sm:rounded-3xl min-h-[calc(100vh-200px)]">
+        <div
+          className="rounded-xl sm:rounded-3xl min-h-[calc(100vh-200px)] overflow-y-auto p-4 sm:p-7"
+        >
           {children}
         </div>
 

--- a/app/groups/[id]/members/page.tsx
+++ b/app/groups/[id]/members/page.tsx
@@ -1,82 +1,251 @@
 "use client";
 
-import Image from "next/image";
+import { useMemo } from "react";
 import { Trash2 } from "lucide-react";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { useAuthStore } from "@/stores/authStore";
+import {
+  Card,
+  SectionLabel,
+  StatBox,
+  Btn,
+  Avatar,
+  T,
+  A,
+  G,
+  Icons,
+} from "@/lib/splito-design";
+
+const MEMBER_COLORS = [
+  A,
+  "#A78BFA",
+  G,
+  "#FB923C",
+  "#F472B6",
+  "#FBBF24",
+  "#F87171",
+  "#818CF8",
+];
+
+function memberColor(userId: string): string {
+  let h = 0;
+  for (let i = 0; i < userId.length; i++)
+    h = (h << 5) - h + userId.charCodeAt(i);
+  return MEMBER_COLORS[Math.abs(h) % MEMBER_COLORS.length];
+}
+
+function getInit(name: string | null): string {
+  if (!name || !name.trim()) return "?";
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2)
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  return name.slice(0, 2).toUpperCase();
+}
 
 export default function GroupMembersPage() {
   const { user } = useAuthStore();
-  const { group, isAdmin, openAddMember, handleRemoveMember } = useGroupLayout();
+  const {
+    group,
+    isAdmin,
+    openAddMember,
+    handleRemoveMember,
+    handleSettleFriendClick,
+    handleSendReminder,
+    formatCurrency,
+    defaultCurrency,
+    getSpecificDebtAmount,
+  } = useGroupLayout();
+
+  const { totalSpent, youAreOwed, expenseCount } = useMemo(() => {
+    if (!group || !user) return { totalSpent: 0, youAreOwed: 0, expenseCount: 0 };
+    const totalSpent = (group.expenses ?? [])
+      .filter((e: { splitType?: string }) => e.splitType !== "SETTLEMENT")
+      .reduce((a: number, e: { amount: number }) => a + e.amount, 0);
+    const youAreOwed = (group.groupBalances ?? [])
+      .filter(
+        (b: { userId: string; firendId: string; amount: number }) =>
+          b.userId === user.id && b.amount > 0
+      )
+      .reduce((a: number, b: { amount: number }) => a + b.amount, 0);
+    const expenseCount = (group.expenses ?? []).filter(
+      (e: { splitType?: string }) => e.splitType !== "SETTLEMENT"
+    ).length;
+    return { totalSpent, youAreOwed, expenseCount };
+  }, [group, user]);
+
+  const formatAmount = (amount: number) =>
+    formatCurrency(amount, defaultCurrency || "USD");
 
   if (!group || !user) return null;
 
   return (
-    <div className="p-4 sm:p-6 space-y-3 sm:space-y-4">
-      {isAdmin && (
-        <div className="flex justify-end mb-2">
-          <button
+    <div className="pb-6">
+      <div className="flex items-center justify-between gap-3 mb-5 sm:mb-6">
+        <SectionLabel>Your Members</SectionLabel>
+        {isAdmin && (
+          <Btn
             onClick={openAddMember}
-            className="flex items-center justify-center gap-1 sm:gap-2 rounded-full text-white hover:bg-white/5 h-8 sm:h-10 px-3 sm:px-4 text-mobile-sm sm:text-base transition-colors border border-white/80"
+            variant="ghost"
+            className="shrink-0"
+            style={{ padding: "8px 14px", fontSize: 12 }}
           >
-            <Image
-              alt="Add Member"
-              src="/plus-sign-circle.svg"
-              width={14}
-              height={14}
-              className="w-4 h-4 sm:w-5 sm:h-5"
-            />
-            <span className="text-mobile-sm sm:text-base">Add Member</span>
-          </button>
-        </div>
-      )}
+            <Icons.userPlus /> Add Member
+          </Btn>
+        )}
+      </div>
 
-      <div className="space-y-3 sm:space-y-4">
-        {group.groupUsers.map((member) => {
+      <Card className="mb-5 sm:mb-[22px] overflow-hidden">
+        {group.groupUsers.map((member, idx) => {
           const isCurrentUser = member.user.id === user.id;
+          const color = memberColor(member.user.id);
+          const paid = (group.expenses ?? [])
+            .filter(
+              (e: { paidBy: string; splitType?: string }) =>
+                e.paidBy === member.user.id && e.splitType !== "SETTLEMENT"
+            )
+            .reduce((a: number, e: { amount: number }) => a + e.amount, 0);
+          const owes = getSpecificDebtAmount(member.user.id);
+          const owesDisplay =
+            owes > 0
+              ? { text: `owes ${formatAmount(owes)}`, color: "#F87171" }
+              : { text: "all clear ✓", color: G };
+
           return (
             <div
               key={member.user.id}
-              className="flex items-center justify-between p-3 sm:p-4 rounded-xl"
+              className={idx < group.groupUsers.length - 1 ? "border-b border-white/[0.06]" : ""}
+              style={{ transition: "background 0.15s" }}
             >
-              <div className="flex items-center gap-3">
-                <div className="h-8 w-8 sm:h-10 sm:w-10 overflow-hidden rounded-full">
-                  <Image
-                    src={
-                      member.user.image ||
-                      `https://api.dicebear.com/9.x/identicon/svg?seed=${member.user.id}`
-                    }
-                    alt={member.user.name || "User"}
-                    width={40}
-                    height={40}
-                    className="h-full w-full object-cover"
-                    onError={(e) => {
-                      const target = e.target as HTMLImageElement;
-                      target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${member.user.id}`;
-                    }}
+              <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-[14px] p-4 sm:p-5">
+                <div className="flex items-center min-w-0 flex-1">
+                  <Avatar
+                    init={getInit(member.user.name)}
+                    color={color}
+                    size={42}
                   />
+                  <div className="ml-3 sm:flex-1 min-w-0">
+                    <p
+                      className="font-bold text-sm sm:text-[14px] text-white leading-tight"
+                      style={{ color: T.bright }}
+                    >
+                      {isCurrentUser
+                        ? `${member.user.name ?? "You"} (you)`
+                        : member.user.name ?? "Member"}
+                    </p>
+                    <p
+                      className="text-xs sm:text-[12px] mt-1 font-medium"
+                      style={{ color: T.muted }}
+                    >
+                      Paid {formatAmount(paid)} ·{" "}
+                      <span style={{ color: owesDisplay.color, fontWeight: 600 }}>
+                        {owesDisplay.text}
+                      </span>
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-mobile-base sm:text-base text-white font-medium">
-                    {isCurrentUser ? "You" : member.user.name}
-                  </p>
-                  <p className="text-mobile-sm sm:text-base text-white/70">
-                    {member.user.email}
-                  </p>
-                </div>
+                {!isCurrentUser && (
+                  <div className="flex items-center gap-2 sm:gap-2 flex-wrap sm:flex-nowrap sm:shrink-0 pl-[54px] sm:pl-0">
+                    <Btn
+                      onClick={() => handleSettleFriendClick(member.user.id)}
+                      variant="ghost"
+                      className="flex-1 sm:flex-initial min-w-0"
+                      style={{
+                        padding: "8px 12px",
+                        fontSize: 12,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        gap: 5,
+                      }}
+                    >
+                      <Icons.wallet /> Settle
+                    </Btn>
+                    <Btn
+                      onClick={() =>
+                        handleSendReminder(
+                          member.user.id,
+                          (group.expenses?.[0] as { id?: string } | undefined)?.id ?? ""
+                        )
+                      }
+                      variant="ghost"
+                      className="flex-1 sm:flex-initial min-w-0"
+                      style={{
+                        padding: "8px 12px",
+                        fontSize: 12,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        gap: 5,
+                      }}
+                    >
+                      <Icons.bell /> Notify
+                    </Btn>
+                    {group.createdBy?.id === user.id && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveMember(member.user.id)}
+                        className="shrink-0 flex items-center justify-center w-9 h-9 sm:w-[36px] sm:h-[36px] rounded-xl"
+                        style={{
+                          background: "rgba(248,113,113,0.06)",
+                          border: "1px solid rgba(248,113,113,0.15)",
+                          color: "#F87171",
+                          cursor: "pointer",
+                          transition: "all 0.2s",
+                        }}
+                      >
+                        <Trash2 style={{ width: 16, height: 16 }} />
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
-              {!isCurrentUser && group.createdBy.id === user.id && (
-                <button
-                  className="flex items-center justify-center w-7 h-7 sm:w-8 sm:h-8 rounded-full hover:bg-white/5 ml-1 sm:ml-2"
-                  onClick={() => handleRemoveMember(member.user.id)}
-                >
-                  <Trash2 className="h-4 w-4 sm:h-5 sm:w-5 text-white/70" />
-                </button>
-              )}
             </div>
           );
         })}
-      </div>
+      </Card>
+
+      <Card className="p-4 sm:p-[22px]">
+        <SectionLabel>Group spend breakdown</SectionLabel>
+        <div className="flex gap-4 sm:gap-8 flex-wrap mb-4 sm:mb-[18px]">
+          <StatBox
+            label="Total spent"
+            value={formatAmount(totalSpent)}
+            color="#e8e8e8"
+          />
+          <StatBox
+            label="You're owed"
+            value={formatAmount(youAreOwed)}
+            color={youAreOwed >= 0 ? G : "#F87171"}
+          />
+          <StatBox
+            label="Expenses"
+            value={String(expenseCount)}
+            color="#e8e8e8"
+          />
+        </div>
+        <div
+          style={{
+            height: 6,
+            background: "rgba(255,255,255,0.06)",
+            borderRadius: 99,
+            display: "flex",
+            overflow: "hidden",
+            gap: 2,
+          }}
+        >
+          {group.groupUsers.map((m) => (
+            <div
+              key={m.user.id}
+              style={{
+                width: `${100 / group.groupUsers.length}%`,
+                background: memberColor(m.user.id),
+                opacity: 0.75,
+                borderRadius: 99,
+              }}
+            />
+          ))}
+        </div>
+      </Card>
     </div>
   );
 }

--- a/app/groups/[id]/splits/page.tsx
+++ b/app/groups/[id]/splits/page.tsx
@@ -1,306 +1,247 @@
 "use client";
 
-import Image from "next/image";
-import { Clock, ChevronDown, ChevronUp } from "lucide-react";
 import { useState, useMemo } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { useAuthStore } from "@/stores/authStore";
-import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
+import {
+  Card,
+  SectionLabel,
+  Avatar,
+  Tag,
+  Btn,
+  Icons,
+  G,
+  T,
+} from "@/lib/splito-design";
 
-type BalanceItem = { amount: number; currency: string };
-
-type ExpenseForBreakdown = {
+type ExpenseWithParticipants = {
   id: string;
   name: string;
+  category: string;
   amount: number;
   currency: string;
   paidBy: string;
+  expenseDate: Date | string;
   createdAt: Date | string;
   splitType?: string;
   expenseParticipants?: { userId: string; amount: number }[];
 };
 
-function FriendBalanceRow({
-  friend,
-  owedBalances,
-  oweBalances,
-  defaultCurrency,
-  formatCurrency,
-  onNotify,
-  onSettle,
-  onMarkAsPaid,
-  isSending,
-  isMarkAsPaidPending,
-  expenses,
+const CATEGORY_STYLES: Record<string, { bg: string; icon: string }> = {
+  ACCOMMODATION: { bg: "rgba(255,255,255,0.06)", icon: "🏠" },
+  FOOD: { bg: "rgba(255,255,255,0.06)", icon: "🍽" },
+  TRAVEL: { bg: "rgba(255,255,255,0.06)", icon: "🚗" },
+  TRANSPORT: { bg: "rgba(255,255,255,0.06)", icon: "🚗" },
+};
+
+function getCategoryStyle(category: string) {
+  const key = (category || "").toUpperCase();
+  return (
+    CATEGORY_STYLES[key] ||
+    CATEGORY_STYLES[key.split(/[\s-_]/)[0]] || { bg: "rgba(255,255,255,0.06)", icon: "🧾" }
+  );
+}
+
+function formatDateKey(d: Date | string): string {
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" }).toUpperCase();
+}
+
+function ExpenseRow({
+  expense,
   groupUsers,
   currentUserId,
   currentUserName,
+  formatCurrency,
+  onNotify,
+  onSettle,
+  onDelete,
+  isLast,
 }: {
-  friend: { id: string; name: string | null; image: string | null };
-  owedBalances: BalanceItem[];
-  oweBalances: BalanceItem[];
-  defaultCurrency: string;
-  formatCurrency: (amount: number, currencyId: string) => string;
-  onNotify: () => void;
-  onSettle: () => void;
-  onMarkAsPaid: (payload: {
-    payerId: string;
-    payeeId: string;
-    amount: number;
-    currency: string;
-    currencyType: string;
-  }) => void;
-  isSending: boolean;
-  isMarkAsPaidPending: boolean;
-  expenses: ExpenseForBreakdown[];
+  expense: ExpenseWithParticipants;
   groupUsers: { user: { id: string; name: string | null; image: string | null } }[];
   currentUserId: string;
   currentUserName: string | null;
+  formatCurrency: (amount: number, currency: string) => string;
+  onNotify: () => void;
+  onSettle: () => void;
+  onDelete: () => void;
+  isLast: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
 
-  const { total: totalOwed, isLoading: loadingOwed } = useConvertedBalanceTotal(
-    owedBalances.map((b) => ({ amount: b.amount, currency: b.currency })),
-    defaultCurrency
-  );
-  const { total: totalOwe, isLoading: loadingOwe } = useConvertedBalanceTotal(
-    oweBalances.map((b) => ({ amount: Math.abs(b.amount), currency: b.currency })),
-    defaultCurrency
-  );
+  const paidByUser = groupUsers.find((gu) => gu.user.id === expense.paidBy)?.user;
+  const paidByName =
+    expense.paidBy === currentUserId ? (currentUserName || "You") : (paidByUser?.name ?? "Someone");
 
-  const hasOwedBalances = owedBalances.length > 0;
-  const hasOweBalances = oweBalances.length > 0;
-  const converting = loadingOwed || loadingOwe;
+  const participants = expense.expenseParticipants ?? [];
+  const oweCount = participants.filter((p) => p.amount > 0).length;
+  const settledCount = 0;
+  const settledLabel = `${settledCount}/${oweCount} settled`;
 
-  const expensesWithFriend = useMemo(() => {
-    return expenses.filter((exp) => {
-      if (exp.splitType === "SETTLEMENT") return false;
-      const paidByMe = exp.paidBy === currentUserId;
-      const paidByFriend = exp.paidBy === friend.id;
-      const participants = exp.expenseParticipants ?? [];
-      const myPart = participants.find((p) => p.userId === currentUserId);
-      const friendPart = participants.find((p) => p.userId === friend.id);
-      const involvesMe = paidByMe || (myPart != null && myPart.amount !== 0);
-      const involvesFriend = paidByFriend || (friendPart != null && friendPart.amount !== 0);
-      return involvesMe && involvesFriend;
-    });
-  }, [expenses, currentUserId, friend.id]);
+  const myShare = participants.find((p) => p.userId === currentUserId)?.amount ?? 0;
+  const iAmPayer = expense.paidBy === currentUserId;
+  const owedToMe = iAmPayer ? participants.filter((p) => p.amount > 0).reduce((s, p) => s + p.amount, 0) : 0;
+  const pending = participants.filter((p) => p.amount > 0).reduce((a, p) => a + p.amount, 0);
+
+  const categoryStyle = getCategoryStyle(expense.category);
+
+  const statusLine = (() => {
+    if (myShare > 0 && !iAmPayer) return { text: `you owe ${formatCurrency(myShare, expense.currency)}`, color: "#F87171" };
+    if (iAmPayer && pending > 0) return { text: `owed ${formatCurrency(pending, expense.currency)}`, color: G };
+    if (iAmPayer && pending === 0) return { text: "all settled ✓", color: G };
+    return null;
+  })();
 
   return (
-    <div className="rounded-xl overflow-hidden">
-      <div className="flex items-center justify-between p-3 sm:p-4">
-        <button
-          type="button"
-          onClick={() => setExpanded((e) => !e)}
-          className="flex items-center gap-3 sm:gap-4 flex-1 min-w-0 text-left"
+    <div style={{ borderBottom: isLast ? "none" : "1px solid rgba(255,255,255,0.06)" }}>
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="w-full text-left transition-colors hover:bg-white/[0.02]"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+          padding: "16px 22px",
+          cursor: "pointer",
+        }}
+      >
+        <div
+          style={{
+            width: 48,
+            height: 48,
+            background: categoryStyle.bg,
+            border: "1px solid rgba(255,255,255,0.09)",
+            borderRadius: 14,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 24,
+            flexShrink: 0,
+          }}
         >
-          <div className="h-10 w-10 sm:h-12 sm:w-12 overflow-hidden rounded-full flex-shrink-0">
-            <Image
-              src={
-                friend.image ||
-                `https://api.dicebear.com/9.x/identicon/svg?seed=${friend.id}`
-              }
-              alt={friend.name || "User"}
-              width={48}
-              height={48}
-              className="h-full w-full object-cover"
-              onError={(e) => {
-                const target = e.target as HTMLImageElement;
-                target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${friend.id}`;
-              }}
-            />
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="text-mobile-base sm:text-lg font-medium text-white">
-              {friend.name}
+          {categoryStyle.icon}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p style={{ fontWeight: 700, fontSize: 14, color: T.bright, marginBottom: 4 }}>
+            {expense.name}
+          </p>
+          <p style={{ fontSize: 12, color: T.muted, fontWeight: 500 }}>
+            Paid by {paidByName} · {settledLabel}
+          </p>
+        </div>
+        <div style={{ textAlign: "right", flexShrink: 0, marginRight: 8 }}>
+          <p
+            style={{
+              fontWeight: 800,
+              fontSize: 15,
+              color: T.bright,
+              fontFamily: "'DM Mono',monospace",
+            }}
+          >
+            {formatCurrency(expense.amount, expense.currency)}
+          </p>
+          {statusLine && (
+            <p style={{ fontSize: 12, color: statusLine.color, fontWeight: 600, marginTop: 2 }}>
+              {statusLine.text}
             </p>
-            {hasOwedBalances && (
-              <div className="text-mobile-sm sm:text-base text-white/70">
-                <span className="text-red-500">
-                  You owe{" "}
-                  {converting ? "…" : formatCurrency(totalOwed, defaultCurrency)}
-                </span>
-              </div>
-            )}
-            {hasOweBalances && (
-              <div className="text-mobile-sm sm:text-base text-white/70">
-                <span className="text-green-500">
-                  Owes you{" "}
-                  {converting ? "…" : formatCurrency(totalOwe, defaultCurrency)}
-                </span>
-              </div>
-            )}
-          </div>
-          <span className="text-white/50 flex-shrink-0 ml-1">
-            {expanded ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
-          </span>
-        </button>
-
-        <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-          {hasOweBalances && (
-            <button
-              className="flex items-center justify-center gap-1 sm:gap-2 rounded-full border border-white/80 text-white h-8 sm:h-10 px-3 sm:px-4 text-mobile-sm sm:text-sm hover:bg-white/5 transition-colors"
-              onClick={(e) => {
-                e.stopPropagation();
-                onNotify();
-              }}
-              disabled={isSending}
-            >
-              <Clock className="h-3 w-3 sm:h-4 sm:w-4" />
-              <span className="hidden sm:inline">
-                {isSending ? "Sending..." : "Notify"}
-              </span>
-            </button>
-          )}
-          {hasOwedBalances && (
-            <>
-              <button
-                className="flex items-center justify-center gap-1 sm:gap-2 rounded-full border border-white/80 text-white h-8 sm:h-10 px-3 sm:px-4 text-mobile-sm sm:text-sm hover:bg-white/5 transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSettle();
-                }}
-              >
-                <Image
-                  src="/coins-dollar.svg"
-                  alt="Settle Debts"
-                  width={16}
-                  height={16}
-                  className="h-3 w-3 sm:h-4 sm:w-4"
-                />
-                <span className="hidden sm:inline">Settle Debts</span>
-              </button>
-              <button
-                className="flex items-center justify-center gap-1 sm:gap-2 rounded-full border border-white/80 text-white h-8 sm:h-10 px-3 sm:px-4 text-mobile-sm sm:text-sm hover:bg-white/5 transition-colors"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const first = owedBalances[0];
-                  if (first) {
-                    onMarkAsPaid({
-                      payerId: currentUserId,
-                      payeeId: friend.id,
-                      amount: Math.abs(first.amount),
-                      currency: first.currency,
-                      currencyType: "FIAT",
-                    });
-                  }
-                }}
-                disabled={isMarkAsPaidPending}
-              >
-                <Image
-                  src="/checkmark-circle.svg"
-                  alt="Mark as Paid"
-                  width={16}
-                  height={16}
-                  className="h-3 w-3 sm:h-4 sm:w-4"
-                />
-                <span className="hidden sm:inline">Mark as Paid</span>
-              </button>
-            </>
           )}
         </div>
-      </div>
-
-      {expanded && (hasOwedBalances || hasOweBalances) && (
+        <span
+          style={{
+            color: T.dim,
+            display: "flex",
+            transition: "transform 0.2s",
+            transform: expanded ? "rotate(180deg)" : "none",
+          }}
+        >
+          {Icons.chevD()}
+        </span>
+      </button>
+      {expanded && (
         <div
-          className="pt-0 pb-3 sm:pb-4 space-y-2"
+          style={{
+            borderTop: "1px solid rgba(255,255,255,0.06)",
+            background: "rgba(0,0,0,0.2)",
+            padding: "18px 22px",
+          }}
           onClick={(e) => e.stopPropagation()}
         >
-          {expensesWithFriend.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-mobile-sm sm:text-base text-white/60 px-3 sm:px-4">
-                Expenses
-              </p>
-              {expensesWithFriend.map((expense) => {
-                const paidByUser = groupUsers.find((gu) => gu.user.id === expense.paidBy)?.user;
-                const paidByName =
-                  expense.paidBy === currentUserId ? (currentUserName || "You") : (paidByUser?.name ?? "Someone");
-                const friendPart = expense.expenseParticipants?.find((p) => p.userId === friend.id);
-                const myPart = expense.expenseParticipants?.find((p) => p.userId === currentUserId);
-                const friendOwesMe = expense.paidBy === currentUserId && friendPart && friendPart.amount > 0;
-                const iOweFriend = expense.paidBy === friend.id && myPart && myPart.amount > 0;
-                const shareAmount = friendOwesMe ? friendPart!.amount : iOweFriend ? myPart!.amount : 0;
-                const shareLabel = friendOwesMe ? "Owes you" : iOweFriend ? "You owe" : null;
-                const showShare = shareLabel && shareAmount > 0;
-
+          <SectionLabel className="!mb-2">Breakdown</SectionLabel>
+          <div style={{ marginBottom: 16 }}>
+            {participants
+              .filter((p) => p.amount > 0)
+              .map((p) => {
+                const u = groupUsers.find((gu) => gu.user.id === p.userId)?.user;
+                const name = p.userId === currentUserId ? (currentUserName || "You") : (u?.name ?? "Someone");
+                const isSettled = false;
                 return (
                   <div
-                    key={expense.id}
-                    className="flex items-center justify-between p-3 sm:p-4 rounded-xl text-left"
+                    key={p.userId}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      padding: "10px 0",
+                      borderBottom: "1px solid rgba(255,255,255,0.05)",
+                    }}
                   >
-                    <div className="flex items-center gap-3 min-w-0 flex-1">
-                      <div className="h-8 w-8 sm:h-10 sm:w-10 overflow-hidden rounded-full flex-shrink-0">
-                        <Image
-                          src={
-                            paidByUser?.image ||
-                            `https://api.dicebear.com/9.x/identicon/svg?seed=${expense.paidBy}`
-                          }
-                          alt={paidByName}
-                          width={40}
-                          height={40}
-                          className="h-full w-full object-cover"
-                          onError={(e) => {
-                            const t = e.target as HTMLImageElement;
-                            t.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${expense.paidBy}`;
-                          }}
-                        />
-                      </div>
-                      <div className="min-w-0">
-                        <p className="text-mobile-base sm:text-base text-white">
-                          <span className="font-medium">{paidByName}</span> paid for &quot;{expense.name}&quot;
-                        </p>
-                        <p className="text-mobile-xs sm:text-sm text-white/60">
-                          {new Date(expense.createdAt).toLocaleString()}
-                          {showShare && (
-                            <span className={friendOwesMe ? " text-green-500/90" : " text-red-500/90"}>
-                              {" · "}{shareLabel}{" "}
-                              <span className="text-white/70">{formatCurrency(shareAmount, expense.currency)}</span>
-                              <span className="text-white/50 text-mobile-xs"> (your share)</span>
-                            </span>
-                          )}
-                        </p>
-                      </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                      <Avatar
+                        init={u ? (u.name ?? "?")[0].toUpperCase() : "?"}
+                        size={28}
+                        color="#22D3EE"
+                      />
+                      <span style={{ color: T.body, fontSize: 13, fontWeight: 500 }}>{name}</span>
                     </div>
-                    <div className="text-right flex-shrink-0 ml-2">
-                      <p className="text-mobile-xs sm:text-xs text-white/50 mb-0.5">Total</p>
-                      <p className="text-mobile-base sm:text-base text-white font-medium">
-                        {formatCurrency(expense.amount, expense.currency)}
-                      </p>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span
+                        style={{
+                          color: isSettled ? G : "#F87171",
+                          fontSize: 13,
+                          fontWeight: 700,
+                          fontFamily: "'DM Mono',monospace",
+                        }}
+                      >
+                        {formatCurrency(p.amount, expense.currency)}
+                      </span>
+                      <Tag color={isSettled ? G : "#F87171"}>
+                        {isSettled ? "settled" : "pending"}
+                      </Tag>
                     </div>
                   </div>
                 );
               })}
-            </div>
-          )}
-
-          <div className="px-3 sm:px-4 pt-1">
-            <p className="text-mobile-xs sm:text-sm text-white/50 mb-1.5">Balance by currency</p>
-            <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-mobile-sm sm:text-base text-white/70">
-              {hasOwedBalances && (
-                <span>
-                  <span className="text-red-500/90">You owe: </span>
-                  {owedBalances.map((b, i) => (
-                    <span key={i}>
-                      {formatCurrency(Math.abs(b.amount), b.currency)}
-                      {i < owedBalances.length - 1 ? ", " : ""}
-                    </span>
-                  ))}
-                </span>
-              )}
-              {hasOweBalances && (
-                <span>
-                  <span className="text-green-500/90">Owes you: </span>
-                  {oweBalances.map((b, i) => (
-                    <span key={i}>
-                      {formatCurrency(Math.abs(b.amount), b.currency)}
-                      {i < oweBalances.length - 1 ? ", " : ""}
-                    </span>
-                  ))}
-                </span>
-              )}
-            </div>
+          </div>
+          <div style={{ display: "flex", gap: 8, paddingTop: 16 }}>
+            <Btn variant="ghost" onClick={onSettle} style={{ padding: "8px 16px", fontSize: 12 }}>
+              <Icons.check /> Settle
+            </Btn>
+            <Btn variant="ghost" onClick={onNotify} style={{ padding: "8px 16px", fontSize: 12 }}>
+              <Icons.bell /> Notify
+            </Btn>
+            <button
+              type="button"
+              onClick={onDelete}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                background: "rgba(248,113,113,0.06)",
+                border: "1px solid rgba(248,113,113,0.15)",
+                borderRadius: 12,
+                padding: "8px 14px",
+                color: "#F87171",
+                fontSize: 12,
+                cursor: "pointer",
+                fontFamily: "inherit",
+                fontWeight: 600,
+              }}
+            >
+              <Icons.trash size={14} /> Delete
+            </button>
           </div>
         </div>
       )}
@@ -312,88 +253,84 @@ export default function GroupSplitsPage() {
   const { user } = useAuthStore();
   const {
     group,
-    groupId,
     formatCurrency,
-    defaultCurrency,
     handleSettleFriendClick,
     handleSendReminder,
-    markAsPaidMutation,
-    isSending,
     openAddExpense,
   } = useGroupLayout();
 
   if (!group || !user) return null;
 
-  const expenses = group.expenses;
-  const currentUserBalances = group.groupBalances.filter(
-    (balance) => balance.userId === user.id && balance.amount !== 0
+  const expenses = (group.expenses ?? []) as ExpenseWithParticipants[];
+  const nonSettlement = useMemo(
+    () => expenses.filter((e) => e.splitType !== "SETTLEMENT"),
+    [expenses]
   );
 
-  if (currentUserBalances.length === 0) {
-    return (
-      <div className="p-4 sm:p-6">
-        <div className="text-center py-8 sm:py-12 text-mobile-base sm:text-base text-white/60">
-          Start by adding your first expense
-          <Button onClick={openAddExpense} className="mt-4">
-            Add Expense
-          </Button>
-        </div>
-      </div>
+  const byDate = useMemo(() => {
+    const map = new Map<string, ExpenseWithParticipants[]>();
+    const sorted = [...nonSettlement].sort(
+      (a, b) =>
+        new Date(b.expenseDate ?? b.createdAt).getTime() -
+        new Date(a.expenseDate ?? a.createdAt).getTime()
     );
-  }
-
-  const balancesByFriend = currentUserBalances.reduce(
-    (acc, balance) => {
-      if (!acc[balance.firendId]) acc[balance.firendId] = [];
-      acc[balance.firendId].push(balance);
-      return acc;
-    },
-    {} as Record<string, typeof currentUserBalances>
-  );
+    for (const e of sorted) {
+      const key = formatDateKey(e.expenseDate ?? e.createdAt);
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(e);
+    }
+    return Array.from(map.entries());
+  }, [nonSettlement]);
 
   return (
-    <div className="p-4 sm:p-6 space-y-3 sm:space-y-4">
-      {Object.entries(balancesByFriend).map(([friendId, balances]) => {
-        const friend = group.groupUsers.find((gu) => gu.user.id === friendId)?.user;
-        if (!friend) return null;
-
-        const owedBalances = balances.filter((b) => b.amount > 0);
-        const oweBalances = balances.filter((b) => b.amount < 0);
-
-        return (
-          <FriendBalanceRow
-            key={friendId}
-            friend={friend}
-            owedBalances={owedBalances.map((b) => ({ amount: b.amount, currency: b.currency }))}
-            oweBalances={oweBalances.map((b) => ({ amount: b.amount, currency: b.currency }))}
-            defaultCurrency={defaultCurrency}
-            formatCurrency={formatCurrency}
-            onNotify={() => {
-              const latestExpense = expenses?.length ? expenses[0] : null;
-              if (latestExpense) handleSendReminder(friend.id, latestExpense.id);
-            }}
-            onSettle={() => handleSettleFriendClick(friend.id)}
-            onMarkAsPaid={(payload) =>
-              markAsPaidMutation.mutate(
-                { groupId, payload },
-                {
-                  onSuccess: () =>
-                    toast.success(`Marked payment to ${friend.name} as paid`, {
-                      description: "This will be recorded in your activity.",
-                    }),
-                  onError: () => toast.error("Failed to mark as paid"),
-                }
-              )
-            }
-            isSending={isSending}
-            isMarkAsPaidPending={markAsPaidMutation.isPending}
-            expenses={group.expenses ?? []}
-            groupUsers={group.groupUsers}
-            currentUserId={user.id}
-            currentUserName={user.name ?? null}
-          />
-        );
-      })}
+    <div className="space-y-6">
+      {byDate.length === 0 ? (
+        <div style={{ textAlign: "center", padding: "80px 20px" }}>
+          <p style={{ fontSize: 48, marginBottom: 18 }}>💸</p>
+          <p style={{ fontSize: 18, fontWeight: 800, color: T.body, marginBottom: 8 }}>
+            No expenses yet
+          </p>
+          <p style={{ fontSize: 14, color: T.sub }}>Add your first expense to get started</p>
+          <button
+            type="button"
+            onClick={openAddExpense}
+            className="mt-4 inline-flex items-center gap-2 rounded-xl text-[13px] font-extrabold text-[#0a0a0a] transition-opacity hover:opacity-90"
+            style={{ background: "#22D3EE", padding: "10px 18px", gap: 6 }}
+          >
+            <Icons.plus /> Add Expense
+          </button>
+        </div>
+      ) : (
+        byDate.map(([dateLabel, dateExpenses]) => (
+          <section key={dateLabel} style={{ marginBottom: 24 }}>
+            <SectionLabel>{dateLabel}</SectionLabel>
+            <Card style={{ padding: 0 }}>
+              {dateExpenses.map((expense, idx) => (
+                <ExpenseRow
+                  key={expense.id}
+                  expense={expense}
+                  groupUsers={group.groupUsers}
+                  currentUserId={user.id}
+                  currentUserName={user.name ?? null}
+                  formatCurrency={formatCurrency}
+                  isLast={idx === dateExpenses.length - 1}
+                  onNotify={() => {
+                    const firstOwer = expense.expenseParticipants?.find((p) => p.amount > 0);
+                    if (firstOwer) handleSendReminder(firstOwer.userId, expense.id);
+                  }}
+                  onSettle={() => {
+                    const firstOwer = expense.expenseParticipants?.find((p) => p.amount > 0);
+                    if (firstOwer) handleSettleFriendClick(firstOwer.userId);
+                  }}
+                  onDelete={() => {
+                    toast.info("Delete expense is not implemented yet.");
+                  }}
+                />
+              ))}
+            </Card>
+          </section>
+        ))
+      )}
     </div>
   );
 }

--- a/app/groups/[id]/splits/page.tsx
+++ b/app/groups/[id]/splits/page.tsx
@@ -259,9 +259,7 @@ export default function GroupSplitsPage() {
     openAddExpense,
   } = useGroupLayout();
 
-  if (!group || !user) return null;
-
-  const expenses = (group.expenses ?? []) as ExpenseWithParticipants[];
+  const expenses = (group?.expenses ?? []) as ExpenseWithParticipants[];
   const nonSettlement = useMemo(
     () => expenses.filter((e) => e.splitType !== "SETTLEMENT"),
     [expenses]
@@ -281,6 +279,8 @@ export default function GroupSplitsPage() {
     }
     return Array.from(map.entries());
   }, [nonSettlement]);
+
+  if (!group || !user) return null;
 
   return (
     <div className="space-y-6">

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -42,7 +42,7 @@ export default function GroupsPage() {
     };
   }, [user, router]);
 
-  // Function to handle clicking the "Create app" button
+  // Function to handle clicking the "Create Group" button
   const handleAddGroupClick = () => {
     // Check if user has a connected wallet
     // if (!user?.stellarAccount) {
@@ -83,13 +83,13 @@ export default function GroupsPage() {
             className="flex items-center justify-center gap-1 sm:gap-2 rounded-full bg-white text-black h-10 sm:h-12 px-4 sm:px-6 text-mobile-sm sm:text-base font-medium hover:bg-white/90 transition-all"
           >
             <Image
-              alt="Create app"
+              alt="Create Group"
               src="/plus-sign-circle.svg"
               width={20}
               height={20}
               className="h-4 w-4 sm:h-5 sm:w-5 invert"
             />
-            <span>Create app</span>
+            <span>Create Group</span>
           </button>
           <button
             onClick={handleProfileClick}

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -1,136 +1,55 @@
 "use client";
 
 import { GroupsList } from "@/components/groups-list";
-import { motion } from "framer-motion";
-import { fadeIn } from "@/utils/animations";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { useAuthStore } from "@/stores/authStore";
 import { useState, useEffect } from "react";
 import { CreateGroupForm } from "@/components/create-group-form";
-import { toast } from "sonner";
+import { Icons } from "@/lib/splito-design";
 
 export default function GroupsPage() {
-  const router = useRouter();
-  const { user } = useAuthStore();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
-  // Listen for custom event to open the create group modal
   useEffect(() => {
-    const handleOpenModal = () => {
-      // Check if user has a connected wallet
-      // if (!user?.stellarAccount) {
-      //   toast.error("You need to connect a wallet before creating a group", {
-      //     description: "Add a wallet in your settings to continue",
-      //     action: {
-      //       label: "Add Wallet",
-      //       onClick: () => router.push("/settings"),
-      //     },
-      //     duration: 8000,
-      //   });
-      //   return;
-      // }
-
-      // If they have a wallet, open the modal
-      setIsCreateModalOpen(true);
-    };
-
+    const handleOpenModal = () => setIsCreateModalOpen(true);
     document.addEventListener("open-create-group-modal", handleOpenModal);
-
-    return () => {
-      document.removeEventListener("open-create-group-modal", handleOpenModal);
-    };
-  }, [user, router]);
-
-  // Function to handle clicking the "Create Group" button
-  const handleAddGroupClick = () => {
-    // Check if user has a connected wallet
-    // if (!user?.stellarAccount) {
-    //   toast.error("You need to connect a wallet before creating a group", {
-    //     description: "Add a wallet in your settings to continue",
-    //     action: {
-    //       label: "Add Wallet",
-    //       onClick: () => router.push("/settings"),
-    //     },
-    //     duration: 8000,
-    //   });
-    //   return;
-    // }
-
-    // If they have a wallet, open the modal
-    setIsCreateModalOpen(true);
-  };
-
-  // Handle profile click to redirect to settings
-  const handleProfileClick = () => {
-    router.push("/settings");
-  };
+    return () => document.removeEventListener("open-create-group-modal", handleOpenModal);
+  }, []);
 
   return (
-    <motion.div
-      variants={fadeIn}
-      initial="initial"
-      animate="animate"
-      className="w-full -mt-2"
-    >
-      <div className="flex items-center justify-between px-3 sm:px-5 py-3 sm:py-4">
-        <h1 className="text-mobile-base sm:text-xl font-medium text-white">
+    <div className="flex-1 flex flex-col min-w-0">
+      <div
+        className="flex items-center justify-between sticky top-0 z-10 px-4 sm:px-7 h-14 sm:h-[70px] border-b border-white/[0.07] bg-[#0b0b0b]/95 backdrop-blur-xl"
+      >
+        <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
           My Groups
         </h1>
-        <div className="flex items-center gap-3 sm:gap-4">
-          <button
-            onClick={handleAddGroupClick}
-            className="flex items-center justify-center gap-1 sm:gap-2 rounded-full bg-white text-black h-10 sm:h-12 px-4 sm:px-6 text-mobile-sm sm:text-base font-medium hover:bg-white/90 transition-all"
-          >
-            <Image
-              alt="Create Group"
-              src="/plus-sign-circle.svg"
-              width={20}
-              height={20}
-              className="h-4 w-4 sm:h-5 sm:w-5 invert"
-            />
-            <span>Create Group</span>
-          </button>
-          <button
-            onClick={handleProfileClick}
-            className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:from-purple-500/30 hover:to-blue-500/30 transition-all cursor-pointer"
-          >
-            <div className="h-full w-full rounded-full overflow-hidden bg-[#0f0f10]">
-              {user?.image ? (
-                <Image
-                  src={user.image}
-                  alt="Profile"
-                  width={56}
-                  height={56}
-                  className="h-full w-full object-cover"
-                />
-              ) : (
-                <Image
-                  src={`https://api.dicebear.com/9.x/identicon/svg?seed=${
-                    user?.id || user?.email || "user"
-                  }`}
-                  alt="Profile"
-                  width={56}
-                  height={56}
-                  className="h-full w-full"
-                  onError={(e) => {
-                    console.error(`Error loading identicon for user`);
-                    const target = e.target as HTMLImageElement;
-                    target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=user`;
-                  }}
-                />
-              )}
-            </div>
-          </button>
-        </div>
+        <button
+          onClick={() => setIsCreateModalOpen(true)}
+          className="flex items-center gap-1.5 rounded-xl text-[12px] sm:text-[13px] font-extrabold text-[#0a0a0a] transition-all hover:opacity-90 shrink-0 py-2.5 px-3 sm:py-2.5 sm:px-[18px]"
+          style={{ background: "#22D3EE", gap: 6 }}
+        >
+          <Icons.plus /> New Group
+        </button>
       </div>
-      <GroupsList />
-
-      {/* Create Group Modal */}
+      <div className="flex-1 overflow-y-auto p-4 sm:p-7">
+        <div
+          className="flex items-center rounded-[14px] mb-5 sm:mb-6 py-2.5 px-4 gap-2 bg-white/[0.04] border border-white/[0.08]"
+        >
+          <span className="text-[#999] shrink-0">{Icons.search({ size: 18 })}</span>
+          <input
+            type="text"
+            placeholder="Search groups…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="flex-1 min-w-0 bg-transparent text-[14px] text-white placeholder:text-white/50 focus:outline-none font-medium"
+          />
+        </div>
+        <GroupsList searchQuery={searchQuery} />
+      </div>
       <CreateGroupForm
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
       />
-    </motion.div>
+    </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { Instrument_Sans } from "next/font/google";
+import { Instrument_Sans, DM_Sans, DM_Mono } from "next/font/google";
 import { Sidebar } from "@/components/sidebar";
 import { MobileMenuToggle } from "@/components/mobile-menu-toggle";
 import { MobileMenuProvider } from "@/contexts/mobile-menu";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
 import { Toaster } from "sonner";
 import { OnboardingGate } from "@/components/onboarding-gate";
+import { PersonalMobileNav } from "@/components/personal-mobile-nav";
+import { OrganizationMobileNav } from "@/components/organization-mobile-nav";
 
 const instrumentSans = Instrument_Sans({
   subsets: ["latin"],
@@ -16,28 +19,54 @@ const instrumentSans = Instrument_Sans({
   display: "swap",
 });
 
+const dmSans = DM_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800"],
+  display: "swap",
+  variable: "--font-dm-sans",
+});
+
+const dmMono = DM_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  display: "swap",
+  variable: "--font-dm-mono",
+});
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const isAuthPage = usePathname()?.match(/^\/login|^\/signup/);
+  const pathname = usePathname();
+  const isAuthPage = pathname?.match(/^\/login|^\/signup/);
+  const isOrganizationMode = pathname?.includes("/organization");
+  const isPersonalMode = !isOrganizationMode;
 
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" className={`${dmSans.variable} ${dmMono.variable}`}>
+      <body className={instrumentSans.className}>
         <MobileMenuProvider>
           <Providers>
             {isAuthPage ? (
               children
             ) : (
-              <div className="min-h-screen bg-[#09090B]">
+              <div className="min-h-screen bg-[#0b0b0b] splito-page-wrap">
                 <OnboardingGate />
                 <Sidebar />
                 <MobileMenuToggle />
-                <div className="min-[1025px]:pl-[260px] min-h-screen flex flex-col">
-                  <main className="flex-1 bg-[#09090B] p-4 pt-16 min-[1025px]:pt-4 min-[1125px]:p-8 relative">
-                    <div className="w-full">{children}</div>
+                {isPersonalMode && <PersonalMobileNav />}
+                {isOrganizationMode && <OrganizationMobileNav />}
+                <div className="min-[1025px]:pl-[226px] min-h-screen flex flex-col">
+                  <main className="flex-1 bg-[#0b0b0b] min-h-screen relative flex flex-col min-w-0">
+                    <div
+                      className={cn(
+                        "w-full flex-1 flex flex-col min-w-0",
+                        "max-[1024px]:max-w-[430px] max-[1024px]:mx-auto max-[1024px]:pb-[88px]"
+                      )}
+                    >
+                      {children}
+                    </div>
                   </main>
                 </div>
               </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,6 +11,17 @@ import { defaultPostLoginPath } from "@/lib/app-mode";
 import { toast } from "sonner";
 import { ApiError } from "@/types/api-error";
 
+function GoogleIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0">
+      <path d="M19.8055 10.2298C19.8055 9.51795 19.7434 8.83835 19.6299 8.18213H10.2002V11.9624H15.6016C15.3853 13.1709 14.6875 14.1933 13.6543 14.8622V17.311H16.8564C18.7502 15.5938 19.8055 13.1499 19.8055 10.2298Z" fill="#4285F4" />
+      <path d="M10.1999 20.0001C12.8999 20.0001 15.1499 19.115 16.8561 17.3113L13.654 14.8625C12.7754 15.4513 11.6077 15.7968 10.1999 15.7968C7.5938 15.7968 5.38819 14.0732 4.58777 11.7H1.28149V14.2318C2.9752 17.6232 6.3313 20.0001 10.1999 20.0001Z" fill="#34A853" />
+      <path d="M4.58753 11.7002C4.18753 10.4917 4.18753 9.17 4.58753 7.9615V5.42969H1.28126C-0.119933 8.00938 -0.119933 11.6523 1.28126 14.232L4.58753 11.7002Z" fill="#FBBC05" />
+      <path d="M10.1999 4.20378C11.6218 4.18533 12.9998 4.73503 14.0345 5.72847L16.8959 2.8671C15.1044 1.18895 12.6958 0.200905 10.1999 0.229336C6.3313 0.229336 2.9752 2.60621 1.28149 5.99761L4.58777 8.52941C5.38819 6.15621 7.5938 4.43261 10.1999 4.20378Z" fill="#EA4335" />
+    </svg>
+  );
+}
+
 export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -92,7 +103,7 @@ export default function LoginPage() {
         {/* Card container only visible on desktop */}
         <div className="hidden sm:block animate-border-light">
           <div className="relative rounded-[24px] !bg-[#0f0f10] p-8 space-y-6">
-            <div className="flex justify-center mb-6">
+            <div className="flex justify-center mb-4">
               <Image
                 src="/logo.svg"
                 alt="Splito"
@@ -103,8 +114,40 @@ export default function LoginPage() {
             </div>
 
             <h1 className="text-2xl font-semibold text-white text-center">
-              Sign in
+              Welcome Back
             </h1>
+            <p className="text-center text-sm text-white/60 -mt-2">
+              Don&apos;t have an account yet?{" "}
+              <Link href="/signup" className="text-white hover:underline font-medium">
+                Sign up
+              </Link>
+            </p>
+
+            {/* Google as full-width strip first */}
+            <button
+              type="button"
+              onClick={handleGoogleLogin}
+              className="w-full h-[52px] flex items-center justify-center gap-3 rounded-xl
+                bg-[#1a1a1c] border border-white/10
+                text-base font-medium text-white
+                transition-all duration-200 hover:bg-white/[0.06] hover:border-white/20 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoadingEmail || isLoadingGoogle}
+            >
+              {isLoadingGoogle ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <>
+                  <GoogleIcon />
+                  <span>Login with Google</span>
+                </>
+              )}
+            </button>
+
+            <div className="relative flex items-center">
+              <div className="flex-grow border-t border-white/10" />
+              <span className="px-4 text-sm text-white/40">OR</span>
+              <div className="flex-grow border-t border-white/10" />
+            </div>
 
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="form-group">
@@ -115,8 +158,8 @@ export default function LoginPage() {
                   <input
                     type="email"
                     id="email-desktop"
-                    className="form-input !rounded-[19px] !bg-[#0D0D0F] !pl-12"
-                    placeholder="name@gmail.com"
+                    className="form-input !rounded-[12px] !bg-[#0D0D0F] !pl-12 !border-white/10"
+                    placeholder="email address"
                     value={formData.email}
                     onChange={(e) =>
                       setFormData({ ...formData, email: e.target.value })
@@ -136,8 +179,8 @@ export default function LoginPage() {
                   <input
                     type={showPassword ? "text" : "password"}
                     id="password-desktop"
-                    className="form-input !rounded-[19px] !bg-[#0D0D0F] !pl-12"
-                    placeholder="●●●●●●●●"
+                    className="form-input !rounded-[12px] !bg-[#0D0D0F] !pl-12 !border-white/10"
+                    placeholder="Password"
                     value={formData.password}
                     onChange={(e) =>
                       setFormData({ ...formData, password: e.target.value })
@@ -167,54 +210,26 @@ export default function LoginPage() {
                 </Link>
               </div>
 
-              <div className="flex justify-center">
-                <button
-                  type="submit"
-                  className="w-2/4 h-[58px] flex items-center justify-center mt-6
-                  bg-[#101012] border border-white/75 rounded-[19px]
-                  text-[21.5px] font-semibold text-white leading-[34px] tracking-[-0.03em]
-                  transition-all duration-200 hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled={isLoadingEmail || isLoadingGoogle}
-                >
-                  {isLoadingEmail ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    "Sign in"
-                  )}
-                </button>
-              </div>
-
-              <div className="flex justify-center mt-0">
-                <button
-                  type="button"
-                  onClick={handleGoogleLogin}
-                  className="w-full h-[58px] flex items-center justify-center mt-6
-                  bg-[#101012] border border-white/75 rounded-[19px]
-                  text-[21.5px] font-semibold text-white leading-[34px] tracking-[-0.03em]
-                  transition-all duration-200 hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled={isLoadingEmail || isLoadingGoogle}
-                >
-                  {isLoadingGoogle ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    "Sign in with Google"
-                  )}
-                </button>
-              </div>
-
-              <p className="text-center text-sm text-white/70">
-                Don't have an account?{" "}
-                <Link href="/signup" className="text-white hover:underline">
-                  Sign up
-                </Link>
-              </p>
+              <button
+                type="submit"
+                className="w-full h-[52px] flex items-center justify-center rounded-xl
+                  bg-[#22D3EE] text-[#0a0a0a] font-semibold text-base
+                  transition-all duration-200 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={isLoadingEmail || isLoadingGoogle}
+              >
+                {isLoadingEmail ? (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                ) : (
+                  "Login"
+                )}
+              </button>
             </form>
           </div>
         </div>
 
-        {/* Mobile view - borderless design */}
+        {/* Mobile view - same layout: Google first (full width), then OR, email/password */}
         <div className="sm:hidden w-full flex flex-col min-h-[calc(100vh-48px)] justify-between">
-          <div className="flex flex-col space-y-8 pt-12">
+          <div className="flex flex-col space-y-6 pt-10">
             <div className="flex justify-center">
               <Image
                 src="/logo.svg"
@@ -226,24 +241,53 @@ export default function LoginPage() {
               />
             </div>
 
-            <h1 className="text-mobile-xl md:text-2xl font-semibold text-white text-center">
-              Log in to Splito
+            <h1 className="text-xl font-semibold text-white text-center">
+              Welcome Back
             </h1>
+            <p className="text-center text-sm text-white/60 -mt-2">
+              Don&apos;t have an account yet?{" "}
+              <Link href="/signup" className="text-white hover:underline font-medium">
+                Sign up
+              </Link>
+            </p>
 
-            <form onSubmit={handleSubmit} className="space-y-7 pt-4">
+            {/* Google full-width strip first */}
+            <button
+              type="button"
+              onClick={handleGoogleLogin}
+              className="w-full h-[52px] flex items-center justify-center gap-3 rounded-xl
+                bg-[#1a1a1c] border border-white/10
+                text-base font-medium text-white
+                transition-all duration-200 hover:bg-white/[0.06] disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoadingEmail || isLoadingGoogle}
+            >
+              {isLoadingGoogle ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <>
+                  <GoogleIcon />
+                  <span>Login with Google</span>
+                </>
+              )}
+            </button>
+
+            <div className="relative flex items-center">
+              <div className="flex-grow border-t border-white/10" />
+              <span className="px-4 text-sm text-white/40">OR</span>
+              <div className="flex-grow border-t border-white/10" />
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-5">
               <div className="form-group">
-                <label
-                  htmlFor="email-mobile"
-                  className="text-mobile-sm font-medium text-white/80 mb-2 block"
-                >
+                <label htmlFor="email-mobile" className="text-sm font-medium text-white/80 mb-2 block">
                   Email
                 </label>
                 <div className="relative">
                   <input
                     type="email"
                     id="email-mobile"
-                    className="w-full bg-transparent border-0 border-b border-white/20 px-0 py-2 text-mobile-base text-white focus:ring-0 focus:border-white/40 placeholder-white/30"
-                    placeholder="name@gmail.com"
+                    className="w-full bg-[#0D0D0F] border border-white/10 rounded-xl px-4 pl-11 py-3 text-white focus:ring-2 focus:ring-white/20 focus:border-white/20 placeholder-white/40"
+                    placeholder="email address"
                     value={formData.email}
                     onChange={(e) =>
                       setFormData({ ...formData, email: e.target.value })
@@ -251,22 +295,20 @@ export default function LoginPage() {
                     required
                     disabled={isLoadingEmail || isLoadingGoogle}
                   />
+                  <Mail className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-white/50" />
                 </div>
               </div>
 
               <div className="form-group">
-                <label
-                  htmlFor="password-mobile"
-                  className="text-mobile-sm font-medium text-white/80 mb-2 block"
-                >
+                <label htmlFor="password-mobile" className="text-sm font-medium text-white/80 mb-2 block">
                   Password
                 </label>
                 <div className="relative">
                   <input
                     type={showPassword ? "text" : "password"}
                     id="password-mobile"
-                    className="w-full bg-transparent border-0 border-b border-white/20 px-0 py-2 text-mobile-base text-white focus:ring-0 focus:border-white/40 placeholder-white/30"
-                    placeholder="Your password"
+                    className="w-full bg-[#0D0D0F] border border-white/10 rounded-xl px-4 pl-11 py-3 text-white focus:ring-2 focus:ring-white/20 focus:border-white/20 placeholder-white/40"
+                    placeholder="Password"
                     value={formData.password}
                     onChange={(e) =>
                       setFormData({ ...formData, password: e.target.value })
@@ -274,98 +316,41 @@ export default function LoginPage() {
                     required
                     disabled={isLoadingEmail || isLoadingGoogle}
                   />
+                  <Lock className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-white/50" />
                   <button
                     type="button"
-                    className="absolute right-0 top-1/2 -translate-y-1/2 text-white/50 hover:text-white/70 transition-colors"
+                    className="absolute right-4 top-1/2 -translate-y-1/2 text-white/50 hover:text-white/70"
                     onClick={() => setShowPassword(!showPassword)}
                     disabled={isLoadingEmail || isLoadingGoogle}
                   >
-                    {showPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
+                    {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                   </button>
                 </div>
-                <Link
-                  href="/forgot-password"
-                  className="text-mobile-sm text-green-400 hover:text-green-300 mt-2 inline-block"
-                >
+                <Link href="/forgot-password" className="text-sm text-white/50 hover:text-white/70 mt-2 inline-block">
                   Forgot Password?
                 </Link>
               </div>
 
               <button
                 type="submit"
-                className="w-full h-[50px] flex items-center justify-center mt-8
-                bg-white rounded-full
-                text-mobile-lg font-semibold text-black
-                transition-all duration-200 hover:bg-white/90 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full h-[52px] flex items-center justify-center rounded-xl
+                  bg-[#22D3EE] text-[#0a0a0a] font-semibold text-base
+                  transition-all duration-200 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={isLoadingEmail || isLoadingGoogle}
               >
                 {isLoadingEmail ? (
-                  <Loader2 className="h-5 w-5 animate-spin text-black" />
+                  <Loader2 className="h-5 w-5 animate-spin" />
                 ) : (
                   "Login"
                 )}
               </button>
             </form>
-
-            <div className="relative flex items-center justify-center">
-              <div className="flex-grow border-t border-white/20"></div>
-              <span className="mx-4 text-white/50 text-mobile-sm">OR</span>
-              <div className="flex-grow border-t border-white/20"></div>
-            </div>
-
-            <button
-              type="button"
-              onClick={handleGoogleLogin}
-              className="w-full h-[50px] flex items-center justify-center
-              bg-transparent border border-white/20 rounded-full
-              text-mobile-lg font-medium text-white
-              transition-all duration-200 hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled={isLoadingEmail || isLoadingGoogle}
-            >
-              <div className="flex items-center gap-2">
-                {isLoadingGoogle ? (
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                ) : (
-                  <>
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 20 20"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19.8055 10.2298C19.8055 9.51795 19.7434 8.83835 19.6299 8.18213H10.2002V11.9624H15.6016C15.3853 13.1709 14.6875 14.1933 13.6543 14.8622V17.311H16.8564C18.7502 15.5938 19.8055 13.1499 19.8055 10.2298Z"
-                        fill="#4285F4"
-                      />
-                      <path
-                        d="M10.1999 20.0001C12.8999 20.0001 15.1499 19.115 16.8561 17.3113L13.654 14.8625C12.7754 15.4513 11.6077 15.7968 10.1999 15.7968C7.5938 15.7968 5.38819 14.0732 4.58777 11.7H1.28149V14.2318C2.9752 17.6232 6.3313 20.0001 10.1999 20.0001Z"
-                        fill="#34A853"
-                      />
-                      <path
-                        d="M4.58753 11.7002C4.18753 10.4917 4.18753 9.17 4.58753 7.9615V5.42969H1.28126C-0.119933 8.00938 -0.119933 11.6523 1.28126 14.232L4.58753 11.7002Z"
-                        fill="#FBBC05"
-                      />
-                      <path
-                        d="M10.1999 4.20378C11.6218 4.18533 12.9998 4.73503 14.0345 5.72847L16.8959 2.8671C15.1044 1.18895 12.6958 0.200905 10.1999 0.229336C6.3313 0.229336 2.9752 2.60621 1.28149 5.99761L4.58777 8.52941C5.38819 6.15621 7.5938 4.43261 10.1999 4.20378Z"
-                        fill="#EA4335"
-                      />
-                    </svg>
-                    <span>Continue with Google</span>
-                  </>
-                )}
-              </div>
-            </button>
           </div>
 
-          <div className="mt-auto pb-12 space-y-6">
-            <p className="text-center text-mobile-sm text-white/70">
-              Don't have an account?{" "}
-              <Link href="/signup" className="text-white hover:underline">
+          <div className="mt-auto pb-10">
+            <p className="text-center text-sm text-white/60">
+              Don&apos;t have an account?{" "}
+              <Link href="/signup" className="text-white hover:underline font-medium">
                 Sign up
               </Link>
             </p>

--- a/app/organization/[organizationId]/activity/page.tsx
+++ b/app/organization/[organizationId]/activity/page.tsx
@@ -7,6 +7,7 @@ import { useGetOrganizationActivity } from "@/features/business/hooks/use-invoic
 import { useOrganizationOrg } from "@/contexts/organization-org-context";
 import { Loader2 } from "lucide-react";
 import { formatCurrency } from "@/utils/formatters";
+import { Card, SectionLabel, T, G } from "@/lib/splito-design";
 
 function activityLabel(type: string) {
   switch (type) {
@@ -48,58 +49,68 @@ export default function OrganizationActivityPage() {
     );
   }
 
+  const dotColor = (type: string) => (type.includes("APPROVED") || type.includes("SIGNED") ? G : "#22D3EE");
+
   return (
-    <div className="space-y-3 sm:space-y-4">
-      <h3 className="text-mobile-lg sm:text-xl font-medium text-white mb-3 sm:mb-4">Activity</h3>
+    <div className="space-y-4 sm:space-y-5">
+      <SectionLabel>Activity</SectionLabel>
       {isActivityLoading ? (
         <div className="flex justify-center py-8">
           <Loader2 className="h-8 w-8 animate-spin text-white/50" />
         </div>
       ) : activities.length > 0 ? (
-        activities.map((act) => (
-          <div key={act.id} className="p-3 sm:p-4 rounded-xl bg-white/[0.02] flex items-center gap-3">
-            <div className="h-8 w-8 sm:h-10 sm:w-10 rounded-full overflow-hidden flex-shrink-0">
-              <Image
-                src={act.user?.image || `https://api.dicebear.com/9.x/identicon/svg?seed=${act.user?.id}`}
-                alt={act.user?.name || "User"}
-                width={40}
-                height={40}
-                className="h-full w-full object-cover"
-              />
+        <Card className="p-0 overflow-hidden">
+          {activities.map((act, idx) => (
+            <div
+              key={act.id}
+              className="flex items-center gap-3 p-4 sm:p-5 border-b border-white/[0.06] last:border-b-0"
+            >
+              <div className="w-2 h-2 rounded-full flex-shrink-0 mt-1.5" style={{ background: dotColor(act.type) }} />
+              <div className="h-8 w-8 sm:h-10 sm:w-10 rounded-full overflow-hidden flex-shrink-0 border border-white/[0.08]">
+                <Image
+                  src={act.user?.image || `https://api.dicebear.com/9.x/identicon/svg?seed=${act.user?.id}`}
+                  alt={act.user?.name || "User"}
+                  width={40}
+                  height={40}
+                  className="h-full w-full object-cover"
+                />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm sm:text-base leading-snug" style={{ color: T.body }}>
+                  <span className="font-semibold" style={{ color: T.bright }}>{act.user?.name || act.user?.email || "Someone"}</span> {activityLabel(act.type)}
+                  {act.invoice && (
+                    <span style={{ color: T.muted }}>
+                      {" "}
+                      ({formatCurrency(act.invoice.amount, act.invoice.currency)}
+                      {act.invoice.recipient?.name && ` to ${act.invoice.recipient.name}`})
+                    </span>
+                  )}
+                  {act.contract && act.type === "CONTRACT_CREATED" && (
+                    <span style={{ color: T.muted }}>
+                      {" "}for &quot;{act.contract.assignedToEmail ?? act.contract.assignedTo?.email ?? "—"}&quot;
+                      {(act.contract.jobTitle || act.contract.title) && (
+                        <> ({act.contract.jobTitle || act.contract.title})</>
+                      )}
+                    </span>
+                  )}
+                  {act.contract && act.type !== "CONTRACT_CREATED" && (
+                    <span style={{ color: T.muted }}>
+                      {" "}
+                      ({act.contract.title || "Contract"}
+                      {act.contract.assignedTo?.name && ` · ${act.contract.assignedTo.name}`})
+                    </span>
+                  )}
+                </p>
+                <p className="text-xs sm:text-sm mt-1 font-semibold" style={{ color: T.sub }}>{new Date(act.createdAt).toLocaleString()}</p>
+                {act.note && <p className="text-sm mt-1" style={{ color: T.dim }}>Note: {act.note}</p>}
+              </div>
             </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-mobile-base sm:text-base text-white">
-                <span className="font-medium">{act.user?.name || act.user?.email || "Someone"}</span> {activityLabel(act.type)}
-                {act.invoice && (
-                  <span className="text-white/70">
-                    {" "}
-                    ({formatCurrency(act.invoice.amount, act.invoice.currency)}
-                    {act.invoice.recipient?.name && ` to ${act.invoice.recipient.name}`})
-                  </span>
-                )}
-                {act.contract && act.type === "CONTRACT_CREATED" && (
-                  <span className="text-white/70">
-                    {" "}for &quot;{act.contract.assignedToEmail ?? act.contract.assignedTo?.email ?? "—"}&quot;
-                    {(act.contract.jobTitle || act.contract.title) && (
-                      <> ({act.contract.jobTitle || act.contract.title})</>
-                    )}
-                  </span>
-                )}
-                {act.contract && act.type !== "CONTRACT_CREATED" && (
-                  <span className="text-white/70">
-                    {" "}
-                    ({act.contract.title || "Contract"}
-                    {act.contract.assignedTo?.name && ` · ${act.contract.assignedTo.name}`})
-                  </span>
-                )}
-              </p>
-              <p className="text-mobile-xs sm:text-sm text-white/60">{new Date(act.createdAt).toLocaleString()}</p>
-              {act.note && <p className="text-white/50 text-sm mt-1">Note: {act.note}</p>}
-            </div>
-          </div>
-        ))
+          ))}
+        </Card>
       ) : (
-        <div className="text-center py-8 sm:py-12 text-mobile-base sm:text-base text-white/60">No activity yet</div>
+        <Card className="p-8 sm:p-12 text-center">
+          <p className="text-[15px] font-semibold" style={{ color: T.muted }}>No activity yet</p>
+        </Card>
       )}
     </div>
   );

--- a/app/organization/[organizationId]/activity/page.tsx
+++ b/app/organization/[organizationId]/activity/page.tsx
@@ -77,11 +77,19 @@ export default function OrganizationActivityPage() {
                     {act.invoice.recipient?.name && ` to ${act.invoice.recipient.name}`})
                   </span>
                 )}
-                {act.contract && (
+                {act.contract && act.type === "CONTRACT_CREATED" && (
+                  <span className="text-white/70">
+                    {" "}for &quot;{act.contract.assignedToEmail ?? act.contract.assignedTo?.email ?? "—"}&quot;
+                    {(act.contract.jobTitle || act.contract.title) && (
+                      <> ({act.contract.jobTitle || act.contract.title})</>
+                    )}
+                  </span>
+                )}
+                {act.contract && act.type !== "CONTRACT_CREATED" && (
                   <span className="text-white/70">
                     {" "}
                     ({act.contract.title || "Contract"}
-                    {act.contract.assignedTo?.name && ` · assigned to ${act.contract.assignedTo.name}`})
+                    {act.contract.assignedTo?.name && ` · ${act.contract.assignedTo.name}`})
                   </span>
                 )}
               </p>

--- a/app/organization/[organizationId]/contracts/page.tsx
+++ b/app/organization/[organizationId]/contracts/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { Plus, Pencil, Trash2, Loader2, CheckCircle2, Clock, Download, Eye } from "lucide-react";
 import {
   useGetContractsByOrganization,
-  useDeleteContract,
+  useRevokeContract,
 } from "@/features/business/hooks/use-contracts";
 import { useOrganizationOrg } from "@/contexts/organization-org-context";
 import { toast } from "sonner";
@@ -24,9 +24,9 @@ export default function OrganizationContractsPage() {
   const { isAdmin, openCreateContract } = useOrganizationOrg();
   const { user } = useAuthStore();
   const { data: contracts = [], isLoading: isContractsLoading } = useGetContractsByOrganization(organizationId);
-  const deleteContractMutation = useDeleteContract();
+  const revokeContractMutation = useRevokeContract();
   const [contractToEdit, setContractToEdit] = useState<Contract | null>(null);
-  const [contractToDelete, setContractToDelete] = useState<Contract | null>(null);
+  const [contractToRevoke, setContractToRevoke] = useState<Contract | null>(null);
   const [contractToView, setContractToView] = useState<Contract | null>(null);
   const [contractToSign, setContractToSign] = useState<Contract | null>(null);
 
@@ -42,15 +42,15 @@ export default function OrganizationContractsPage() {
     }
   };
 
-  const handleConfirmDelete = () => {
-    if (!contractToDelete) return;
-    deleteContractMutation.mutate(contractToDelete.id, {
+  const handleConfirmRevoke = () => {
+    if (!contractToRevoke) return;
+    revokeContractMutation.mutate(contractToRevoke.id, {
       onSuccess: () => {
-        toast.success("Contract deleted");
-        setContractToDelete(null);
+        toast.success("Contract revoked and member removed from organization");
+        setContractToRevoke(null);
       },
       onError: (err: { message?: string }) => {
-        toast.error(err?.message ?? "Failed to delete contract");
+        toast.error(err?.message ?? "Failed to revoke contract");
       },
     });
   };
@@ -83,6 +83,7 @@ export default function OrganizationContractsPage() {
       ) : contracts.length > 0 ? (
         contracts.map((c) => {
           const isSigned = !!c.signedAt;
+          const isRevoked = c.status === "REVOKED";
           const isAssignee = c.assignedToUserId === user?.id;
 
           return (
@@ -96,8 +97,12 @@ export default function OrganizationContractsPage() {
                 <div className="flex items-center gap-2 flex-wrap">
                   <p className="text-white font-medium">{c.title || "Contract"}</p>
                   {c.jobTitle && <span className="text-xs text-white/40">· {c.jobTitle}</span>}
-                  {/* Signed status badge */}
-                  {isSigned ? (
+                  {/* Status badge */}
+                  {isRevoked ? (
+                    <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-400 bg-amber-400/10 border border-amber-400/20 rounded-full px-2 py-0.5">
+                      Revoked
+                    </span>
+                  ) : isSigned ? (
                     <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-400 bg-emerald-400/10 border border-emerald-400/20 rounded-full px-2 py-0.5">
                       <CheckCircle2 className="h-3 w-3" />
                       Signed {formatDate(c.signedAt)}
@@ -135,7 +140,7 @@ export default function OrganizationContractsPage() {
                   <Download className="h-4 w-4" />
                 </button>
                 {/* Member: view opens contract gate (View → Accept/Reject) */}
-                {!isAdmin && isAssignee && !isSigned && (
+                {!isAdmin && isAssignee && !isSigned && !isRevoked && (
                   <button
                     type="button"
                     onClick={(e) => { e.stopPropagation(); setContractToSign(c); }}
@@ -146,7 +151,7 @@ export default function OrganizationContractsPage() {
                   </button>
                 )}
 
-                {/* Admin: view + edit + delete */}
+                {/* Admin: view + edit + revoke (edit/revoke hidden for revoked contracts) */}
                 {isAdmin && (
                   <>
                     <button
@@ -157,23 +162,27 @@ export default function OrganizationContractsPage() {
                     >
                       <Eye className="h-4 w-4" />
                     </button>
-                    <button
-                      type="button"
-                      onClick={(e) => { e.stopPropagation(); setContractToEdit(c); }}
-                      className="rounded-full border border-white/20 p-2 text-white/80 hover:text-white hover:bg-white/5"
-                      title="Edit contract"
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={(e) => { e.stopPropagation(); setContractToDelete(c); }}
-                      disabled={deleteContractMutation.isPending}
-                      className="rounded-full border border-white/20 p-2 text-red-400/80 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-50"
-                      title="Delete contract"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+                    {!isRevoked && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={(e) => { e.stopPropagation(); setContractToEdit(c); }}
+                          className="rounded-full border border-white/20 p-2 text-white/80 hover:text-white hover:bg-white/5"
+                          title="Edit contract"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={(e) => { e.stopPropagation(); setContractToRevoke(c); }}
+                          disabled={revokeContractMutation.isPending}
+                          className="rounded-full border border-white/20 p-2 text-red-400/80 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-50"
+                          title="Revoke contract"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </>
+                    )}
                   </>
                 )}
               </div>
@@ -206,7 +215,7 @@ export default function OrganizationContractsPage() {
       />
 
       <AnimatePresence>
-        {contractToDelete && (
+        {contractToRevoke && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -215,7 +224,7 @@ export default function OrganizationContractsPage() {
           >
             <div
               className="absolute inset-0 bg-black/70"
-              onClick={() => !deleteContractMutation.isPending && setContractToDelete(null)}
+              onClick={() => !revokeContractMutation.isPending && setContractToRevoke(null)}
             />
             <motion.div
               initial={{ opacity: 0, scale: 0.95 }}
@@ -224,26 +233,26 @@ export default function OrganizationContractsPage() {
               className="relative z-10 bg-[#101012] rounded-2xl border border-white/20 p-6 w-full max-w-sm shadow-xl"
               onClick={(e) => e.stopPropagation()}
             >
-              <h3 className="text-lg font-semibold text-white mb-2">Delete contract?</h3>
+              <h3 className="text-lg font-semibold text-white mb-2">Revoke contract?</h3>
               <p className="text-white/70 text-sm mb-6">
-                This cannot be undone. The contract will be permanently removed.
+                This will revoke the contract and remove the member from the organization. They will lose access. This cannot be undone.
               </p>
               <div className="flex gap-3">
                 <button
                   type="button"
-                  onClick={() => setContractToDelete(null)}
-                  disabled={deleteContractMutation.isPending}
+                  onClick={() => setContractToRevoke(null)}
+                  disabled={revokeContractMutation.isPending}
                   className="flex-1 h-11 rounded-full border border-white/20 text-white hover:bg-white/5 disabled:opacity-50"
                 >
                   Cancel
                 </button>
                 <button
                   type="button"
-                  onClick={handleConfirmDelete}
-                  disabled={deleteContractMutation.isPending}
+                  onClick={handleConfirmRevoke}
+                  disabled={revokeContractMutation.isPending}
                   className="flex-1 h-11 rounded-full bg-red-500/20 text-red-400 border border-red-500/40 hover:bg-red-500/30 font-medium disabled:opacity-50 flex items-center justify-center gap-2"
                 >
-                  {deleteContractMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Delete"}
+                  {revokeContractMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Revoke"}
                 </button>
               </div>
             </motion.div>

--- a/app/organization/[organizationId]/contracts/page.tsx
+++ b/app/organization/[organizationId]/contracts/page.tsx
@@ -17,6 +17,7 @@ import { ContractGateModal } from "@/components/contract-gate-modal";
 import { Contract } from "@/features/business/api/client";
 import { motion, AnimatePresence } from "framer-motion";
 import { useAuthStore } from "@/stores/authStore";
+import { Card, SectionLabel, T, A, Tag, G } from "@/lib/splito-design";
 
 export default function OrganizationContractsPage() {
   const params = useParams();
@@ -61,72 +62,67 @@ export default function OrganizationContractsPage() {
   };
 
   return (
-    <div className="space-y-3 sm:space-y-4">
-      {isAdmin && (
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-mobile-lg sm:text-xl font-medium text-white">Contracts</h3>
+    <div className="space-y-4 sm:space-y-5">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <SectionLabel>{isAdmin ? "Contracts" : "My contracts"}</SectionLabel>
+        {isAdmin && (
           <button
             onClick={openCreateContract}
-            className="flex items-center gap-2 rounded-full bg-white text-black h-10 px-4 text-sm font-medium hover:bg-white/90"
+            className="flex items-center gap-2 rounded-xl h-9 sm:h-10 px-3 sm:px-4 text-sm font-extrabold transition-all hover:opacity-90"
+            style={{ background: A, color: "#0a0a0a" }}
           >
             <Plus className="h-4 w-4" />
             Create contract
           </button>
-        </div>
-      )}
-      {!isAdmin && <h3 className="text-mobile-lg sm:text-xl font-medium text-white mb-3 sm:mb-4">My contracts</h3>}
+        )}
+      </div>
 
       {isContractsLoading ? (
         <div className="flex justify-center py-8">
           <Loader2 className="h-8 w-8 animate-spin text-white/50" />
         </div>
       ) : contracts.length > 0 ? (
-        contracts.map((c) => {
-          const isSigned = !!c.signedAt;
-          const isRevoked = c.status === "REVOKED";
-          const isAssignee = c.assignedToUserId === user?.id;
+        <div className="space-y-3">
+          {contracts.map((c) => {
+            const isSigned = !!c.signedAt;
+            const isRevoked = c.status === "REVOKED";
+            const isAssignee = c.assignedToUserId === user?.id;
 
-          return (
-            <div
-              key={c.id}
-              className={`flex flex-col sm:flex-row sm:items-start gap-4 p-4 rounded-xl bg-white/[0.02] border border-white/[0.05] ${isAdmin || isAssignee ? " cursor-pointer hover:bg-white/[0.04] transition-colors" : ""}`}
-              onClick={isAdmin || isAssignee ? () => handleRowClick(c) : undefined}
-            >
-              {/* Left: info */}
-              <div className="min-w-0 flex-1 space-y-1">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <p className="text-white font-medium">{c.title || "Contract"}</p>
-                  {c.jobTitle && <span className="text-xs text-white/40">· {c.jobTitle}</span>}
-                  {/* Status badge */}
-                  {isRevoked ? (
-                    <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-400 bg-amber-400/10 border border-amber-400/20 rounded-full px-2 py-0.5">
-                      Revoked
-                    </span>
-                  ) : isSigned ? (
-                    <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-400 bg-emerald-400/10 border border-emerald-400/20 rounded-full px-2 py-0.5">
-                      <CheckCircle2 className="h-3 w-3" />
-                      Signed {formatDate(c.signedAt)}
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1 text-xs font-medium text-white/40 bg-white/5 border border-white/10 rounded-full px-2 py-0.5">
-                      <Clock className="h-3 w-3" />
-                      Awaiting signature
-                    </span>
-                  )}
-                </div>
-                <p className="text-white/60 text-sm">
-                  {isAdmin
-                    ? `Assigned to ${c.assignedTo?.name ?? c.assignedToEmail}`
-                    : `From ${c.organization?.name ?? "organization"}`}
-                  {c.compensationAmount != null &&
-                    ` · ${formatCurrencyLocal(c.compensationAmount, c.compensationCurrency ?? "USD")}${c.paymentFrequency ? " / " + c.paymentFrequency.toLowerCase() : ""}`}
-                </p>
-                {c.startDate && (
-                  <p className="text-white/40 text-xs">
-                    {formatDate(c.startDate)}{c.endDate ? ` → ${formatDate(c.endDate)}` : " · No end date"}
-                  </p>
-                )}
-              </div>
+            return (
+              <div
+                key={c.id}
+                role={isAdmin || isAssignee ? "button" : undefined}
+                onClick={isAdmin || isAssignee ? () => handleRowClick(c) : undefined}
+                className={isAdmin || isAssignee ? "cursor-pointer" : ""}
+              >
+              <Card className="p-4 sm:p-5 hover:bg-white/[0.03] transition-colors">
+                <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+                  {/* Left: info */}
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <p className="font-semibold" style={{ color: T.bright }}>{c.title || "Contract"}</p>
+                      {c.jobTitle && <span className="text-xs" style={{ color: T.dim }}>· {c.jobTitle}</span>}
+                      {isRevoked ? (
+                        <Tag color="#FB923C">Revoked</Tag>
+                      ) : isSigned ? (
+                        <Tag color={G}><CheckCircle2 className="h-3 w-3 inline mr-0.5" /> Signed {formatDate(c.signedAt)}</Tag>
+                      ) : (
+                        <Tag color={T.muted}><Clock className="h-3 w-3 inline mr-0.5" /> Awaiting signature</Tag>
+                      )}
+                    </div>
+                    <p className="text-sm" style={{ color: T.muted }}>
+                      {isAdmin
+                        ? `Assigned to ${c.assignedTo?.name ?? c.assignedToEmail}`
+                        : `From ${c.organization?.name ?? "organization"}`}
+                      {c.compensationAmount != null &&
+                        ` · ${formatCurrencyLocal(c.compensationAmount, c.compensationCurrency ?? "USD")}${c.paymentFrequency ? " / " + c.paymentFrequency.toLowerCase() : ""}`}
+                    </p>
+                    {c.startDate && (
+                      <p className="text-xs" style={{ color: T.dim }}>
+                        {formatDate(c.startDate)}{c.endDate ? ` → ${formatDate(c.endDate)}` : " · No end date"}
+                      </p>
+                    )}
+                  </div>
 
               {/* Right: actions */}
               <div className="flex items-center gap-2 flex-shrink-0">
@@ -186,13 +182,18 @@ export default function OrganizationContractsPage() {
                   </>
                 )}
               </div>
-            </div>
-          );
-        })
-      ) : (
-        <div className="text-center py-12 text-white/60">
-          {isAdmin ? "No contracts yet. Create one to assign to someone by email." : "No contracts assigned to you."}
+                </div>
+              </Card>
+              </div>
+            );
+          })}
         </div>
+      ) : (
+        <Card className="p-8 sm:p-12 text-center">
+          <p className="text-[15px] font-semibold" style={{ color: T.muted }}>
+            {isAdmin ? "No contracts yet. Create one to assign to someone by email." : "No contracts assigned to you."}
+          </p>
+        </Card>
       )}
 
       <EditContractModal

--- a/app/organization/[organizationId]/invoices/page.tsx
+++ b/app/organization/[organizationId]/invoices/page.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { formatCurrency } from "@/utils/formatters";
 import { InvoiceReviewModal } from "@/components/invoice-review-modal";
 import type { Invoice } from "@/features/business/api/client";
+import { Card, SectionLabel, Btn, T, Icons } from "@/lib/splito-design";
 
 export default function OrganizationInvoicesPage() {
   const params = useParams();
@@ -35,101 +36,104 @@ export default function OrganizationInvoicesPage() {
   const formatCurrencyLocal = (amount: number, currency: string) => formatCurrency(amount, currency);
 
   return (
-    <div className="space-y-3 sm:space-y-4">
+    <div className="space-y-4 sm:space-y-5">
+      <SectionLabel>Invoices</SectionLabel>
       {isInvoicesLoading ? (
         <div className="flex justify-center py-8">
           <Loader2 className="h-8 w-8 animate-spin text-white/50" />
         </div>
       ) : invoices.length > 0 ? (
-        invoices.map((inv) => (
-          <div key={inv.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 sm:p-4 rounded-xl bg-white/[0.02]">
-            <div className="flex gap-3 flex-1 min-w-0">
-              {inv.imageUrl && (
-                <button
-                  type="button"
-                  onClick={() =>
-                    setExpandedImage({
-                      url: inv.imageUrl!,
-                      description: inv.description || `Invoice — ${formatCurrencyLocal(inv.amount, inv.currency)}`,
-                    })
-                  }
-                  className="relative h-20 w-28 flex-shrink-0 rounded-lg overflow-hidden bg-white/5 cursor-pointer hover:ring-2 hover:ring-white/30 transition-shadow"
-                >
-                  <Image src={inv.imageUrl} alt="Invoice" fill className="object-cover" sizes="112px" />
-                </button>
-              )}
-              <div className="min-w-0">
-                <p className="text-white font-medium">
-                  {inv.issuer?.name || inv.issuer?.email || "Member"} — {formatCurrencyLocal(inv.amount, inv.currency)}
-                </p>
-                <p className="text-white/60 text-sm">
-                  Due {new Date(inv.dueDate).toLocaleDateString()} · {inv.status}
-                </p>
-                {inv.description && <p className="text-white/50 text-sm mt-1">{inv.description}</p>}
-              </div>
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              {isAdmin && (inv.status === "DRAFT" || inv.status === "SENT") && (
-                <button
-                  type="button"
-                  onClick={() => setInvoiceToReview(inv)}
-                  className="rounded-full border border-white/20 px-3 py-1.5 text-white/80 hover:text-white hover:bg-white/5 text-sm flex items-center gap-1.5"
-                >
-                  <Eye className="h-3.5 w-3.5" />
-                  View
-                </button>
-              )}
-              {isAdmin && (inv.status === "APPROVED" || inv.status === "DECLINED" || inv.status === "PAID") && (
-                <button
-                  onClick={() =>
-                    clearInvoiceMutation.mutate(inv.id, {
-                      onSuccess: () => toast.success("Invoice cleared"),
-                      onError: () => toast.error("Failed to clear"),
-                    })
-                  }
-                  disabled={clearInvoiceMutation.isPending}
-                  className="rounded-full border border-white/20 px-3 py-1.5 text-white/80 hover:text-white text-sm"
-                >
-                  Clear
-                </button>
-              )}
-              {inv.issuerId === user?.id && (inv.status === "DRAFT" || inv.status === "SENT") && (
-                <>
+        <Card className="p-0 overflow-hidden">
+          {invoices.map((inv, idx) => (
+            <div
+              key={inv.id}
+              className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-4 sm:p-5 border-b border-white/[0.06] last:border-b-0"
+            >
+              <div className="flex gap-3 flex-1 min-w-0">
+                {inv.imageUrl && (
                   <button
                     type="button"
                     onClick={() =>
-                      setInvoiceToEdit({
-                        id: inv.id,
-                        amount: inv.amount,
-                        currency: inv.currency,
-                        dueDate: inv.dueDate,
-                        description: inv.description ?? null,
-                        imageUrl: inv.imageUrl ?? null,
+                      setExpandedImage({
+                        url: inv.imageUrl!,
+                        description: inv.description || `Invoice — ${formatCurrencyLocal(inv.amount, inv.currency)}`,
                       })
                     }
-                    className="rounded-full border border-white/20 px-3 py-1.5 text-white/80 hover:text-white text-sm"
+                    className="relative h-20 w-28 flex-shrink-0 rounded-xl overflow-hidden bg-white/[0.05] border border-white/[0.08] cursor-pointer hover:ring-2 hover:ring-white/20 transition-shadow"
                   >
-                    Edit
+                    <Image src={inv.imageUrl} alt="Invoice" fill className="object-cover" sizes="112px" />
                   </button>
-                  {inv.status === "DRAFT" && (
-                    <button
+                )}
+                <div className="min-w-0">
+                  <p className="font-medium text-[#f5f5f5]">
+                    {inv.issuer?.name || inv.issuer?.email || "Member"} — {formatCurrencyLocal(inv.amount, inv.currency)}
+                  </p>
+                  <p className="text-sm mt-1" style={{ color: T.muted }}>
+                    Due {new Date(inv.dueDate).toLocaleDateString()} · {inv.status}
+                  </p>
+                  {inv.description && <p className="text-sm mt-1" style={{ color: T.sub }}>{inv.description}</p>}
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {isAdmin && (inv.status === "DRAFT" || inv.status === "SENT") && (
+                  <Btn variant="ghost" onClick={() => setInvoiceToReview(inv)} style={{ padding: "6px 12px", fontSize: 12 }}>
+                    <Eye className="h-3.5 w-3.5" /> View
+                  </Btn>
+                )}
+                {isAdmin && (inv.status === "APPROVED" || inv.status === "DECLINED" || inv.status === "PAID") && (
+                  <Btn
+                    variant="ghost"
+                    onClick={() =>
+                      clearInvoiceMutation.mutate(inv.id, {
+                        onSuccess: () => toast.success("Invoice cleared"),
+                        onError: () => toast.error("Failed to clear"),
+                      })
+                    }
+                    disabled={clearInvoiceMutation.isPending}
+                    style={{ padding: "6px 12px", fontSize: 12 }}
+                  >
+                    Clear
+                  </Btn>
+                )}
+                {inv.issuerId === user?.id && (inv.status === "DRAFT" || inv.status === "SENT") && (
+                  <>
+                    <Btn
+                      variant="ghost"
                       onClick={() =>
-                        deleteInvoiceMutation.mutate(inv.id, {
-                          onSuccess: () => toast.success("Invoice deleted"),
-                          onError: () => toast.error("Failed to delete"),
+                        setInvoiceToEdit({
+                          id: inv.id,
+                          amount: inv.amount,
+                          currency: inv.currency,
+                          dueDate: inv.dueDate,
+                          description: inv.description ?? null,
+                          imageUrl: inv.imageUrl ?? null,
                         })
                       }
-                      disabled={deleteInvoiceMutation.isPending}
-                      className="rounded-full border border-red-500/50 px-3 py-1.5 text-red-400 hover:bg-red-500/10 text-sm"
+                      style={{ padding: "6px 12px", fontSize: 12 }}
                     >
-                      Delete
-                    </button>
-                  )}
-                </>
-              )}
+                      Edit
+                    </Btn>
+                    {inv.status === "DRAFT" && (
+                      <Btn
+                        variant="danger"
+                        onClick={() =>
+                          deleteInvoiceMutation.mutate(inv.id, {
+                            onSuccess: () => toast.success("Invoice deleted"),
+                            onError: () => toast.error("Failed to delete"),
+                          })
+                        }
+                        disabled={deleteInvoiceMutation.isPending}
+                        style={{ padding: "6px 12px", fontSize: 12 }}
+                      >
+                        {Icons.trash({ size: 12 })} Delete
+                      </Btn>
+                    )}
+                  </>
+                )}
+              </div>
             </div>
-        </div>
-      ))
+          ))}
+        </Card>
       ) : null}
 
       <InvoiceReviewModal
@@ -156,17 +160,20 @@ export default function OrganizationInvoicesPage() {
       />
 
       {invoices.length === 0 && !isInvoicesLoading && (
-        <div className="text-center py-12 text-white/60">
-          No invoices yet.
+        <Card className="p-8 sm:p-12 text-center">
+          <p className="text-[15px] font-semibold mb-2" style={{ color: T.muted }}>
+            No invoices yet.
+          </p>
           {!isAdmin && (
-            <>
-              {" "}
-              <button onClick={openAddInvoice} className="text-white hover:underline">
-                Raise an invoice
-              </button>
-            </>
+            <button
+              onClick={openAddInvoice}
+              className="mt-2 inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-bold transition-all"
+              style={{ background: A, color: "#0a0a0a" }}
+            >
+              Raise an invoice
+            </button>
           )}
-        </div>
+        </Card>
       )}
     </div>
   );

--- a/app/organization/[organizationId]/invoices/page.tsx
+++ b/app/organization/[organizationId]/invoices/page.tsx
@@ -18,7 +18,7 @@ import { toast } from "sonner";
 import { formatCurrency } from "@/utils/formatters";
 import { InvoiceReviewModal } from "@/components/invoice-review-modal";
 import type { Invoice } from "@/features/business/api/client";
-import { Card, SectionLabel, Btn, T, Icons } from "@/lib/splito-design";
+import { Card, SectionLabel, Btn, T, Icons, A } from "@/lib/splito-design";
 
 export default function OrganizationInvoicesPage() {
   const params = useParams();

--- a/app/organization/[organizationId]/layout.tsx
+++ b/app/organization/[organizationId]/layout.tsx
@@ -33,6 +33,7 @@ import { toast } from "sonner";
 import CurrencyDropdown from "@/components/currency-dropdown";
 import type { Currency } from "@/features/currencies/api/client";
 import { OrganizationOrgProvider, useOrganizationOrg } from "@/contexts/organization-org-context";
+import { Card, Btn, T, A } from "@/lib/splito-design";
 
 function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
   const params = useParams();
@@ -254,38 +255,72 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
 
   return (
     <OrganizationOrgProvider value={contextValue}>
-      <div className="w-full">
-        <div className="flex items-center justify-between py-4 sm:py-6 mb-4 sm:mb-6">
-          <div className="flex items-center gap-3 sm:gap-4">
-            <div className="h-12 w-12 sm:h-14 sm:w-14 overflow-hidden rounded-xl bg-white/[0.03]">
+      <div className="w-full flex flex-col min-w-0">
+        {/* Sticky header – design language (matches Dashboard/personal), responsive */}
+        <div
+          className="border-b border-white/[0.07] flex items-center justify-between h-14 sm:h-[70px] px-4 sm:px-7 sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
+        >
+          <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+            <div className="h-12 w-12 sm:h-14 sm:w-14 overflow-hidden rounded-xl flex-shrink-0 border border-white/[0.08] bg-white/[0.03]">
               {group.image ? (
                 <Image src={group.image} alt={group.name} width={56} height={56} className="h-full w-full object-cover" />
               ) : (
                 <Image src={`https://api.dicebear.com/9.x/identicon/svg?seed=${group.id}`} alt={group.name} width={56} height={56} className="h-full w-full" />
               )}
             </div>
-            <div>
-              <h1 className="text-mobile-xl sm:text-2xl font-semibold text-white">{group.name}</h1>
-              <p className="text-white/60 text-sm">{(group.groupUsers || []).length} members</p>
+            <div className="min-w-0">
+            <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white truncate">{group.name}</h1>
+            <p style={{ color: T.muted, fontSize: 12, fontWeight: 600 }}>{(group.groupUsers || []).length} members</p>
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-shrink-0">
             {!isAdmin && (
-              <button onClick={() => setIsAddInvoiceModalOpen(true)} className="flex items-center gap-2 rounded-full bg-white text-black h-10 sm:h-12 px-4 sm:px-6 text-sm font-medium hover:bg-white/90">
+              <button
+                onClick={() => setIsAddInvoiceModalOpen(true)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  height: 40,
+                  padding: "0 18px",
+                  borderRadius: 12,
+                  background: A,
+                  color: "#0a0a0a",
+                  border: "none",
+                  fontSize: 13,
+                  fontWeight: 800,
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
                 <Plus className="h-4 w-4" />
                 <span>Raise Invoice</span>
               </button>
             )}
             {isAdmin && (
-              <button onClick={() => setIsSettingsModalOpen(true)} className="h-10 w-10 rounded-full border border-white/20 flex items-center justify-center text-white/70 hover:text-white">
+              <button
+                onClick={() => setIsSettingsModalOpen(true)}
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 12,
+                  border: "1px solid rgba(255,255,255,0.11)",
+                  background: "rgba(255,255,255,0.06)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: T.body,
+                  cursor: "pointer",
+                }}
+              >
                 <Settings className="h-5 w-5" />
               </button>
             )}
           </div>
         </div>
 
-        <div className="bg-[#101012] rounded-xl sm:rounded-3xl min-h-[calc(100vh-200px)]">
-          <div className="p-4 sm:p-6">{children}</div>
+        <div className="flex-1 p-4 sm:p-7 overflow-y-auto min-h-0">
+          {children}
         </div>
 
         <AddInvoiceModal isOpen={isAddInvoiceModalOpen} onClose={() => setIsAddInvoiceModalOpen(false)} organizationId={organizationId} initialContract={contractForInvoice ?? undefined} />
@@ -295,24 +330,31 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
         {declineInvoiceId && (
           <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
             <div className="fixed inset-0 bg-black/70" onClick={() => { setDeclineInvoiceId(null); setDeclineNote(""); }} />
-            <div className="relative z-10 bg-[#101012] rounded-2xl border border-white/20 p-6 w-full max-w-sm" onClick={(e) => e.stopPropagation()}>
-              <h3 className="text-lg font-medium text-white mb-2">Decline invoice</h3>
-              <p className="text-white/60 text-sm mb-4">Optionally add a reason (visible in activity).</p>
-              <input type="text" value={declineNote} onChange={(e) => setDeclineNote(e.target.value)} placeholder="Reason" className="w-full px-4 py-2 rounded-lg bg-white/5 text-white border border-white/20 mb-4" />
-              <div className="flex gap-2">
-                <button onClick={() => { setDeclineInvoiceId(null); setDeclineNote(""); }} className="flex-1 py-2 rounded-full border border-white/20 text-white">Cancel</button>
-                <button
+            <div className="relative z-10 w-full max-w-sm rounded-2xl p-6 shadow-2xl" style={{ background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)", border: "1px solid rgba(255,255,255,0.08)", boxShadow: "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)" }} onClick={(e) => e.stopPropagation()}>
+              <h3 className="text-lg font-semibold mb-2" style={{ color: T.bright }}>Decline invoice</h3>
+              <p className="text-sm mb-4" style={{ color: T.body }}>Optionally add a reason (visible in activity).</p>
+              <input
+                type="text"
+                value={declineNote}
+                onChange={(e) => setDeclineNote(e.target.value)}
+                placeholder="Reason"
+                className="w-full rounded-xl border outline-none mb-4 font-medium"
+                style={{ padding: "12px 14px", background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", color: "#fff", fontSize: 14 }}
+              />
+              <div className="flex gap-3">
+                <Btn variant="ghost" onClick={() => { setDeclineInvoiceId(null); setDeclineNote(""); }} style={{ flex: 1 }}>Cancel</Btn>
+                <Btn
+                  variant="danger"
                   onClick={() =>
                     declineInvoiceMutation.mutate(
                       { invoiceId: declineInvoiceId, note: declineNote || undefined },
                       { onSuccess: () => { toast.success("Invoice declined"); setDeclineInvoiceId(null); setDeclineNote(""); }, onError: () => toast.error("Failed to decline") }
                     )
                   }
-                  disabled={declineInvoiceMutation.isPending}
-                  className="flex-1 py-2 rounded-full bg-red-500/20 text-red-400 border border-red-500/50 hover:bg-red-500/30"
+                  style={{ flex: 1, opacity: declineInvoiceMutation.isPending ? 0.7 : 1, cursor: declineInvoiceMutation.isPending ? "not-allowed" : "pointer" }}
                 >
-                  {declineInvoiceMutation.isPending ? "Declining..." : "Decline"}
-                </button>
+                  {declineInvoiceMutation.isPending ? <><Loader2 className="h-4 w-4 animate-spin" /> Declining...</> : "Decline"}
+                </Btn>
               </div>
             </div>
           </div>
@@ -320,26 +362,44 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
 
         {isSettingsModalOpen && (
           <div className="fixed inset-0 z-50 h-screen w-screen">
-            <div className="fixed inset-0 bg-black/80 brightness-50" onClick={() => setIsSettingsModalOpen(false)} />
-            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[450px] rounded-[20px] bg-black p-6 border border-white/20 z-10">
-              <h2 className="text-xl font-medium text-white mb-6">Organization settings</h2>
+            <div className="fixed inset-0 bg-black/80 backdrop-blur-sm" onClick={() => setIsSettingsModalOpen(false)} />
+            <div
+              className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[450px] rounded-2xl p-6 z-10"
+              style={{ background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)", border: "1px solid rgba(255,255,255,0.08)", boxShadow: "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)" }}
+            >
+              <h2 className="text-xl font-extrabold tracking-[-0.02em] mb-6" style={{ color: T.bright }}>Organization settings</h2>
               <form onSubmit={handleSettingsSubmit} className="space-y-4">
                 <div>
-                  <label className="block text-base text-white/80 mb-2">Organization Name</label>
-                  <input type="text" value={groupSettings.name || group.name} onChange={(e) => setGroupSettings((p) => ({ ...p, name: e.target.value }))} className="w-full px-4 py-2 rounded-lg bg-[#1A1A1C] text-white border border-white/20" />
+                  <label className="block text-sm font-semibold mb-2" style={{ color: T.soft }}>Organization Name</label>
+                  <input
+                    type="text"
+                    value={groupSettings.name || group.name}
+                    onChange={(e) => setGroupSettings((p) => ({ ...p, name: e.target.value }))}
+                    className="w-full rounded-xl outline-none font-medium"
+                    style={{ padding: "12px 14px", background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", color: T.bright, fontSize: 14 }}
+                  />
                 </div>
                 <div>
-                  <label className="block text-base text-white/80 mb-2">Default Currency</label>
+                  <label className="block text-sm font-semibold mb-2" style={{ color: T.soft }}>Default Currency</label>
                   <CurrencyDropdown selectedCurrencies={groupSettings.currency ? [groupSettings.currency] : []} setSelectedCurrencies={(currencies) => setGroupSettings((prev) => ({ ...prev, currency: currencies[0] || "" }))} mode="single" showFiatCurrencies={true} filterCurrencies={(c: Currency) => c.symbol !== "ETH" && c.symbol !== "USDC"} disableChainCurrencies={true} />
                 </div>
                 <div className="flex justify-end gap-3 mt-6">
-                  <button type="button" onClick={() => setIsSettingsModalOpen(false)} className="px-4 py-2 rounded-lg text-white/80 hover:text-white">Cancel</button>
-                  <button type="submit" className="px-4 py-2 rounded-lg bg-white text-black hover:bg-white/90">Save</button>
+                  <Btn variant="ghost" type="button" onClick={() => setIsSettingsModalOpen(false)}>Cancel</Btn>
+                  <button
+                    type="submit"
+                    style={{ padding: "9px 22px", borderRadius: 12, background: A, color: "#0a0a0a", fontWeight: 800, fontSize: 13, cursor: "pointer", fontFamily: "inherit", border: "none" }}
+                  >
+                    Save
+                  </button>
                 </div>
               </form>
               {isAdmin && (
-                <div className="mt-8 pt-6 border-t border-white/20">
-                  <button onClick={handleDeleteOrganization} className="flex items-center gap-2 text-red-500 hover:text-red-400">
+                <div className="mt-8 pt-6 border-t border-white/[0.07]">
+                  <button
+                    onClick={handleDeleteOrganization}
+                    className="flex items-center gap-2 font-semibold text-sm transition-colors"
+                    style={{ color: "#F87171" }}
+                  >
                     <Trash2 className="h-4 w-4" />
                     <span>Delete Organization</span>
                   </button>

--- a/app/organization/[organizationId]/layout.tsx
+++ b/app/organization/[organizationId]/layout.tsx
@@ -337,12 +337,14 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
                   <button type="submit" className="px-4 py-2 rounded-lg bg-white text-black hover:bg-white/90">Save</button>
                 </div>
               </form>
-              <div className="mt-8 pt-6 border-t border-white/20">
-                <button onClick={handleDeleteOrganization} className="flex items-center gap-2 text-red-500 hover:text-red-400">
-                  <Trash2 className="h-4 w-4" />
-                  <span>Delete Organization</span>
-                </button>
-              </div>
+              {isAdmin && (
+                <div className="mt-8 pt-6 border-t border-white/20">
+                  <button onClick={handleDeleteOrganization} className="flex items-center gap-2 text-red-500 hover:text-red-400">
+                    <Trash2 className="h-4 w-4" />
+                    <span>Delete Organization</span>
+                  </button>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/app/organization/[organizationId]/layout.tsx
+++ b/app/organization/[organizationId]/layout.tsx
@@ -384,7 +384,7 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
                   <CurrencyDropdown selectedCurrencies={groupSettings.currency ? [groupSettings.currency] : []} setSelectedCurrencies={(currencies) => setGroupSettings((prev) => ({ ...prev, currency: currencies[0] || "" }))} mode="single" showFiatCurrencies={true} filterCurrencies={(c: Currency) => c.symbol !== "ETH" && c.symbol !== "USDC"} disableChainCurrencies={true} />
                 </div>
                 <div className="flex justify-end gap-3 mt-6">
-                  <Btn variant="ghost" type="button" onClick={() => setIsSettingsModalOpen(false)}>Cancel</Btn>
+                  <Btn variant="ghost" onClick={() => setIsSettingsModalOpen(false)}>Cancel</Btn>
                   <button
                     type="submit"
                     style={{ padding: "9px 22px", borderRadius: 12, background: A, color: "#0a0a0a", fontWeight: 800, fontSize: 13, cursor: "pointer", fontFamily: "inherit", border: "none" }}

--- a/app/organization/[organizationId]/members/page.tsx
+++ b/app/organization/[organizationId]/members/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Image from "next/image";
-import { Plus } from "lucide-react";
+import { Plus, UserMinus, Loader2 } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
 import { useOrganizationOrg } from "@/contexts/organization-org-context";
-import { useGetGroupById, useUpdateMemberRole } from "@/features/groups/hooks/use-create-group";
-import { Loader2 } from "lucide-react";
+import { useGetGroupById, useUpdateMemberRole, useRemoveMemberFromGroup } from "@/features/groups/hooks/use-create-group";
 import { toast } from "sonner";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   Select,
   SelectContent,
@@ -42,6 +42,8 @@ export default function OrganizationMembersPage() {
   const { openAddMember } = useOrganizationOrg();
   const { data: group, isLoading } = useGetGroupById(organizationId, { type: "BUSINESS" });
   const updateRoleMutation = useUpdateMemberRole();
+  const removeMemberMutation = useRemoveMemberFromGroup();
+  const [memberToRemove, setMemberToRemove] = useState<GroupUser | null>(null);
 
   const currentUserIsAdmin = group && user && isAdmin(group, user.id);
   const members = (group?.groupUsers ?? []) as GroupUser[];
@@ -59,6 +61,23 @@ export default function OrganizationMembersPage() {
         onSuccess: () => toast.success("Role updated"),
         onError: (err: unknown) => {
           const message = err instanceof Error ? err.message : "Failed to update role";
+          toast.error(message);
+        },
+      }
+    );
+  };
+
+  const handleConfirmRemove = () => {
+    if (!memberToRemove || !organizationId) return;
+    removeMemberMutation.mutate(
+      { groupId: organizationId, userId: memberToRemove.userId },
+      {
+        onSuccess: () => {
+          toast.success("Member removed from organization");
+          setMemberToRemove(null);
+        },
+        onError: (err: unknown) => {
+          const message = err instanceof Error ? err.message : "Failed to remove member";
           toast.error(message);
         },
       }
@@ -137,13 +156,13 @@ export default function OrganizationMembersPage() {
                       Admin
                     </div>
                   ) : (
-                    <div className="shrink-0 w-[140px]">
+                    <div className="shrink-0 flex items-center gap-2 w-[200px] sm:w-[240px]">
                       <Select
                         value={displayRole}
                         onValueChange={(value) => handleRoleChange(gu.userId, value as "ADMIN" | "MEMBER")}
                         disabled={updateRoleMutation.isPending}
                       >
-                        <SelectTrigger className="w-full h-12 bg-[#17171A] text-white border border-white/20 rounded-lg px-4 focus:ring-1 focus:ring-white/40 focus:outline-none disabled:opacity-70 disabled:cursor-not-allowed [&>span]:line-clamp-1 [&>svg]:text-white/70">
+                        <SelectTrigger className="flex-1 min-w-0 h-12 bg-[#17171A] text-white border border-white/20 rounded-lg px-4 focus:ring-1 focus:ring-white/40 focus:outline-none disabled:opacity-70 disabled:cursor-not-allowed [&>span]:line-clamp-1 [&>svg]:text-white/70">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent className="bg-[#17171A] border border-white/10 rounded-lg shadow-xl">
@@ -158,6 +177,15 @@ export default function OrganizationMembersPage() {
                           ))}
                         </SelectContent>
                       </Select>
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); setMemberToRemove(gu); }}
+                        disabled={removeMemberMutation.isPending}
+                        className="shrink-0 rounded-full border border-red-500/30 p-2 text-red-400/80 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-50"
+                        title="Remove from organization"
+                      >
+                        <UserMinus className="h-4 w-4" />
+                      </button>
                     </div>
                   )
                 )}
@@ -170,6 +198,52 @@ export default function OrganizationMembersPage() {
           No members yet. {currentUserIsAdmin ? "Use Add Admin above to add org admins; members join via contract." : "Ask an admin to add admins or send you a contract."}
         </div>
       )}
+
+      <AnimatePresence>
+        {memberToRemove && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          >
+            <div
+              className="absolute inset-0 bg-black/70"
+              onClick={() => !removeMemberMutation.isPending && setMemberToRemove(null)}
+            />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              className="relative z-10 bg-[#101012] rounded-2xl border border-white/20 p-6 w-full max-w-sm shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 className="text-lg font-semibold text-white mb-2">Remove member?</h3>
+              <p className="text-white/70 text-sm mb-6">
+                {memberToRemove.user.name || memberToRemove.user.email || "This member"} will be removed from the organization and will lose access.
+              </p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => setMemberToRemove(null)}
+                  disabled={removeMemberMutation.isPending}
+                  className="flex-1 h-11 rounded-full border border-white/20 text-white hover:bg-white/5 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirmRemove}
+                  disabled={removeMemberMutation.isPending}
+                  className="flex-1 h-11 rounded-full bg-red-500/20 text-red-400 border border-red-500/40 hover:bg-red-500/30 font-medium disabled:opacity-50 flex items-center justify-center gap-2"
+                >
+                  {removeMemberMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Remove"}
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/app/organization/[organizationId]/members/page.tsx
+++ b/app/organization/[organizationId]/members/page.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Image from "next/image";
-import { Plus, UserMinus, Loader2 } from "lucide-react";
+import { UserMinus, Loader2 } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
 import { useOrganizationOrg } from "@/contexts/organization-org-context";
 import { useGetGroupById, useUpdateMemberRole, useRemoveMemberFromGroup } from "@/features/groups/hooks/use-create-group";
 import { toast } from "sonner";
 import { motion, AnimatePresence } from "framer-motion";
+import { Card, SectionLabel, T, A, Icons } from "@/lib/splito-design";
 import {
   Select,
   SelectContent,
@@ -93,21 +94,21 @@ export default function OrganizationMembersPage() {
   }
 
   return (
-    <div className="space-y-3 sm:space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-3 sm:mb-4">
-        <h3 className="text-mobile-lg sm:text-xl font-medium text-white">Members</h3>
+    <div className="space-y-4 sm:space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <SectionLabel>Members</SectionLabel>
         {currentUserIsAdmin && (
           <button
             onClick={openAddMember}
-            className="flex items-center gap-2 rounded-full border border-white/20 h-9 sm:h-10 px-3 sm:px-4 text-sm text-white hover:bg-white/5"
+            className="flex items-center gap-2 rounded-xl h-9 sm:h-10 px-3 sm:px-4 text-sm font-extrabold transition-all hover:opacity-90"
+            style={{ background: A, color: "#0a0a0a" }}
           >
-            <Plus className="h-4 w-4" />
-            Add Admin
+            {Icons.plus({ size: 16 })} Add Admin
           </button>
         )}
       </div>
       {currentUserIsAdmin && (
-        <p className="text-white/60 text-mobile-sm sm:text-base mb-4">
+        <p className="text-sm mb-4" style={{ color: T.muted }}>
           Manage members and their roles. Admins can manage roles and organization settings.
         </p>
       )}
@@ -116,37 +117,33 @@ export default function OrganizationMembersPage() {
           <Loader2 className="h-8 w-8 animate-spin text-white/50" />
         </div>
       ) : members.length > 0 ? (
-        <div className="space-y-3">
-          {members.map((gu) => {
+        <Card className="p-0 overflow-hidden">
+          {members.map((gu, idx) => {
             const displayRole = gu.role ?? (group?.userId === gu.userId ? "ADMIN" : "MEMBER");
             const isCurrentUser = gu.userId === user?.id;
             return (
               <div
                 key={gu.userId}
-                className="flex items-center justify-between gap-4 p-3 sm:p-4 rounded-xl bg-white/[0.02]"
+                className="flex items-center justify-between gap-4 p-4 sm:p-5 border-b border-white/[0.06] last:border-b-0"
               >
                 <div className="flex items-center gap-3 sm:gap-4 min-w-0">
-                  <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full flex-shrink-0">
+                  <div className="h-10 w-10 sm:h-12 sm:w-12 overflow-hidden rounded-full flex-shrink-0 border border-white/[0.08]">
                     <Image
                       src={gu.user.image || `https://api.dicebear.com/9.x/identicon/svg?seed=${gu.user.id}`}
                       alt={gu.user.name || "Member"}
-                      width={56}
-                      height={56}
+                      width={48}
+                      height={48}
                       className="h-full w-full object-cover"
                     />
                   </div>
                   <div className="min-w-0">
-                    <p className="text-mobile-base sm:text-xl text-white font-medium truncate">
+                    <p className="font-semibold truncate" style={{ color: T.bright }}>
                       {gu.user.name || gu.user.email || "Member"}
-                      {isCurrentUser && (
-                        <span className="ml-1.5 text-white/60 text-mobile-sm sm:text-base">(you)</span>
-                      )}
-                      {gu.userId === group?.userId && (
-                        <span className="ml-1.5 text-white/60 text-mobile-sm sm:text-base">(Owner)</span>
-                      )}
+                      {isCurrentUser && <span className="ml-1.5 text-sm" style={{ color: T.muted }}>(you)</span>}
+                      {gu.userId === group?.userId && <span className="ml-1.5 text-sm" style={{ color: T.muted }}>(Owner)</span>}
                     </p>
                     {gu.user.email && (
-                      <p className="text-mobile-sm sm:text-base text-white/60 truncate">{gu.user.email}</p>
+                      <p className="text-sm truncate mt-0.5" style={{ color: T.muted }}>{gu.user.email}</p>
                     )}
                   </div>
                 </div>
@@ -192,11 +189,13 @@ export default function OrganizationMembersPage() {
               </div>
             );
           })}
-        </div>
+        </Card>
       ) : (
-        <div className="text-center py-12 text-white/60">
-          No members yet. {currentUserIsAdmin ? "Use Add Admin above to add org admins; members join via contract." : "Ask an admin to add admins or send you a contract."}
-        </div>
+        <Card className="p-8 sm:p-12 text-center">
+          <p className="text-[15px] font-semibold" style={{ color: T.muted }}>
+            No members yet. {currentUserIsAdmin ? "Use Add Admin above to add org admins; members join via contract." : "Ask an admin to add admins or send you a contract."}
+          </p>
+        </Card>
       )}
 
       <AnimatePresence>

--- a/app/organization/[organizationId]/streams/page.tsx
+++ b/app/organization/[organizationId]/streams/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Plus, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import {
   useGetStreamsByOrganization,
   useDeleteStream,
@@ -10,6 +10,7 @@ import {
 import { useOrganizationOrg } from "@/contexts/organization-org-context";
 import { toast } from "sonner";
 import { formatCurrency } from "@/utils/formatters";
+import { Card, SectionLabel, Btn, T, A, Icons } from "@/lib/splito-design";
 
 export default function OrganizationStreamsPage() {
   const params = useParams();
@@ -36,15 +37,15 @@ export default function OrganizationStreamsPage() {
   }
 
   return (
-    <div className="space-y-3 sm:space-y-4">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-mobile-lg sm:text-xl font-medium text-white">Income streams</h3>
+    <div className="space-y-4 sm:space-y-5">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <SectionLabel>Income streams</SectionLabel>
         <button
           onClick={openStreamModal}
-          className="flex items-center gap-2 rounded-full bg-white text-black h-9 sm:h-10 px-3 sm:px-4 text-sm font-medium hover:bg-white/90"
+          className="flex items-center gap-2 rounded-xl h-9 sm:h-10 px-3 sm:px-4 text-sm font-extrabold transition-all hover:opacity-90"
+          style={{ background: A, color: "#0a0a0a" }}
         >
-          <Plus className="h-4 w-4" />
-          <span>Add stream</span>
+          {Icons.plus({ size: 16 })} Add stream
         </button>
       </div>
       {isStreamsLoading ? (
@@ -52,15 +53,15 @@ export default function OrganizationStreamsPage() {
           <Loader2 className="h-8 w-8 animate-spin text-white/50" />
         </div>
       ) : streams.length > 0 ? (
-        <div className="space-y-2">
-          {streams.map((stream) => (
+        <Card className="p-0 overflow-hidden">
+          {streams.map((stream, idx) => (
             <div
               key={stream.id}
-              className="flex items-center justify-between p-3 sm:p-4 rounded-xl bg-white/[0.02]"
+              className="flex items-center justify-between p-4 sm:p-5 border-b border-white/[0.06] last:border-b-0"
             >
               <div className="min-w-0">
-                <p className="text-white font-medium">{stream.name}</p>
-                <p className="text-white/60 text-sm">
+                <p className="font-semibold" style={{ color: T.bright }}>{stream.name}</p>
+                <p className="text-sm mt-1" style={{ color: T.muted }}>
                   {stream.expectedAmount != null
                     ? formatCurrencyLocal(stream.expectedAmount, stream.currency)
                     : stream.currency}
@@ -68,15 +69,11 @@ export default function OrganizationStreamsPage() {
                 </p>
               </div>
               <div className="flex items-center gap-2 shrink-0">
-                <button
-                  type="button"
-                  onClick={() => openEditStream(stream)}
-                  className="rounded-full border border-white/20 px-3 py-1.5 text-white/80 hover:text-white text-sm"
-                >
+                <Btn variant="ghost" onClick={() => openEditStream(stream)} style={{ padding: "6px 12px", fontSize: 12 }}>
                   Edit
-                </button>
-                <button
-                  type="button"
+                </Btn>
+                <Btn
+                  variant="danger"
                   onClick={() =>
                     deleteStreamMutation.mutate(
                       { organizationId, streamId: stream.id },
@@ -87,18 +84,27 @@ export default function OrganizationStreamsPage() {
                     )
                   }
                   disabled={deleteStreamMutation.isPending}
-                  className="rounded-full border border-red-500/50 px-3 py-1.5 text-red-400 hover:bg-red-500/10 text-sm"
+                  style={{ padding: "6px 12px", fontSize: 12 }}
                 >
-                  Delete
-                </button>
+                  {Icons.trash({ size: 12 })} Delete
+                </Btn>
               </div>
             </div>
           ))}
-        </div>
+        </Card>
       ) : (
-        <div className="text-center py-8 sm:py-12 text-white/60">
-          No income streams yet. Add one to track money coming into the organization.
-        </div>
+        <Card className="p-8 sm:p-12 text-center">
+          <p className="text-[15px] font-semibold mb-4" style={{ color: T.muted }}>
+            No income streams yet. Add one to track money coming into the organization.
+          </p>
+          <button
+            onClick={openStreamModal}
+            className="inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-bold"
+            style={{ background: A, color: "#0a0a0a" }}
+          >
+            {Icons.plus({ size: 16 })} Add stream
+          </button>
+        </Card>
       )}
     </div>
   );

--- a/app/organization/create/page.tsx
+++ b/app/organization/create/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { CreateOrganizationForm } from "@/components/create-organization-form";
+
+export default function OrganizationCreatePage() {
+  const router = useRouter();
+
+  return (
+    <CreateOrganizationForm
+      isOpen={true}
+      onClose={() => router.push("/organization")}
+    />
+  );
+}

--- a/app/organization/organizations/page.tsx
+++ b/app/organization/organizations/page.tsx
@@ -13,6 +13,16 @@ import { Loader2, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 
+function isOrgAdmin(
+  org: { userId: string; groupUsers?: { userId: string; role?: string | null }[] },
+  currentUserId: string | undefined
+): boolean {
+  if (!currentUserId) return false;
+  if (org.userId === currentUserId) return true;
+  const membership = org.groupUsers?.find((gu) => gu.userId === currentUserId);
+  return membership?.role === "ADMIN";
+}
+
 export default function OrganizationOrganizationsPage() {
   const router = useRouter();
   const { user } = useAuthStore();
@@ -101,17 +111,19 @@ export default function OrganizationOrganizationsPage() {
                     </p>
                   </div>
                 </Link>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setOrgToDelete({ id: org.id, name: org.name });
-                  }}
-                  className="shrink-0 p-2 rounded-lg text-white/50 hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                  aria-label={`Delete organization ${org.name}`}
-                >
-                  <Trash2 className="h-4 w-4 sm:h-5 sm:w-5" />
-                </button>
+                {isOrgAdmin(org, user?.id) && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setOrgToDelete({ id: org.id, name: org.name });
+                    }}
+                    className="shrink-0 p-2 rounded-lg text-white/50 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                    aria-label={`Delete organization ${org.name}`}
+                  >
+                    <Trash2 className="h-4 w-4 sm:h-5 sm:w-5" />
+                  </button>
+                )}
               </div>
             ))}
           </div>

--- a/app/organization/organizations/page.tsx
+++ b/app/organization/organizations/page.tsx
@@ -12,6 +12,7 @@ import { useDeleteGroup } from "@/features/groups/hooks/use-create-group";
 import { Loader2, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { Card, Btn, T, A, Icons } from "@/lib/splito-design";
 
 function isOrgAdmin(
   org: { userId: string; groupUsers?: { userId: string; role?: string | null }[] },
@@ -33,151 +34,61 @@ export default function OrganizationOrganizationsPage() {
   const deleteGroupMutation = useDeleteGroup();
 
   return (
-    <motion.div
-      variants={fadeIn}
-      initial="initial"
-      animate="animate"
-      className="w-full -mt-2"
-    >
-      <div className="flex items-center justify-between px-3 sm:px-5 py-3 sm:py-4">
-        <h1 className="text-mobile-base sm:text-xl font-medium text-white">
-          My Organizations
-        </h1>
-        <div className="flex items-center gap-3 sm:gap-4">
-          <button
-            onClick={() => setIsCreateModalOpen(true)}
-            className="flex items-center justify-center gap-1 sm:gap-2 rounded-full bg-white text-black h-10 sm:h-12 px-4 sm:px-6 text-mobile-sm sm:text-base font-medium hover:bg-white/90 transition-all"
-          >
-            <Image
-              alt="Add Organization"
-              src="/plus-sign-circle.svg"
-              width={20}
-              height={20}
-              className="h-4 w-4 sm:h-5 sm:w-5 invert"
-            />
-            <span>Add Organization</span>
-          </button>
-          <button
-            onClick={() => router.push("/settings")}
-            className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:from-purple-500/30 hover:to-blue-500/30 transition-all cursor-pointer"
-          >
-            <div className="h-full w-full rounded-full overflow-hidden bg-[#0f0f10]">
-              {user?.image ? (
-                <Image src={user.image} alt="Profile" width={56} height={56} className="h-full w-full object-cover" />
-              ) : (
-                <Image
-                  src={`https://api.dicebear.com/9.x/identicon/svg?seed=${user?.id || user?.email || "user"}`}
-                  alt="Profile"
-                  width={56}
-                  height={56}
-                  className="h-full w-full"
-                />
-              )}
-            </div>
-          </button>
-        </div>
+    <motion.div variants={fadeIn} initial="initial" animate="animate" className="w-full flex flex-col min-w-0">
+      <div className="border-b border-white/[0.07] flex items-center justify-between h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10" style={{ padding: "0 28px" }}>
+        <h1 className="text-[20px] font-extrabold tracking-[-0.02em] text-white">My Organizations</h1>
+        <button onClick={() => setIsCreateModalOpen(true)} style={{ display: "flex", alignItems: "center", gap: 6, height: 40, padding: "0 18px", borderRadius: 12, background: A, color: "#0a0a0a", border: "none", fontSize: 13, fontWeight: 800, cursor: "pointer", fontFamily: "inherit" }}>
+          {Icons.plus({ size: 16 })}
+          <span>Add Organization</span>
+        </button>
       </div>
 
-      <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6">
-        {isLoading ? (
-          <div className="flex items-center justify-center p-12">
-            <Loader2 className="h-8 w-8 animate-spin text-white/50" />
-          </div>
-        ) : organizations.length > 0 ? (
-          <div className="space-y-3">
-            {organizations.map((org) => (
+      <div className="flex-1 p-7 overflow-y-auto" style={{ padding: "28px" }}>
+        <Card className="p-[22px]">
+          {isLoading ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin" style={{ color: T.muted }} />
+            </div>
+          ) : organizations.length > 0 ? (
+            organizations.map((org, idx) => (
               <div
                 key={org.id}
-                className="flex items-center justify-between p-3 sm:p-4 rounded-xl hover:bg-white/[0.02] transition-colors gap-2"
+                className="flex items-center justify-between gap-2 py-4"
+                style={{ borderBottom: idx < organizations.length - 1 ? "1px solid rgba(255,255,255,0.06)" : "none" }}
               >
                 <Link href={`/organization/${org.id}/invoices`} className="flex flex-1 min-w-0 items-center gap-3 sm:gap-4">
-                  <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-xl bg-white/[0.03] shrink-0">
-                    {org.image ? (
-                      <Image src={org.image} alt={org.name} width={56} height={56} className="h-full w-full object-cover" />
-                    ) : (
-                      <Image
-                        src={`https://api.dicebear.com/9.x/identicon/svg?seed=${org.id}`}
-                        alt={org.name}
-                        width={56}
-                        height={56}
-                        className="h-full w-full"
-                      />
-                    )}
+                  <div className="h-10 w-10 sm:h-12 sm:w-12 overflow-hidden rounded-xl shrink-0 border border-white/[0.08] bg-white/[0.03]">
+                    {org.image ? <Image src={org.image} alt={org.name} width={48} height={48} className="h-full w-full object-cover" /> : <Image src={`https://api.dicebear.com/9.x/identicon/svg?seed=${org.id}`} alt={org.name} width={48} height={48} className="h-full w-full" />}
                   </div>
                   <div className="min-w-0">
-                    <p className="text-mobile-base sm:text-xl text-white font-medium truncate">{org.name}</p>
-                    <p className="text-mobile-sm sm:text-base text-white/60">
-                      {(org.groupUsers || []).length} member{(org.groupUsers || []).length !== 1 ? "s" : ""}
-                    </p>
+                    <p className="text-[15px] font-bold truncate" style={{ color: T.bright }}>{org.name}</p>
+                    <p className="text-[13px] font-medium" style={{ color: T.muted }}>{(org.groupUsers || []).length} member{(org.groupUsers || []).length !== 1 ? "s" : ""}</p>
                   </div>
                 </Link>
                 {isOrgAdmin(org, user?.id) && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setOrgToDelete({ id: org.id, name: org.name });
-                    }}
-                    className="shrink-0 p-2 rounded-lg text-white/50 hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                    aria-label={`Delete organization ${org.name}`}
-                  >
+                  <button type="button" onClick={(e) => { e.preventDefault(); setOrgToDelete({ id: org.id, name: org.name }); }} className="shrink-0 p-2 rounded-lg" style={{ color: T.muted }} aria-label={`Delete organization ${org.name}`}>
                     <Trash2 className="h-4 w-4 sm:h-5 sm:w-5" />
                   </button>
                 )}
               </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-12 text-white/70 text-mobile-base sm:text-base">
-            No organizations yet. Create one to get started!
-          </div>
-        )}
+            ))
+          ) : (
+            <p className="text-center py-12 text-sm" style={{ color: T.body }}>No organizations yet. Create one to get started!</p>
+          )}
+        </Card>
       </div>
 
       <CreateOrganizationForm isOpen={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)} />
 
       {orgToDelete && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60" onClick={() => !isDeleting && setOrgToDelete(null)}>
-          <div className="rounded-2xl bg-[#101012] border border-white/10 p-4 sm:p-6 max-w-sm w-full shadow-xl" onClick={(e) => e.stopPropagation()}>
-            <p className="mb-4 text-mobile-base sm:text-base text-white/80">
-              Are you sure you want to delete &quot;{orgToDelete.name}&quot;? This action cannot be undone.
-            </p>
-            <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => !isDeleting && setOrgToDelete(null)}
-                className="rounded-lg px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-white/70 hover:bg-white/5"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setIsDeleting(true);
-                  deleteGroupMutation.mutate(orgToDelete.id, {
-                    onSuccess: () => {
-                      toast.success("Organization deleted");
-                      setOrgToDelete(null);
-                      setIsDeleting(false);
-                    },
-                    onError: (err: { message?: string }) => {
-                      toast.error(err?.message || "Failed to delete organization");
-                      setIsDeleting(false);
-                    },
-                  });
-                }}
-                disabled={isDeleting}
-                className="flex items-center gap-2 rounded-lg bg-red-500/10 px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
-              >
-                {isDeleting ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Deleting...
-                  </>
-                ) : (
-                  "Delete"
-                )}
-              </button>
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70" onClick={() => !isDeleting && setOrgToDelete(null)}>
+          <div className="rounded-2xl p-6 max-w-sm w-full shadow-xl" style={{ background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)", border: "1px solid rgba(255,255,255,0.08)", boxShadow: "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)" }} onClick={(e) => e.stopPropagation()}>
+            <p className="mb-4 text-sm" style={{ color: T.body }}>Are you sure you want to delete &quot;{orgToDelete.name}&quot;? This action cannot be undone.</p>
+            <div className="flex justify-end gap-3">
+              <Btn variant="ghost" onClick={() => !isDeleting && setOrgToDelete(null)}>Cancel</Btn>
+              <Btn variant="danger" onClick={() => { setIsDeleting(true); deleteGroupMutation.mutate(orgToDelete.id, { onSuccess: () => { toast.success("Organization deleted"); setOrgToDelete(null); setIsDeleting(false); }, onError: (err: { message?: string }) => { toast.error(err?.message || "Failed to delete organization"); setIsDeleting(false); } }); }} style={{ opacity: isDeleting ? 0.7 : 1 }}>
+                {isDeleting ? <><Loader2 className="h-4 w-4 animate-spin" /> Deleting...</> : "Delete"}
+              </Btn>
             </div>
           </div>
         </div>

--- a/app/organization/page.tsx
+++ b/app/organization/page.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { useQueries } from "@tanstack/react-query";
+import Image from "next/image";
 import { useAuthStore } from "@/stores/authStore";
+import { ProfileDropdown } from "@/components/profile-dropdown";
 import { useGetAllOrganizations } from "@/features/business/hooks/use-organizations";
 import { useGetInvoicesByOrganization } from "@/features/business/hooks/use-invoices";
 import { useGetContractsByOrganization } from "@/features/business/hooks/use-contracts";
-import { getStreamsByOrganization } from "@/features/business/api/client";
-import { QueryKeys } from "@/lib/constants";
-import { Loader2, Users2, UserPlus, Building2, FileText, TrendingUp, FileSignature } from "lucide-react";
+import { useGetStreamsByOrganization } from "@/features/business/hooks/use-streams";
+import { Loader2, UserPlus, Building2, FileText, TrendingUp, FileSignature } from "lucide-react";
 import { formatCurrency } from "@/utils/formatters";
 import { OrganizationConnectionError } from "@/components/organization-connection-error";
 import { ContractNotifications } from "@/components/contract-notifications";
@@ -41,37 +40,33 @@ export default function OrganizationDashboardPage() {
   const { data: organizations = [], isLoading: isOrgsLoading, isError: isOrgsError, error: orgsError } = useGetAllOrganizations();
 
   const orgIds = organizations.map((o) => o.id);
-  const firstOrgId = orgIds[0] ?? "";
-  const adminOrgIds = organizations.filter((o) => o.userId === user?.id).map((o) => o.id);
+  const selectedOrgId = orgIds[0] ?? "";
+  const selectedOrg = organizations.find((o) => o.id === selectedOrgId);
   const hasAdminOrg = organizations.some((o) => isOrgAdmin(o, user?.id ?? ""));
-  const firstOrgIdForAdmin = hasAdminOrg ? firstOrgId : "";
+  const isAdminOfSelectedOrg = selectedOrg ? isOrgAdmin(selectedOrg, user?.id ?? "") : false;
 
-  const { data: invoicesFirstOrg = [] } = useGetInvoicesByOrganization(firstOrgIdForAdmin);
-  const { data: contractsFirstOrg = [], isLoading: contractsLoading } = useGetContractsByOrganization(firstOrgIdForAdmin);
+  const { data: invoicesForOrg = [] } = useGetInvoicesByOrganization(isAdminOfSelectedOrg ? selectedOrgId : "");
+  const { data: contractsForOrg = [], isLoading: contractsLoading } = useGetContractsByOrganization(selectedOrgId);
 
-  const streamQueries = useQueries({
-    queries: adminOrgIds.map((orgId) => ({
-      queryKey: [QueryKeys.STREAMS, orgId],
-      queryFn: () => getStreamsByOrganization(orgId),
-      enabled: !!orgId,
-    })),
+  const { data: streamsForOrg = [], isLoading: streamsLoading } = useGetStreamsByOrganization(selectedOrgId, {
+    enabled: !!selectedOrgId && isAdminOfSelectedOrg,
   });
-  const allStreams = streamQueries.flatMap((q) => q.data ?? []);
-  const streamsLoading = streamQueries.some((q) => q.isLoading);
-  const totalStreamsCount = allStreams.length;
-  const expectedUsd = allStreams
+
+  const memberCountForOrg = selectedOrg ? (selectedOrg.groupUsers?.length ?? 0) : 0;
+  const totalStreamsCount = streamsForOrg.length;
+  const expectedUsd = streamsForOrg
     .filter((s) => s.currency === "USD" && s.expectedAmount != null)
     .reduce((sum, s) => sum + (s.expectedAmount ?? 0), 0);
-  const streamsWithAmount = allStreams.filter((s) => s.expectedAmount != null).length;
+  const streamsWithAmount = streamsForOrg.filter((s) => s.expectedAmount != null).length;
 
-  const totalOutstanding = invoicesFirstOrg
+  const totalOutstanding = invoicesForOrg
     .filter((i) => i.status === "SENT" || i.status === "OVERDUE" || i.status === "APPROVED")
     .reduce((sum, i) => sum + i.amount, 0);
-  const currencyFirst = invoicesFirstOrg[0]?.currency ?? "USD";
-  const pendingCount = invoicesFirstOrg.filter(
+  const currencyFirst = invoicesForOrg[0]?.currency ?? "USD";
+  const pendingCount = invoicesForOrg.filter(
     (i) => i.status === "DRAFT" || i.status === "SENT" || i.status === "OVERDUE" || i.status === "APPROVED"
   ).length;
-  const totalInvoicesFirstOrg = invoicesFirstOrg.length;
+  const totalInvoicesForOrg = invoicesForOrg.length;
 
   const membersMap = new Map<string, { id: string; name: string | null; image: string | null; email: string | null; orgNames: string[] }>();
   organizations.forEach((org) => {
@@ -111,30 +106,20 @@ export default function OrganizationDashboardPage() {
           </h2>
           <div className="flex items-center gap-2">
             <ContractNotifications />
-            <Link href="/organization/settings" className="cursor-pointer">
-              <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:opacity-80 transition-opacity">
-                <div className="h-full w-full rounded-full overflow-hidden bg-[#101012]">
-                  {user?.image ? (
-                    <Image src={user.image} alt="Profile" width={56} height={56} className="h-full w-full object-cover" />
-                  ) : (
-                    <Image
-                      src={`https://api.dicebear.com/9.x/identicon/svg?seed=${user?.id || user?.email || "user"}`}
-                      alt="Profile"
-                      width={56}
-                      height={56}
-                      className="h-full w-full"
-                    />
-                  )}
-                </div>
-              </div>
-            </Link>
+            {user && (
+              <ProfileDropdown
+                user={user}
+                profileHref="/settings"
+                avatarSizeClass="h-10 w-10 sm:h-14 sm:w-14"
+              />
+            )}
           </div>
         </div>
       </div>
 
-      {/* Stats: Team for everyone; Invoices, Streams, Contracts for admin only */}
+      {/* Stats: all 4 cards are for the selected (first) organization only */}
       <div
-        className={`grid grid-cols-1 gap-5 sm:gap-6 lg:gap-8 mb-6 sm:mb-8 ${hasAdminOrg ? (adminOrgIds.length > 0 ? "sm:grid-cols-2" : "sm:grid-cols-3") : ""}`}
+        className={`grid grid-cols-1 gap-5 sm:gap-6 lg:gap-8 mb-6 sm:mb-8 ${hasAdminOrg ? (selectedOrgId ? "sm:grid-cols-2" : "sm:grid-cols-3") : ""}`}
       >
         <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-5 sm:p-6 lg:p-7 border border-white/5 min-w-0">
           <div className="flex items-center gap-2 text-white/60 mb-4">
@@ -143,15 +128,9 @@ export default function OrganizationDashboardPage() {
           </div>
           <div className="flex justify-between gap-4">
             <div>
-              <p className="text-white/50 text-xs sm:text-sm">Organizations</p>
-              <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                {isOrgsLoading ? "—" : organizations.length}
-              </p>
-            </div>
-            <div>
               <p className="text-white/50 text-xs sm:text-sm">Members</p>
               <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                {isOrgsLoading ? "—" : members.length}
+                {isOrgsLoading || !selectedOrgId ? "—" : memberCountForOrg}
               </p>
             </div>
           </div>
@@ -166,16 +145,13 @@ export default function OrganizationDashboardPage() {
               <div>
                 <p className="text-white/50 text-xs sm:text-sm">Total</p>
                 <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {totalInvoicesFirstOrg}
+                  {totalInvoicesForOrg}
                 </p>
-                {organizations.length > 1 && (
-                  <p className="text-white/50 text-xs mt-0.5">First org</p>
-                )}
               </div>
               <div>
                 <p className="text-white/50 text-xs sm:text-sm">Outstanding</p>
                 <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {invoicesFirstOrg.length > 0 ? formatCurrency(totalOutstanding, currencyFirst) : "—"}
+                  {invoicesForOrg.length > 0 ? formatCurrency(totalOutstanding, currencyFirst) : "—"}
                 </p>
                 {pendingCount > 0 && (
                   <p className="text-white/50 text-xs mt-0.5">{pendingCount} pending</p>
@@ -184,7 +160,7 @@ export default function OrganizationDashboardPage() {
             </div>
           </div>
         )}
-        {adminOrgIds.length > 0 && (
+        {selectedOrgId && isAdminOfSelectedOrg && (
           <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-5 sm:p-6 lg:p-7 border border-white/5 min-w-0">
             <div className="flex items-center gap-2 text-white/60 mb-4">
               <TrendingUp className="h-5 w-5 sm:h-6 sm:w-6" />
@@ -217,14 +193,14 @@ export default function OrganizationDashboardPage() {
             </div>
             <div className="flex flex-col gap-2">
               <div>
-                <p className="text-white/50 text-xs sm:text-sm">Total (first org)</p>
+                <p className="text-white/50 text-xs sm:text-sm">Total</p>
                 <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {contractsLoading ? "—" : contractsFirstOrg.length}
+                  {contractsLoading ? "—" : contractsForOrg.length}
                 </p>
               </div>
-              {firstOrgId && (
+              {selectedOrgId && (
                 <Link
-                  href={`/organization/${firstOrgId}/contracts`}
+                  href={`/organization/${selectedOrgId}/contracts`}
                   className="text-white/70 hover:text-white text-sm font-medium mt-1 inline-flex items-center gap-1"
                 >
                   View contracts
@@ -236,97 +212,44 @@ export default function OrganizationDashboardPage() {
         )}
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_420px] gap-4 sm:gap-6">
-        <div className="space-y-4 sm:space-y-6">
-          <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6">
-            <div className="flex items-center justify-between mb-4 sm:mb-8">
-              <h2 className="text-xl sm:text-2xl font-semibold text-white">Your Members</h2>
-              <Link href="/organization/members" className={viewAllButtonClass}>
-                <UserPlus className="h-4 w-4 sm:h-5 sm:w-5" />
-                <span>View All</span>
-              </Link>
-            </div>
-            <div className="space-y-4 sm:space-y-8">
-              {isOrgsLoading ? (
-                <div className="flex items-center justify-center p-8">
-                  <Loader2 className="h-5 w-5 sm:h-6 sm:w-6 animate-spin text-white/50" />
-                </div>
-              ) : members.length > 0 ? (
-                members.slice(0, 5).map((member) => (
-                  <div key={member.id} className="flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-3 sm:gap-4">
-                      <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full">
-                        <Image
-                          src={member.image || `https://api.dicebear.com/9.x/identicon/svg?seed=${member.id}`}
-                          alt={member.name || "Member"}
-                          width={56}
-                          height={56}
-                          className="h-full w-full object-cover"
-                        />
-                      </div>
-                      <div>
-                        <p className="text-mobile-base sm:text-xl text-white font-medium">{member.name || member.email || "Member"}</p>
-                        <p className="text-mobile-sm sm:text-base text-white/60">{member.orgNames.join(", ")}</p>
-                      </div>
-                    </div>
-                  </div>
-                ))
-              ) : (
-                <div className="text-white/70 text-center py-6 sm:py-8 text-mobile-sm sm:text-base">
-                  No members yet. Create an organization and add members to get started.
-                </div>
-              )}
-            </div>
-          </div>
+      <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6">
+        <div className="flex items-center justify-between mb-4 sm:mb-8">
+          <h2 className="text-xl sm:text-2xl font-semibold text-white">Your Members</h2>
+          <Link href="/organization/members" className={viewAllButtonClass}>
+            <UserPlus className="h-4 w-4 sm:h-5 sm:w-5" />
+            <span>View All</span>
+          </Link>
         </div>
-
-        <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6 min-w-0">
-          <div className="flex items-center justify-between gap-3 mb-4 sm:mb-8">
-            <h2 className="text-xl sm:text-2xl font-semibold text-white truncate min-w-0">Your Organizations</h2>
-            <Link href="/organization/organizations" className={viewAllButtonClass}>
-              <Users2 className="h-4 w-4 sm:h-5 sm:w-5" />
-              <span>View All</span>
-            </Link>
-          </div>
-          <div className="space-y-4 sm:space-y-6">
-            {isOrgsLoading ? (
-              <div className="flex items-center justify-center p-6 sm:p-8">
-                <Loader2 className="h-5 w-5 sm:h-6 sm:w-6 animate-spin text-white/50" />
-              </div>
-            ) : organizations.length > 0 ? (
-              organizations.slice(0, 4).map((org) => (
-                <Link href={`/organization/${org.id}/invoices`} key={org.id}>
-                  <div className="flex items-center justify-between hover:bg-white/[0.02] p-2 sm:p-3 rounded-lg transition-colors">
-                    <div className="flex items-center gap-3 sm:gap-4">
-                      <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-xl bg-white/[0.03]">
-                        {org.image ? (
-                          <Image src={org.image} alt={org.name} width={56} height={56} className="h-full w-full object-cover" />
-                        ) : (
-                          <Image
-                            src={`https://api.dicebear.com/9.x/identicon/svg?seed=${org.id}`}
-                            alt={org.name}
-                            width={56}
-                            height={56}
-                            className="h-full w-full"
-                          />
-                        )}
-                      </div>
-                      <div>
-                        <p className="text-mobile-base sm:text-xl text-white font-medium">{org.name}</p>
-                        <p className="text-mobile-sm sm:text-base text-white/60">
-                          {(org.groupUsers || []).length} member{(org.groupUsers || []).length !== 1 ? "s" : ""}
-                        </p>
-                      </div>
-                    </div>
+        <div className="space-y-4 sm:space-y-8">
+          {isOrgsLoading ? (
+            <div className="flex items-center justify-center p-8">
+              <Loader2 className="h-5 w-5 sm:h-6 sm:w-6 animate-spin text-white/50" />
+            </div>
+          ) : members.length > 0 ? (
+            members.slice(0, 5).map((member) => (
+              <div key={member.id} className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-3 sm:gap-4">
+                  <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full">
+                    <Image
+                      src={member.image || `https://api.dicebear.com/9.x/identicon/svg?seed=${member.id}`}
+                      alt={member.name || "Member"}
+                      width={56}
+                      height={56}
+                      className="h-full w-full object-cover"
+                    />
                   </div>
-                </Link>
-              ))
-            ) : (
-              <div className="text-white/70 text-center py-6 sm:py-8 text-mobile-sm sm:text-base">
-                No organizations yet. Create one to get started!
+                  <div>
+                    <p className="text-mobile-base sm:text-xl text-white font-medium">{member.name || member.email || "Member"}</p>
+                    <p className="text-mobile-sm sm:text-base text-white/60">{member.orgNames.join(", ")}</p>
+                  </div>
+                </div>
               </div>
-            )}
-          </div>
+            ))
+          ) : (
+            <div className="text-white/70 text-center py-6 sm:py-8 text-mobile-sm sm:text-base">
+              No members yet. Create an organization and add members to get started.
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/app/organization/page.tsx
+++ b/app/organization/page.tsx
@@ -2,19 +2,20 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import { useState, useRef, useEffect } from "react";
 import { useAuthStore } from "@/stores/authStore";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { useGetAllOrganizations } from "@/features/business/hooks/use-organizations";
 import { useGetInvoicesByOrganization } from "@/features/business/hooks/use-invoices";
 import { useGetContractsByOrganization } from "@/features/business/hooks/use-contracts";
 import { useGetStreamsByOrganization } from "@/features/business/hooks/use-streams";
-import { Loader2, UserPlus, Building2, FileText, TrendingUp, FileSignature } from "lucide-react";
+import { Loader2, UserPlus, Building2, FileText, TrendingUp, FileSignature, ChevronsUpDown, Plus } from "lucide-react";
 import { formatCurrency } from "@/utils/formatters";
 import { OrganizationConnectionError } from "@/components/organization-connection-error";
 import { ContractNotifications } from "@/components/contract-notifications";
-
-const viewAllButtonClass =
-  "inline-flex items-center gap-1.5 sm:gap-2 rounded-full border border-white/80 px-3 sm:px-4 py-1.5 sm:py-2 hover:bg-white/[0.06] transition-colors text-white font-medium text-mobile-sm sm:text-base whitespace-nowrap flex-shrink-0";
+import { Card, SectionLabel, StatBox, T, A, Avatar } from "@/lib/splito-design";
+import { cn } from "@/lib/utils";
+import { motion, AnimatePresence } from "framer-motion";
 
 function getConnectionErrorMessage(error: unknown): string {
   const msg = typeof (error as { message?: string })?.message === "string"
@@ -35,9 +36,27 @@ function isOrgAdmin(
   return membership?.role === "ADMIN";
 }
 
+const dropdownVariants = {
+  hidden: { opacity: 0, y: 4, scale: 0.98 },
+  visible: { opacity: 1, y: 0, scale: 1 },
+  exit: { opacity: 0, y: 4, scale: 0.98 },
+};
+
 export default function OrganizationDashboardPage() {
   const { user } = useAuthStore();
+  const [mobileOrgSwitcherOpen, setMobileOrgSwitcherOpen] = useState(false);
+  const mobileOrgSwitcherRef = useRef<HTMLDivElement>(null);
   const { data: organizations = [], isLoading: isOrgsLoading, isError: isOrgsError, error: orgsError } = useGetAllOrganizations();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (mobileOrgSwitcherRef.current && !mobileOrgSwitcherRef.current.contains(e.target as Node)) {
+        setMobileOrgSwitcherOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   const orgIds = organizations.map((o) => o.id);
   const selectedOrgId = orgIds[0] ?? "";
@@ -91,166 +110,205 @@ export default function OrganizationDashboardPage() {
   }
 
   return (
-    <div className="w-full">
-      <div className="py-4 sm:py-6 mb-4 sm:mb-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-mobile-base sm:text-xl text-white max-w-[60%]">
+    <div className="w-full flex flex-col min-w-0">
+      <div
+        className="border-b border-white/[0.07] flex items-center justify-between gap-3 h-14 sm:h-[70px] px-4 sm:px-7 sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
+      >
+        {/* Mobile: org switcher; Desktop: "Organization dashboard" */}
+        <div className="my-10 min-w-0 flex-1 flex items-center min-[1025px]:flex-initial">
+          <div className="hidden sm:block">
+            <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
+              {isOrgsLoading ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-5 w-5 animate-spin" style={{ color: T.muted }} />
+                  Loading...
+                </span>
+              ) : (
+                "Organization dashboard"
+              )}
+            </h1>
+          </div>
+          <div className="relative sm:hidden flex-1 min-w-0 max-w-[calc(100%-100px)]" ref={mobileOrgSwitcherRef}>
             {isOrgsLoading ? (
-              <div className="flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="flex items-center gap-2 text-white">
+                <Loader2 className="h-5 w-5 animate-spin" style={{ color: T.muted }} />
                 Loading...
-              </div>
+              </span>
             ) : (
-              "Organization dashboard"
-            )}
-          </h2>
-          <div className="flex items-center gap-2">
-            <ContractNotifications />
-            {user && (
-              <ProfileDropdown
-                user={user}
-                profileHref="/settings"
-                avatarSizeClass="h-10 w-10 sm:h-14 sm:w-14"
-              />
+              <>
+                <button
+                  type="button"
+                  onClick={() => setMobileOrgSwitcherOpen((v) => !v)}
+                  className={cn(
+                    "flex w-full items-center gap-2 py-2 pr-2.5 pl-2.5 rounded-xl text-left transition-colors",
+                    "bg-white/[0.05] border border-white/[0.07]",
+                    "hover:bg-white/[0.07] hover:border-white/[0.1]",
+                    mobileOrgSwitcherOpen && "bg-white/[0.07] border-white/[0.1]"
+                  )}
+                  style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)" }}
+                >
+                  <Avatar
+                    init={selectedOrg ? selectedOrg.name.charAt(0).toUpperCase() : "?"}
+                    color={A}
+                    size={32}
+                    className="shrink-0"
+                  />
+                  <div className="min-w-0 flex-1 py-0.5">
+                    <p className="text-[13px] font-bold truncate text-white leading-tight">
+                      {selectedOrg?.name ?? "Select organization"}
+                    </p>
+                    <p className="text-[10px] truncate leading-tight mt-0.5" style={{ color: T.muted }}>Organization</p>
+                  </div>
+                  <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-60 ml-0.5" style={{ color: T.muted }} strokeWidth={1.5} />
+                </button>
+                <AnimatePresence>
+                  {mobileOrgSwitcherOpen && (
+                    <motion.div
+                      variants={dropdownVariants}
+                      initial="hidden"
+                      animate="visible"
+                      exit="exit"
+                      className="absolute left-0 top-full mt-1 rounded-xl bg-[#17171A] border border-white/10 shadow-xl py-2 z-[1001] max-h-[280px] overflow-y-auto min-w-[200px]"
+                    >
+                      <div className="px-4 py-2 mb-1">
+                        <p className="text-xs text-white/40 uppercase tracking-wider font-medium">Organizations</p>
+                      </div>
+                      {organizations.length === 0 ? (
+                        <div className="px-4 py-3 text-sm text-white/60">No organizations</div>
+                      ) : (
+                        organizations.map((org) => (
+                          <Link
+                            key={org.id}
+                            href={`/organization/${org.id}/invoices`}
+                            onClick={() => setMobileOrgSwitcherOpen(false)}
+                            className={cn(
+                              "flex items-center gap-3 px-4 py-2.5 text-sm transition-colors",
+                              org.id === selectedOrgId
+                                ? "bg-white/10 text-white"
+                                : "text-white/90 hover:bg-white/5 hover:text-white"
+                            )}
+                          >
+                            <div className="h-7 w-7 rounded-full bg-white/10 flex items-center justify-center text-[11px] font-bold shrink-0">
+                              {org.name.charAt(0).toUpperCase()}
+                            </div>
+                            <span className="truncate">{org.name}</span>
+                          </Link>
+                        ))
+                      )}
+                      <Link
+                        href="/organization/create"
+                        onClick={() => setMobileOrgSwitcherOpen(false)}
+                        className="flex items-center gap-3 px-4 py-2.5 text-sm text-white/60 hover:bg-white/5 hover:text-white transition-colors"
+                      >
+                        <Plus className="h-4 w-4" strokeWidth={1.5} />
+                        Create organization
+                      </Link>
+                      <div className="border-t border-white/10 mt-2 pt-2">
+                        <Link
+                          href="/organization/organizations"
+                          onClick={() => setMobileOrgSwitcherOpen(false)}
+                          className="flex items-center gap-3 px-4 py-2.5 text-sm text-white/80 hover:bg-white/5 hover:text-white transition-colors"
+                        >
+                          Manage all organizations
+                        </Link>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </>
             )}
           </div>
+        </div>
+        <div className="flex items-center gap-2 sm:gap-3 shrink-0 ml-1">
+          <ContractNotifications />
+          {user && (
+            <ProfileDropdown
+              user={user}
+              profileHref="/settings"
+              avatarSizeClass="h-10 w-10 sm:h-14 sm:w-14"
+            />
+          )}
         </div>
       </div>
 
-      {/* Stats: all 4 cards are for the selected (first) organization only */}
-      <div
-        className={`grid grid-cols-1 gap-5 sm:gap-6 lg:gap-8 mb-6 sm:mb-8 ${hasAdminOrg ? (selectedOrgId ? "sm:grid-cols-2" : "sm:grid-cols-3") : ""}`}
-      >
-        <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-5 sm:p-6 lg:p-7 border border-white/5 min-w-0">
-          <div className="flex items-center gap-2 text-white/60 mb-4">
-            <Building2 className="h-5 w-5 sm:h-6 sm:w-6" />
-            <span className="text-sm sm:text-base font-medium">Team</span>
+      <div className="flex-1 p-4 sm:p-7 overflow-y-auto">
+      {/* Stats */}
+      <div className="grid gap-4 sm:gap-5 mb-5 sm:mb-7" style={{ gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
+        <Card className="p-4 sm:p-[22px]">
+          <div className="flex items-center gap-2 mb-4">
+            <Building2 style={{ width: 18, height: 18, color: T.muted }} />
+            <span className="text-sm font-medium" style={{ color: T.muted }}>Team</span>
           </div>
-          <div className="flex justify-between gap-4">
-            <div>
-              <p className="text-white/50 text-xs sm:text-sm">Members</p>
-              <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                {isOrgsLoading || !selectedOrgId ? "—" : memberCountForOrg}
-              </p>
-            </div>
-          </div>
-        </div>
+          <StatBox label="Members" value={isOrgsLoading || !selectedOrgId ? "—" : String(memberCountForOrg)} color={T.bright} />
+        </Card>
         {hasAdminOrg && (
-          <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-5 sm:p-6 lg:p-7 border border-white/5 min-w-0">
-            <div className="flex items-center gap-2 text-white/60 mb-4">
-              <FileText className="h-5 w-5 sm:h-6 sm:w-6" />
-              <span className="text-sm sm:text-base font-medium">Invoices</span>
+          <Card className="p-4 sm:p-[22px]">
+            <div className="flex items-center gap-2 mb-4">
+              <FileText style={{ width: 18, height: 18, color: T.muted }} />
+              <span className="text-sm font-medium" style={{ color: T.muted }}>Invoices</span>
             </div>
-            <div className="flex justify-between gap-4">
-              <div>
-                <p className="text-white/50 text-xs sm:text-sm">Total</p>
-                <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {totalInvoicesForOrg}
-                </p>
-              </div>
-              <div>
-                <p className="text-white/50 text-xs sm:text-sm">Outstanding</p>
-                <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {invoicesForOrg.length > 0 ? formatCurrency(totalOutstanding, currencyFirst) : "—"}
-                </p>
-                {pendingCount > 0 && (
-                  <p className="text-white/50 text-xs mt-0.5">{pendingCount} pending</p>
-                )}
-              </div>
+            <div className="flex justify-between gap-4 flex-wrap">
+              <StatBox label="Total" value={String(totalInvoicesForOrg)} color={T.bright} />
+              <StatBox label="Outstanding" value={invoicesForOrg.length > 0 ? formatCurrency(totalOutstanding, currencyFirst) : "—"} color={T.bright} />
             </div>
-          </div>
+            {pendingCount > 0 && <p className="text-xs mt-2" style={{ color: T.muted }}>{pendingCount} pending</p>}
+          </Card>
         )}
         {selectedOrgId && isAdminOfSelectedOrg && (
-          <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-5 sm:p-6 lg:p-7 border border-white/5 min-w-0">
-            <div className="flex items-center gap-2 text-white/60 mb-4">
-              <TrendingUp className="h-5 w-5 sm:h-6 sm:w-6" />
-              <span className="text-sm sm:text-base font-medium">Income streams</span>
+          <Card className="p-4 sm:p-[22px]">
+            <div className="flex items-center gap-2 mb-4">
+              <TrendingUp style={{ width: 18, height: 18, color: T.muted }} />
+              <span className="text-sm font-medium" style={{ color: T.muted }}>Income streams</span>
             </div>
-            <div className="flex justify-between gap-4">
-              <div>
-                <p className="text-white/50 text-xs sm:text-sm">Streams</p>
-                <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {streamsLoading ? "—" : totalStreamsCount}
-                </p>
-                {!streamsLoading && streamsWithAmount > 0 && (
-                  <p className="text-white/50 text-xs mt-0.5">{streamsWithAmount} with amount</p>
-                )}
-              </div>
-              <div>
-                <p className="text-white/50 text-xs sm:text-sm">Amount (USD)</p>
-                <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {streamsLoading ? "—" : expectedUsd > 0 ? formatCurrency(expectedUsd, "USD") : "—"}
-                </p>
-              </div>
+            <div className="flex justify-between gap-4 flex-wrap">
+              <StatBox label="Streams" value={streamsLoading ? "—" : String(totalStreamsCount)} color={T.bright} />
+              <StatBox label="Amount (USD)" value={streamsLoading ? "—" : expectedUsd > 0 ? formatCurrency(expectedUsd, "USD") : "—"} color={T.bright} />
             </div>
-          </div>
+            {!streamsLoading && streamsWithAmount > 0 && <p className="text-xs mt-2" style={{ color: T.muted }}>{streamsWithAmount} with amount</p>}
+          </Card>
         )}
         {hasAdminOrg && (
-          <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-5 sm:p-6 lg:p-7 border border-white/5 min-w-0">
-            <div className="flex items-center gap-2 text-white/60 mb-4">
-              <FileSignature className="h-5 w-5 sm:h-6 sm:w-6" />
-              <span className="text-sm sm:text-base font-medium">Contracts</span>
+          <Card className="p-4 sm:p-[22px]">
+            <div className="flex items-center gap-2 mb-4">
+              <FileSignature style={{ width: 18, height: 18, color: T.muted }} />
+              <span className="text-sm font-medium" style={{ color: T.muted }}>Contracts</span>
             </div>
-            <div className="flex flex-col gap-2">
-              <div>
-                <p className="text-white/50 text-xs sm:text-sm">Total</p>
-                <p className="text-xl sm:text-2xl font-semibold text-white tabular-nums">
-                  {contractsLoading ? "—" : contractsForOrg.length}
-                </p>
-              </div>
-              {selectedOrgId && (
-                <Link
-                  href={`/organization/${selectedOrgId}/contracts`}
-                  className="text-white/70 hover:text-white text-sm font-medium mt-1 inline-flex items-center gap-1"
-                >
-                  View contracts
-                  <span className="text-white/50">→</span>
-                </Link>
-              )}
-            </div>
-          </div>
+            <StatBox label="Total" value={contractsLoading ? "—" : String(contractsForOrg.length)} color={T.bright} />
+            {selectedOrgId && <Link href={`/organization/${selectedOrgId}/contracts`} className="text-sm font-medium mt-2 inline-flex items-center gap-1" style={{ color: A }}>View contracts →</Link>}
+          </Card>
         )}
       </div>
 
-      <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6">
-        <div className="flex items-center justify-between mb-4 sm:mb-8">
-          <h2 className="text-xl sm:text-2xl font-semibold text-white">Your Members</h2>
-          <Link href="/organization/members" className={viewAllButtonClass}>
-            <UserPlus className="h-4 w-4 sm:h-5 sm:w-5" />
-            <span>View All</span>
-          </Link>
-        </div>
-        <div className="space-y-4 sm:space-y-8">
+        <Card className="p-4 sm:p-[22px]">
+          <div className="flex justify-between items-center mb-4">
+            <SectionLabel>Your Members</SectionLabel>
+            <Link href="/organization/members" className="flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium" style={{ borderColor: "rgba(255,255,255,0.2)", color: T.body }}>
+              <UserPlus className="h-4 w-4" />
+              <span>View All</span>
+            </Link>
+          </div>
+          <div className="space-y-4">
           {isOrgsLoading ? (
-            <div className="flex items-center justify-center p-8">
-              <Loader2 className="h-5 w-5 sm:h-6 sm:w-6 animate-spin text-white/50" />
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin" style={{ color: T.muted }} />
             </div>
           ) : members.length > 0 ? (
             members.slice(0, 5).map((member) => (
-              <div key={member.id} className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-3 sm:gap-4">
-                  <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full">
-                    <Image
-                      src={member.image || `https://api.dicebear.com/9.x/identicon/svg?seed=${member.id}`}
-                      alt={member.name || "Member"}
-                      width={56}
-                      height={56}
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                  <div>
-                    <p className="text-mobile-base sm:text-xl text-white font-medium">{member.name || member.email || "Member"}</p>
-                    <p className="text-mobile-sm sm:text-base text-white/60">{member.orgNames.join(", ")}</p>
-                  </div>
+              <div key={member.id} className="flex items-center gap-4 py-2.5 border-b border-white/[0.06] last:border-b-0">
+                <div className="h-10 w-10 sm:h-12 sm:w-12 overflow-hidden rounded-full flex-shrink-0 border border-white/[0.08]">
+                  <Image src={member.image || `https://api.dicebear.com/9.x/identicon/svg?seed=${member.id}`} alt={member.name || "Member"} width={48} height={48} className="h-full w-full object-cover" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-[15px] font-bold truncate" style={{ color: T.bright }}>{member.name || member.email || "Member"}</p>
+                  <p className="text-[13px] font-medium truncate" style={{ color: T.muted }}>{member.orgNames.join(", ")}</p>
                 </div>
               </div>
             ))
           ) : (
-            <div className="text-white/70 text-center py-6 sm:py-8 text-mobile-sm sm:text-base">
-              No members yet. Create an organization and add members to get started.
-            </div>
+            <p className="text-center py-6 text-sm" style={{ color: T.body }}>No members yet. Create an organization and add members to get started.</p>
           )}
         </div>
+        </Card>
       </div>
     </div>
   );

--- a/app/organization/roles/[organizationId]/page.tsx
+++ b/app/organization/roles/[organizationId]/page.tsx
@@ -94,7 +94,6 @@ export default function OrganizationRolesDetailPage() {
           </h1>
         </div>
         <button
-          onClick={() => router.push("/organization/settings")}
           className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:from-purple-500/30 hover:to-blue-500/30 transition-all cursor-pointer"
           aria-label="Settings"
         >

--- a/app/organization/roles/page.tsx
+++ b/app/organization/roles/page.tsx
@@ -46,7 +46,6 @@ export default function OrganizationRolesPage() {
           Manage roles
         </h1>
         <button
-          onClick={() => router.push("/organization/settings")}
           className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:from-purple-500/30 hover:to-blue-500/30 transition-all cursor-pointer"
           aria-label="Settings"
         >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,19 @@ import { useRouter } from "next/navigation";
 import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { toast } from "sonner";
 import { formatCurrency } from "@/utils/formatters";
+import { formatRelativeTime } from "@/lib/utils";
 import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
+import {
+  A,
+  Card,
+  SectionLabel,
+  Avatar,
+  GroupAvatar,
+  fmt,
+  G,
+  T,
+  Icons,
+} from "@/lib/splito-design";
 
 /** Derive overall youOwe/youGet from groups' groupBalances (same source as group pages) */
 function useOverallBalancesFromGroups(
@@ -160,6 +172,100 @@ function DashboardGroupBalance({
       owedItems={owedItems}
       defaultCurrency={defaultCurrency}
     />
+  );
+}
+
+/** Single-line balance for group row: "+$X" (green) or "-$X" (red) or "Settled" */
+function GroupBalanceShort({
+  group,
+  userId,
+  defaultCurrency,
+}: {
+  group: { groupBalances?: { userId: string; currency: string; amount: number }[] };
+  userId: string | null;
+  defaultCurrency: string;
+}) {
+  const oweItems =
+    !userId || !group.groupBalances?.length
+      ? []
+      : group.groupBalances
+          .filter((b) => b.userId === userId && b.amount > 0)
+          .map((b) => ({ amount: b.amount, currency: b.currency }));
+  const owedItems =
+    !userId || !group.groupBalances?.length
+      ? []
+      : group.groupBalances
+          .filter((b) => b.userId === userId && b.amount < 0)
+          .map((b) => ({ amount: Math.abs(b.amount), currency: b.currency }));
+  const { total: oweTotal, isLoading: loadOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
+  const { total: owedTotal, isLoading: loadOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
+  if (loadOwe || loadOwed) return <span className="text-white/60">…</span>;
+  const net = (owedTotal ?? 0) - (oweTotal ?? 0);
+  if (net === 0) return <span style={{ color: G, fontSize: 13, fontWeight: 800 }}>+$0</span>;
+  if (net > 0)
+    return (
+      <span
+        className="font-dm-mono font-extrabold text-[13px]"
+        style={{ color: G }}
+      >
+        +{formatCurrency(net, defaultCurrency)}
+      </span>
+    );
+  return (
+    <span
+      className="font-dm-mono font-extrabold text-[13px]"
+      style={{ color: "#F87171" }}
+    >
+      -{formatCurrency(Math.abs(net), defaultCurrency)}
+    </span>
+  );
+}
+
+/** Single friend card for Friends Balance: avatar, name, "Owes you $X" (green) or "You owe $X" (red) */
+function FriendBalanceCard({
+  friendName,
+  friendInit,
+  color,
+  oweItems,
+  owedItems,
+  defaultCurrency,
+}: {
+  friendName: string;
+  friendInit: string;
+  color: string;
+  oweItems: { amount: number; currency: string }[];
+  owedItems: { amount: number; currency: string }[];
+  defaultCurrency: string;
+}) {
+  const { total: totalOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
+  const { total: totalOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
+  const net = (totalOwed ?? 0) - (totalOwe ?? 0);
+  const balanceLine =
+    net === 0
+      ? { text: "Settled", color: T.muted }
+      : net > 0
+        ? { text: `Owes you ${formatCurrency(net, defaultCurrency)}`, color: G }
+        : { text: `You owe ${formatCurrency(Math.abs(net), defaultCurrency)}`, color: "#F87171" };
+  return (
+    <Card
+      style={{ padding: "18px 20px", display: "flex", alignItems: "center", gap: 14 }}
+    >
+      <Avatar init={friendInit} color={color} size={42} />
+      <div className="flex-1 min-w-0">
+        <p
+          className="text-[14px] font-bold truncate"
+          style={{ color: T.bright }}
+        >
+          {friendName}
+        </p>
+        <p
+          className="text-[12px] font-bold mt-1"
+          style={{ color: balanceLine.color }}
+        >
+          {balanceLine.text}
+        </p>
+      </div>
+    </Card>
   );
 }
 
@@ -312,466 +418,347 @@ export default function Page() {
     setIsFriendsBreakdownModalOpen(true);
   };
 
+  const netOwed = (overallGetLoading || overallOweLoading) ? 0 : overallGetTotal - overallOweTotal;
+
+  /** Recent activity from all groups (expenses + settlements) for Dashboard card */
+  const recentActivityFromGroups = useMemo(() => {
+    if (!user || !groups?.length) return [];
+    const items: { id: string; text: string; date: Date; dotColor: string }[] = [];
+    for (const group of groups) {
+      const expenses = (group as { expenses?: { id: string; name: string; amount: number; currency: string; paidBy: string; createdAt: Date; splitType: string }[] }).expenses ?? [];
+      const groupUsers = (group as { groupUsers?: { user: { id: string; name?: string | null } }[] }).groupUsers ?? [];
+      const paidByName = (userId: string) =>
+        userId === user.id ? "You" : (groupUsers.find((gu) => gu.user.id === userId)?.user?.name ?? "Someone");
+      for (const exp of expenses) {
+        const date = exp.createdAt instanceof Date ? exp.createdAt : new Date(exp.createdAt);
+        const amountStr = formatCurrency(exp.amount, exp.currency || defaultCurrency);
+        if (exp.splitType === "SETTLEMENT") {
+          items.push({
+            id: exp.id,
+            text: `${paidByName(exp.paidBy)} marked a payment as settled (${amountStr})`,
+            date,
+            dotColor: G,
+          });
+        } else {
+          items.push({
+            id: exp.id,
+            text: `${paidByName(exp.paidBy)} added ${exp.name} (${amountStr})`,
+            date,
+            dotColor: A,
+          });
+        }
+      }
+    }
+    items.sort((a, b) => b.date.getTime() - a.date.getTime());
+    return items.slice(0, 5);
+  }, [groups, user?.id, defaultCurrency]);
+
+  const groupAvatarItems = (g: { groupUsers?: { user: { name: string | null; id: string } }[] }) =>
+    (g.groupUsers ?? [])
+      .slice(0, 4)
+      .map((gu) => ({
+        init: gu.user.name?.charAt(0)?.toUpperCase() || "?",
+        color: "#22D3EE",
+      }));
+
   return (
-    <div className="w-full">
-      {/* Header integrated into the dashboard */}
-      <div className="py-4 sm:py-6 mb-4 sm:mb-6">
-        <div className="flex items-center justify-between">
-          <h2
-            id="dashboard-overall-balance"
-            className="text-mobile-base sm:text-xl text-white max-w-[60%]"
-          >
-            {isGroupsLoading ? (
-              <div className="flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Loading balance...
-              </div>
-            ) : youOwe.length > 0 ? (
-              <div>
-                Overall, you owe{" "}
-                <span className="font-inter font-semibold text-[24px] leading-[100%] tracking-[-0.04em] text-[#FF4444]">
-                  {overallOweLoading
-                    ? "…"
-                    : formatCurrency(overallOweTotal, defaultCurrency)}
-                </span>
-                {youOwe.length > 1 && !overallOweLoading && (
-                  <span className="block text-mobile-sm text-white/60 mt-0.5">
-                    (
-                    {youOwe
-                      .map((d) => formatCurrency(d.amount, d.currency))
-                      .join(", ")}
-                    )
-                  </span>
-                )}
-              </div>
-            ) : youGet.length > 0 ? (
-              <div>
-                Overall, you are owed{" "}
-                <span className="font-inter font-semibold text-[24px] leading-[100%] tracking-[-0.04em] text-[#53e45d]">
-                  {overallGetLoading
-                    ? "…"
-                    : formatCurrency(overallGetTotal, defaultCurrency)}
-                </span>
-                {youGet.length > 1 && !overallGetLoading && (
-                  <span className="block text-mobile-sm text-white/60 mt-0.5">
-                    (
-                    {youGet
-                      .map((d) => formatCurrency(d.amount, d.currency))
-                      .join(", ")}
-                    )
-                  </span>
-                )}
-              </div>
-            ) : (
-              <div>You're all settled up!</div>
-            )}
-          </h2>
-          <div className="flex items-center gap-3 sm:gap-4">
-            {/* Settle all debt button - commented out */}
-            {/* <button
-              onClick={handleSettleAllClick}
-              disabled={isSettling || isGroupsLoading}
-              className="group relative flex h-10 sm:h-12 items-center justify-center gap-1 sm:gap-2 rounded-full border border-white/10 bg-white px-4 sm:px-6 text-mobile-sm sm:text-base font-medium text-black transition-all duration-300 hover:shadow-[0_0_15px_rgba(255,255,255,0.2)] disabled:opacity-70 disabled:cursor-not-allowed"
-            >
-              {isSettling ? (
-                <>
-                  <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 animate-spin" />
-                  <span className="truncate">Settling...</span>
-                </>
-              ) : (
-                <>
-                  <Image
-                    src="/coins-dollar.svg"
-                    alt="Settle"
-                    width={22}
-                    height={22}
-                    className="invert h-4 w-4 sm:h-5 sm:w-5"
-                  />
-                  <span className="truncate">Settle all debts</span>
-                </>
-              )}
-            </button> */}
-            {user && (
-              <ProfileDropdown
-                user={user}
-                profileHref="/settings"
-                avatarSizeClass="h-10 w-10 sm:h-14 sm:w-14"
-              />
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Monthly Stats - Three blocks side by side */}
+    <div className="flex-1 flex flex-col min-w-0">
+      {/* Sticky header – design, responsive padding */}
       <div
-        id="dashboard-monthly-stats"
-        className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-6 mb-4 sm:mb-6"
+        className="border-b border-white/[0.07] px-4 sm:px-7 flex items-center h-14 sm:h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
       >
-        <div className="rounded-3xl bg-[#101012] p-8">
-          <div className="flex items-center mb-4">
-            <span className="text-white/60 text-xl">You owed this month</span>
-          </div>
-          <p className="font-inter font-semibold text-[24px] leading-[100%] tracking-[-0.04em] text-white">
-            {isAnalyticsLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin text-white/50" />
-            ) : analyticsError ? (
-              <button
-                onClick={() =>
-                  queryClient.invalidateQueries({
-                    queryKey: [QueryKeys.ANALYTICS],
-                  })
-                }
-                className="text-red-500 text-base font-normal hover:underline flex items-center gap-2"
-              >
-                <span>Error loading data</span>
-                <span className="text-sm">(click to retry)</span>
-              </button>
-            ) : owedConvLoading ? (
-              "…"
-            ) : (
-              formatCurrency(owedConverted, defaultCurrency)
-            )}
-          </p>
-        </div>
-
-        <div className="rounded-3xl bg-[#101012] p-8">
-          <div className="flex items-center mb-4">
-            <span className="text-white/60 text-xl">You lent this month</span>
-          </div>
-          <p className="font-inter font-semibold text-[24px] leading-[100%] tracking-[-0.04em] text-white">
-            {isAnalyticsLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin text-white/50" />
-            ) : analyticsError ? (
-              <button
-                onClick={() =>
-                  queryClient.invalidateQueries({
-                    queryKey: [QueryKeys.ANALYTICS],
-                  })
-                }
-                className="text-red-500 text-base font-normal hover:underline flex items-center gap-2"
-              >
-                <span>Error loading data</span>
-                <span className="text-sm">(click to retry)</span>
-              </button>
-            ) : lentConvLoading ? (
-              "…"
-            ) : (
-              formatCurrency(lentConverted, defaultCurrency)
-            )}
-          </p>
-        </div>
-
-        <div className="rounded-3xl bg-[#101012] p-8">
-          <div className="flex items-center mb-4">
-            <span className="text-white/60 text-xl">
-              You settled this month
-            </span>
-          </div>
-          <p className="font-inter font-semibold text-[24px] leading-[100%] tracking-[-0.04em] text-white">
-            {isAnalyticsLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin text-white/50" />
-            ) : analyticsError ? (
-              <button
-                onClick={() =>
-                  queryClient.invalidateQueries({
-                    queryKey: [QueryKeys.ANALYTICS],
-                  })
-                }
-                className="text-red-500 text-base font-normal hover:underline flex items-center gap-2"
-              >
-                <span>Error loading data</span>
-                <span className="text-sm">(click to retry)</span>
-              </button>
-            ) : settledConvLoading ? (
-              "…"
-            ) : (
-              formatCurrency(settledConverted, defaultCurrency)
-            )}
-          </p>
-        </div>
+        <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
+          Dashboard
+        </h1>
       </div>
 
-      {/* Transaction Requests and Groups/Friends section */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_350px] gap-4 sm:gap-6">
-        {/* Friends and Groups section */}
-        <div className="space-y-4 sm:space-y-6">
-          {/* Friends block (wider) */}
+      <div className="flex-1 p-4 sm:p-7 overflow-y-auto">
+        {/* Balance hero – design, responsive */}
+        <div
+          id="dashboard-overall-balance"
+          className="rounded-2xl sm:rounded-3xl border border-white/[0.09] p-4 sm:p-7 mb-5 sm:mb-7 relative overflow-hidden"
+          style={{
+            background: "linear-gradient(135deg, #111 0%, #0e0e0e 50%, #0f0f0f 100%)",
+            boxShadow: "0 8px 40px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.06)",
+          }}
+        >
           <div
-            id="dashboard-friends-section"
-            className="lg:col-span-2 rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6"
+            className="absolute -top-10 -right-10 w-[200px] h-[200px] rounded-full pointer-events-none"
+            style={{
+              background: netOwed >= 0 ? `${G}08` : "#F871710a",
+            }}
+          />
+          <p
+            className="text-[11px] sm:text-[12px] font-bold tracking-[0.08em] uppercase mb-2.5"
+            style={{ color: T.muted }}
           >
-            <div className="flex items-center justify-between mb-4 sm:mb-8">
-              <h2 className="text-xl sm:text-2xl font-semibold text-white">
-                Your Friends
-              </h2>
-              <div className="flex items-center gap-3">
-                <button
-                  onClick={() => router.push("/groups")}
-                  className="flex items-center gap-1 sm:gap-2 text-white/60 hover:text-white transition-colors"
-                >
-                  <Image
-                    src="/coins-dollar.svg"
-                    alt="Manage Debts"
-                    width={20}
-                    height={20}
-                    className="opacity-90 h-4 w-4 sm:h-5 sm:w-5"
-                  />
-                  <span className="font-medium text-mobile-sm sm:text-base">
-                    Manage Debts
-                  </span>
-                </button>
-                <button
-                  onClick={() => setIsAddFriendModalOpen(true)}
-                  className="flex items-center gap-1 sm:gap-2 text-white/60 hover:text-white transition-colors"
-                >
-                  <Image
-                    src="/plus-sign-circle.svg"
-                    alt="Add"
-                    width={20}
-                    height={20}
-                    className="opacity-90 h-4 w-4 sm:h-5 sm:w-5"
-                  />
-                  <span className="font-medium text-mobile-sm sm:text-base">
-                    Add Friends
-                  </span>
-                </button>
-              </div>
-            </div>
-
-            <div className="space-y-4 sm:space-y-8">
-              {isFriendsLoading ? (
-                <div className="flex items-center justify-center p-8">
-                  <Loader2 className="h-5 w-5 sm:h-6 sm:w-6 animate-spin text-white/50" />
-                  <span className="ml-2 text-white/70 text-mobile-sm sm:text-base">
-                    Loading friends...
-                  </span>
-                </div>
-              ) : friends && friends.length > 0 ? (
-                friends.map((friend) => {
-                  // Use balances from groups (same source as group expense page)
-                  const balances = friendBalancesFromGroups[friend.id] ?? [];
-                  const oweBalances: Record<string, number> = {};
-                  const owedBalances: Record<string, number> = {};
-
-                  balances.forEach((b) => {
-                    if (b.amount > 0) {
-                      oweBalances[b.currency] =
-                        (oweBalances[b.currency] ?? 0) + b.amount;
-                    } else if (b.amount < 0) {
-                      owedBalances[b.currency] =
-                        (owedBalances[b.currency] ?? 0) + Math.abs(b.amount);
-                    }
-                  });
-
-                  const oweItems = Object.entries(oweBalances).map(
-                    ([currency, amount]) => ({ amount, currency })
-                  );
-                  const owedItems = Object.entries(owedBalances).map(
-                    ([currency, amount]) => ({ amount, currency })
-                  );
-                  const hasOwedBalances = owedItems.length > 0;
-                  const hasOweBalances = oweItems.length > 0;
-
-                  return (
-                    <div
-                      key={friend.id}
-                      className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-0"
-                    >
-                      <div className="flex items-center gap-3 sm:gap-4">
-                        <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full">
-                          <Image
-                            src={
-                              friend.image ||
-                              `https://api.dicebear.com/9.x/identicon/svg?seed=${friend.id}`
-                            }
-                            alt={friend.name}
-                            width={56}
-                            height={56}
-                            className="h-full w-full object-cover"
-                            onError={(e) => {
-                              console.error(
-                                `Error loading image for friend ${friend.id}`
-                              );
-                              const target = e.target as HTMLImageElement;
-                              target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${friend.id}`;
-                            }}
-                          />
-                        </div>
-                        <div>
-                          <p className="text-mobile-base sm:text-xl text-white font-medium">
-                            {friend.name}
-                          </p>
-                          <div className="text-mobile-sm sm:text-base text-white/60">
-                            <DashboardConvertedBalance
-                              oweItems={oweItems}
-                              owedItems={owedItems}
-                              defaultCurrency={defaultCurrency}
-                            />
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Show appropriate button based on debt direction */}
-                      {hasOwedBalances && (
-                        <button
-                          className="w-full sm:w-56 group relative flex h-10 sm:h-12 items-center justify-center gap-1 sm:gap-2 rounded-full border-2 border-white/80 bg-transparent px-4 sm:px-5 text-mobile-sm sm:text-base font-medium text-white transition-all duration-300 hover:border-white/40 hover:shadow-[0_0_15px_rgba(255,255,255,0.1)]"
-                          onClick={() =>
-                            sendReminder({
-                              receiverId: friend.id,
-                              reminderType: "USER",
-                              content: "Please settle your balance.",
-                            })
-                          }
-                          disabled={isSending}
-                        >
-                          <Image
-                            src="/clock-03.svg"
-                            alt="Reminder"
-                            width={20}
-                            height={20}
-                            className="opacity-90 h-4 w-4 sm:h-5 sm:w-5"
-                          />
-                          <span>{isSending ? "Sending..." : "Notify"}</span>
-                        </button>
-                      )}
-
-                      {/* Individual settle debt button - commented out, replaced with single Manage Debts button */}
-                      {/* {hasPositiveBalance && (
-                      <button
-                        className="w-full sm:w-56 group relative flex h-10 sm:h-12 items-center justify-center gap-1 sm:gap-2 rounded-full border-2 border-white/80 bg-transparent px-4 sm:px-5 text-mobile-sm sm:text-base font-medium text-white transition-all duration-300 hover:border-white/40 hover:shadow-[0_0_15px_rgba(255,255,255,0.1)]"
-                        onClick={() => handleSettleFriendClick(friend.id)}
-                      >
-                        <Image
-                          src="/coins-dollar.svg"
-                          alt="Settle"
-                          width={20}
-                          height={20}
-                          className="opacity-90 h-4 w-4 sm:h-5 sm:w-5"
-                        />
-                        <span>Settle Debts</span>
-                      </button>
-                    )} */}
-                    </div>
-                  );
-                })
-              ) : (
-                <div className="text-white/70 text-center py-6 sm:py-8 text-mobile-sm sm:text-base">
-                  No friends added yet. Add some friends to get started!
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Groups block */}
+            Overall balance
+          </p>
+          <p className="text-[22px] sm:text-[26px] font-extrabold tracking-[-0.02em] text-white mb-1">
+            {isGroupsLoading ? (
+              <span className="flex items-center gap-2">
+                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+                Loading…
+              </span>
+            ) : youOwe.length > 0 ? (
+              <>
+                Overall, you owe{" "}
+                <span style={{ color: "#F87171" }}>
+                  {overallOweLoading ? "…" : formatCurrency(overallOweTotal, defaultCurrency)}
+                </span>
+              </>
+            ) : youGet.length > 0 ? (
+              <>
+                Overall, you are owed{" "}
+                <span style={{ color: G }}>
+                  +{overallGetLoading ? "…" : formatCurrency(overallGetTotal, defaultCurrency)}
+                </span>
+              </>
+            ) : (
+              <span style={{ color: G }}>All settled ✓</span>
+            )}
+          </p>
           <div
-            id="dashboard-groups-section"
-            className="rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6"
-          >
-            <div className="flex items-center justify-between mb-4 sm:mb-8">
-              <h2 className="text-xl sm:text-2xl font-semibold text-white">
-                Your Groups
-              </h2>
-              <Link
-                href="/groups"
-                className="text-white font-medium flex items-center gap-1 sm:gap-2 rounded-full border border-white/80 px-3 sm:px-4 py-1.5 sm:py-2 hover:bg-white/[0.03] transition-colors text-mobile-sm sm:text-base"
+            className="h-px my-5"
+            style={{ background: "rgba(255,255,255,0.07)" }}
+          />
+          <div className="grid grid-cols-3 gap-0">
+            {[
+              [
+                "You owed this month",
+                isAnalyticsLoading || owedConvLoading
+                  ? "…"
+                  : formatCurrency(owedConverted, defaultCurrency),
+              ],
+              [
+                "You lent this month",
+                isAnalyticsLoading || lentConvLoading
+                  ? "…"
+                  : formatCurrency(lentConverted, defaultCurrency),
+              ],
+              [
+                "You settled this month",
+                isAnalyticsLoading || settledConvLoading
+                  ? "…"
+                  : formatCurrency(settledConverted, defaultCurrency),
+              ],
+            ].map(([label, value], i) => (
+              <div
+                key={String(label)}
+                className={`min-w-0 ${i === 0 ? "pr-2 sm:pr-7" : i === 1 ? "px-2 sm:px-7 border-r border-white/[0.07]" : "pl-2 sm:pl-7"} text-center sm:text-left`}
               >
-                <Users2 className="h-4 w-4 sm:h-5 sm:w-5" />
-                <span>View All</span>
-              </Link>
-            </div>
+                <p
+                  className="text-[10px] sm:text-[11px] mb-1 sm:mb-2.5 font-semibold tracking-[0.04em] truncate"
+                  style={{ color: T.muted }}
+                >
+                  {label}
+                </p>
+                <p
+                  className="text-[14px] sm:text-[22px] font-extrabold tracking-[-0.02em] font-dm-mono truncate"
+                  style={{ color: "#e8e8e8" }}
+                >
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
 
-            <div className="space-y-4 sm:space-y-6">
-              {isGroupsLoading ? (
-                <div className="flex items-center justify-center p-6 sm:p-8">
-                  <Loader2 className="h-5 w-5 sm:h-6 sm:w-6 animate-spin text-white/50" />
-                  <span className="ml-2 text-white/70 text-mobile-sm sm:text-base">
-                    Loading groups...
-                  </span>
-                </div>
-              ) : groups && groups.length > 0 ? (
-                groups.slice(0, 4).map((group) => (
-                  <Link href={`/groups/${group.id}`} key={group.id}>
-                    <div className="flex items-center justify-between hover:bg-white/[0.02] p-2 sm:p-3 rounded-lg transition-colors">
-                      <div className="flex items-center gap-3 sm:gap-4">
-                        <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-xl bg-white/[0.03]">
-                          {group.image ? (
-                            <Image
-                              src={group.image}
-                              alt={group.name}
-                              width={56}
-                              height={56}
-                              className="h-full w-full object-cover"
-                            />
-                          ) : (
-                            <Image
-                              src={`https://api.dicebear.com/9.x/identicon/svg?seed=${group.id}`}
-                              alt={group.name}
-                              width={56}
-                              height={56}
-                              className="h-full w-full"
-                            />
-                          )}
-                        </div>
-                        <div>
-                          <p className="text-mobile-base sm:text-xl text-white font-medium">
-                            {group.name}
-                          </p>
-                          <p className="text-mobile-sm sm:text-base text-white/60">
-                            <DashboardGroupBalance
-                              group={group}
-                              userId={user?.id ?? null}
-                              defaultCurrency={defaultCurrency}
-                            />
-                          </p>
-                        </div>
+        {/* Your Groups + Recent Activity – design grid, responsive */}
+        <div
+          className="grid gap-4 sm:gap-5 mb-5 sm:mb-7"
+          style={{
+            gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          }}
+        >
+          <Card className="p-4 sm:p-[22px]">
+            <div className="flex justify-between items-center mb-4">
+              <SectionLabel>Your Groups</SectionLabel>
+              <span
+                className="text-[11px] font-bold rounded-full px-2.5 py-1 border border-white/[0.09]"
+                style={{ color: T.muted, background: "rgba(255,255,255,0.06)" }}
+              >
+                {groups?.length ?? 0} groups
+              </span>
+            </div>
+            {isGroupsLoading ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+              </div>
+            ) : (
+              (groups ?? []).slice(0, 3).map((g, i) => {
+                const userBalances = (g.groupBalances ?? []).filter(
+                  (b: { userId: string }) => b.userId === user?.id
+                );
+                const byCurr = userBalances.reduce(
+                  (acc: Record<string, number>, b: { currency: string; amount: number }) => {
+                    acc[b.currency] = (acc[b.currency] ?? 0) + b.amount;
+                    return acc;
+                  },
+                  {}
+                );
+                const oweItems = Object.entries(byCurr)
+                  .filter(([, a]) => a > 0)
+                  .map(([currency, amount]) => ({ amount, currency }));
+                const owedItems = Object.entries(byCurr)
+                  .filter(([, a]) => a < 0)
+                  .map(([currency, amount]) => ({ amount: Math.abs(amount), currency }));
+                return (
+                  <Link href={`/groups/${g.id}`} key={g.id}>
+                    <div
+                      className="splito-row-hover flex items-center gap-3 py-2.5 border-b border-white/[0.06] cursor-pointer last:border-b-0"
+                      style={i < 2 ? { borderBottom: "1px solid rgba(255,255,255,0.06)" } : {}}
+                    >
+                      <GroupAvatar
+                        items={groupAvatarItems(g)}
+                        size={38}
+                        radius={11}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[15px] font-bold text-[#f5f5f5] truncate">
+                          {g.name}
+                        </p>
+                        <p className="text-[13px] font-semibold" style={{ color: T.muted }}>
+                          {(Array.isArray((g as { expenses?: unknown[] }).expenses)
+                            ? (g as { expenses: unknown[] }).expenses.length
+                            : 0)}{" "}
+                          expenses
+                        </p>
                       </div>
+                      <GroupBalanceShort
+                        group={g}
+                        userId={user?.id ?? null}
+                        defaultCurrency={defaultCurrency}
+                      />
                     </div>
                   </Link>
-                ))
-              ) : (
-                <div className="text-white/70 text-center py-6 sm:py-8 text-mobile-sm sm:text-base">
-                  No groups created yet. Create a group to get started!
-                </div>
-              )}
-            </div>
-          </div>
+                );
+              })
+            )}
+            {groups?.length === 0 && !isGroupsLoading && (
+              <p className="text-sm text-white/60 py-2">No groups yet</p>
+            )}
+          </Card>
+
+          <Card className="p-[22px] min-h-[200px] flex flex-col">
+            <SectionLabel>Recent Activity</SectionLabel>
+            {isGroupsLoading || isRemindersLoading ? (
+              <div className="flex justify-center py-8 flex-1 items-center">
+                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+              </div>
+            ) : recentActivityFromGroups.length > 0 ? (
+              <div className="flex flex-col">
+                {recentActivityFromGroups.map((a) => (
+                  <div
+                    key={a.id}
+                    className="flex gap-3 py-2.5 border-b border-white/[0.06] last:border-b-0"
+                  >
+                    <div
+                      className="w-2 h-2 rounded-full flex-shrink-0 mt-1.5"
+                      style={{ background: a.dotColor }}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[13px] font-medium leading-snug" style={{ color: T.body }}>
+                        {a.text}
+                      </p>
+                      <p className="text-[11px] mt-0.5 font-semibold" style={{ color: T.sub }}>
+                        {formatRelativeTime(a.date)}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (reminders ?? []).length > 0 ? (
+              <div className="flex flex-col">
+                {(reminders ?? []).slice(0, 5).map((r) => (
+                  <div
+                    key={r.id}
+                    className="flex gap-3 py-2.5 border-b border-white/[0.06] last:border-b-0"
+                  >
+                    <div
+                      className="w-2 h-2 rounded-full flex-shrink-0 mt-1.5"
+                      style={{ background: A }}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[13px] font-medium leading-snug" style={{ color: T.body }}>
+                        {r.content || "Transaction request"}
+                      </p>
+                      <p className="text-[11px] mt-0.5 font-semibold" style={{ color: T.sub }}>
+                        {r.createdAt ? formatRelativeTime(new Date(r.createdAt)) : ""}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex-1 flex flex-col items-center justify-center py-8 text-center">
+                <p className="text-[40px] mb-2" aria-hidden>📋</p>
+                <p className="text-[13px] font-medium" style={{ color: T.body }}>
+                  No recent activity
+                </p>
+                <p className="text-[12px] mt-1" style={{ color: T.muted }}>
+                  Expenses and settlements from your groups will appear here
+                </p>
+              </div>
+            )}
+          </Card>
         </div>
 
-        {/* Transaction Requests */}
-        <div className="rounded-2xl sm:rounded-3xl bg-[#101012] p-4 sm:p-6">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl text-white font-medium">
-              Transaction Requests
-            </h2>
-            <button
-              onClick={() =>
-                queryClient.invalidateQueries({
-                  queryKey: [QueryKeys.REMINDERS],
+        {/* Friends Balance – design */}
+        <div>
+          <SectionLabel>Friends Balance</SectionLabel>
+          <div
+            className="grid gap-3"
+            style={{
+              gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+            }}
+          >
+            {isFriendsLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin text-white/50" />
+              </div>
+            ) : (
+              (friends ?? [])
+                .filter((friend) => {
+                  const balances = friendBalancesFromGroups[friend.id] ?? [];
+                  const hasBalance = balances.some((b: { amount: number }) => b.amount !== 0);
+                  return hasBalance;
                 })
-              }
-              className="p-2 rounded-full hover:bg-white/5 transition-colors"
-            >
-              <Bell className="h-5 w-5 text-white/70" />
-            </button>
+                .map((friend, index) => {
+                  const balances = friendBalancesFromGroups[friend.id] ?? [];
+                  const oweItems = balances
+                    .filter((b: { amount: number }) => b.amount > 0)
+                    .map((b: { amount: number; currency: string }) => ({
+                      amount: b.amount,
+                      currency: b.currency,
+                    }));
+                  const owedItems = balances
+                    .filter((b: { amount: number }) => b.amount < 0)
+                    .map((b: { amount: number; currency: string }) => ({
+                      amount: Math.abs(b.amount),
+                      currency: b.currency,
+                    }));
+                  const friendInit =
+                    friend.name?.split(" ").map((n) => n[0]).join("").slice(0, 2).toUpperCase() || "?";
+                  const FRIEND_COLORS = [A, "#A78BFA", G, "#FB923C", "#F472B6", "#FBBF24", "#818CF8"];
+                  const color = FRIEND_COLORS[index % FRIEND_COLORS.length];
+                  return (
+                    <FriendBalanceCard
+                      key={friend.id}
+                      friendName={friend.name ?? "Friend"}
+                      friendInit={friendInit}
+                      color={color}
+                      oweItems={oweItems}
+                      owedItems={owedItems}
+                      defaultCurrency={defaultCurrency}
+                    />
+                  );
+                })
+            )}
+            {(!friends || friends.length === 0) && !isFriendsLoading && (
+              <p className="text-sm text-white/60 col-span-full py-4">No friends with balances</p>
+            )}
           </div>
-
-          {isRemindersLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-8 w-8 animate-spin text-white/50" />
-            </div>
-          ) : (
-            <TransactionRequestList
-              reminders={reminders || []}
-              onAccept={(reminderId) => {
-                acceptReminder(reminderId);
-              }}
-              onReject={(reminderId) => {
-                rejectReminder(reminderId);
-              }}
-              isAccepting={isAccepting}
-              isRejecting={isRejecting}
-            />
-          )}
         </div>
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "@/lib/constants";
 import { useAuthStore } from "@/stores/authStore";
 import Link from "next/link";
+import { ProfileDropdown } from "@/components/profile-dropdown";
 import { useRouter } from "next/navigation";
 import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { toast } from "sonner";
@@ -390,34 +391,13 @@ export default function Page() {
                 </>
               )}
             </button> */}
-            <Link href="/settings" className="cursor-pointer">
-              <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:opacity-80 transition-opacity">
-                <div className="h-full w-full rounded-full overflow-hidden bg-[#101012]">
-                  {user?.image ? (
-                    <Image
-                      src={user.image}
-                      alt="Profile"
-                      width={56}
-                      height={56}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <Image
-                      src={`https://api.dicebear.com/9.x/identicon/svg?seed=${user?.id || user?.email || "user"}`}
-                      alt="Profile"
-                      width={56}
-                      height={56}
-                      className="h-full w-full"
-                      onError={(e) => {
-                        console.error(`Error loading identicon for user`);
-                        const target = e.target as HTMLImageElement;
-                        target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=user`;
-                      }}
-                    />
-                  )}
-                </div>
-              </div>
-            </Link>
+            {user && (
+              <ProfileDropdown
+                user={user}
+                profileHref="/settings"
+                avatarSizeClass="h-10 w-10 sm:h-14 sm:w-14"
+              />
+            )}
           </div>
         </div>
       </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,44 +1,21 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import Image from "next/image";
-import { Loader2, Trash2, LogOut, Save, Info } from "lucide-react";
+import React, { useState, useEffect } from "react";
+import { Loader2 } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
 import { useRouter } from "next/navigation";
-import { motion, AnimatePresence } from "framer-motion";
-import { fadeIn } from "@/utils/animations";
 import { toast } from "sonner";
 import { signOut } from "@/lib/auth";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { AddWalletModal } from "@/components/add-wallet-modal";
 import { useUpdateUser } from "@/features/user/hooks/use-update-profile";
 import { asEnhancedUser } from "@/types/user";
-import {
-  useGetAllCurrencies,
-  useOrganizedCurrencies,
-} from "@/features/currencies/hooks/use-currencies";
-import type { Currency } from "@/features/currencies/api/client";
+import { useGetAllCurrencies } from "@/features/currencies/hooks/use-currencies";
 import {
   useUserWallets,
   useAddWallet,
   useSetWalletAsPrimary,
   useRemoveWallet,
 } from "@/features/wallets/hooks/use-wallets";
-import CurrencyDropdown from "@/components/currency-dropdown";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { getUser } from "@/features/user/api/client";
-import { Button } from "@/components/ui/button";
+import { SettingsPageContent } from "@/app/settings/settings-page-content";
 
 // Base API URL
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
@@ -331,9 +308,7 @@ export default function SettingsPage() {
         </div>
       </div>
     );
-  }
-
-  if (!isAuthenticated || !user) {
+  } else   if (!isAuthenticated || !user) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="text-white/70 text-lg">
@@ -343,359 +318,34 @@ export default function SettingsPage() {
     );
   }
 
-  return (
-    <motion.div
-      variants={fadeIn}
-      initial="initial"
-      animate="animate"
-      className="flex w-full min-h-screen bg-black rounded-xl"
-    >
-      <div className="w-[750px] pl-10 pt-10 pr-4 pb-24">
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-semibold text-white">Settings</h1>
-          <div className="flex gap-3">
-            <button
-              onClick={handleLogout}
-              disabled={isLoggingOut}
-              className="flex items-center justify-center gap-1 sm:gap-2 rounded-full bg-transparent border border-white/20 text-white h-10 sm:h-12 px-4 sm:px-6 text-mobile-sm sm:text-base font-medium hover:bg-white/5 transition-all disabled:opacity-70 disabled:cursor-not-allowed"
-            >
-              {isLoggingOut ? (
-                <>
-                  <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 animate-spin" />
-                  <span>Logging out...</span>
-                </>
-              ) : (
-                <>
-                  <LogOut className="h-4 w-4 sm:h-5 sm:w-5" />
-                  <span>Logout</span>
-                </>
-              )}
-            </button>
-          </div>
-        </div>
-        {/* Profile Photo Upload */}
-        <div className="mb-8">
-          <p className="text-white mb-3">Upload your PFP</p>
-          <div className="flex items-center gap-5">
-            <div className="relative">
-              <div className="w-[100px] h-[100px] rounded-full border border-dashed border-white/30 flex items-center justify-center overflow-hidden">
-                {user.image ? (
-                  <Image
-                    src={user.image}
-                    alt="Profile"
-                    width={100}
-                    height={100}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <div className="text-xs text-white/60 text-center p-2">
-                    PNGs, JPGs
-                  </div>
-                )}
-                {isUploadingImage && (
-                  <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center">
-                    <Loader2 className="h-6 w-6 animate-spin text-white mb-2" />
-                    <span className="text-xs text-white">
-                      {uploadProgress}%
-                    </span>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <div className="flex flex-col">
-              <label
-                htmlFor="profile-upload"
-                className={`bg-transparent border border-white/20 text-white rounded-full px-6 py-2.5 hover:bg-white/5 transition cursor-pointer ${
-                  isUploadingImage ? "opacity-50 cursor-not-allowed" : ""
-                }`}
-              >
-                {isUploadingImage ? "Uploading..." : "Select Image"}
-                <input
-                  id="profile-upload"
-                  type="file"
-                  accept="image/png, image/jpeg"
-                  className="hidden"
-                  disabled={isUploadingImage}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) {
-                      handleImageUpload(file);
-                    }
-                  }}
-                />
-              </label>
-              {uploadError && (
-                <p className="text-red-500 text-xs mt-2">{uploadError}</p>
-              )}
-            </div>
-          </div>
-        </div>
-        {/* Display Name */}
-        <div className="mb-8">
-          <label htmlFor="display-name" className="block text-white mb-2">
-            Display Name
-          </label>
-          <input
-            id="display-name"
-            type="text"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            className="w-full bg-black border border-white/20 text-white p-3 rounded-lg h-12 focus:outline-none focus:ring-1 focus:ring-white/40"
-            placeholder="Enter your name"
-          />
-        </div>
-        <div id="settings-accept-payments-section" className="mb-8">
-          <label className="text-white mb-2 flex items-center gap-2">
-            Accept Payments in
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <Info className="h-4 w-4 text-white/80" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Select the tokens you want to accept payments in</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </label>
-
-          {wallets.length > 0 ? (
-            <CurrencyDropdown
-              selectedCurrencies={selectedCurrencies}
-              setSelectedCurrencies={setSelectedCurrencies}
-              filterCurrencies={(currency: Currency) =>
-                currency.symbol !== "ETH" &&
-                currency.symbol !== "USDC" &&
-                wallets.some((wallet) => wallet.chainId === currency.chainId)
-              }
-              showFiatCurrencies={false}
-            />
-          ) : (
-            <div className="text-white/50 text-sm">
-              You don't have any wallets yet. Add one to get started.
-            </div>
-          )}
-        </div>
-
-        {/* Preferred Currency - Single Dropdown */}
-        <div className="mb-8">
-          <label className="text-white mb-2 flex items-center gap-2">
-            Default Currency
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <Info className="h-4 w-4 text-white/80" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>
-                    Currencies will be converted to this currency for Display
-                    purposes
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </label>
-          <CurrencyDropdown
-            selectedCurrencies={preferredCurrency ? [preferredCurrency] : []}
-            setSelectedCurrencies={(currencies) =>
-              setPreferredCurrency(currencies[0] || "")
-            }
-            mode="single"
-            showFiatCurrencies={true}
-            filterCurrencies={(currency: Currency) =>
-              currency.symbol !== "ETH" && currency.symbol !== "USDC"
-            }
-            disableChainCurrencies={true}
-          />
-        </div>
-
-        {hasChanges && (
-          <button
-            onClick={handleSaveChanges}
-            disabled={isUpdatatingUser}
-            className={`flex w-full items-center justify-center gap-1 sm:gap-2 rounded-full border text-white h-10 sm:h-12 px-4 sm:px-6 text-mobile-sm sm:text-base font-medium transition-all disabled:cursor-not-allowed ${
-              !isUpdatatingUser
-                ? "bg-black text-black border-white hover:bg-zinc-900"
-                : "bg-transparent border-white/20 text-white/40"
-            }`}
-          >
-            {isUpdatatingUser ? (
-              <>
-                <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 animate-spin" />
-                <span>Saving...</span>
-              </>
-            ) : (
-              <>
-                <Save className="h-4 w-4 sm:h-5 sm:w-5" />
-                <span>Save Changes</span>
-              </>
-            )}
-          </button>
-        )}
-        {/* Divider Line */}
-        <div className="h-px w-full bg-white/10 my-8"></div>
-        {/* Wallet Management */}
-        <div className="mb-8">
-          <button
-            id="settings-add-wallet-button"
-            onClick={() => setIsWalletModalOpen(true)}
-            disabled={isAddingWallet}
-            className="w-full flex items-center justify-center h-10 sm:h-12 gap-1 sm:gap-2 bg-white text-black rounded-full px-4 sm:px-6 text-mobile-sm sm:text-base font-medium hover:bg-white/90 transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
-          >
-
-            {isAddingWallet ? (
-              <>
-                <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 animate-spin" />
-                <span>Adding Wallet...</span>
-              </>
-            ) : (
-              <span>Add Wallet</span>
-            )}
-          </button>
-
-          {/* Wallet List */}
-          <div className="space-y-6 pt-6">
-            <h2 className="text-white text-2lg font-semibold ">Your Wallets</h2>
-            {isLoadingWallets ? (
-              <div className="flex justify-center py-8">
-                <Loader2 className="h-8 w-8 animate-spin text-white/50" />
-              </div>
-            ) : wallets.length > 0 ? (
-              wallets.map((wallet) => (
-                <div key={wallet.id} className="pb-6 mb-2">
-                  <div className="flex items-center justify-between">
-                    <p className="text-white font-mono">
-                      {wallet.address.length > 20
-                        ? wallet.address.slice(0, 17) +
-                          "..." +
-                          wallet.address.slice(-4)
-                        : wallet.address}
-                    </p>
-                    {!wallet.isDefault ? (
-                      <div className="flex items-center">
-                        {/* <button
-                          onClick={() => handleSetAsPrimary(wallet.id)}
-                          className="border border-white/80 text-white text-sm rounded-full px-4 py-1.5 hover:bg-white/5 transition"
-                        >
-                          Set as primary
-                        </button> */}
-                        <button
-                          onClick={() => handleRemoveWallet(wallet.id)}
-                          disabled={isRemovingWallet}
-                          className="text-white/70 p-1.5 rounded-full hover:bg-white/5 transition ml-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {isRemovingWallet ? (
-                            <Loader2 className="h-5 w-5 animate-spin" />
-                          ) : (
-                            <Trash2 className="h-5 w-5" />
-                          )}
-                        </button>
-                      </div>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <div className="text-white/60 text-sm">
-                          Primary Wallet
-                        </div>
-                        <button
-                          onClick={() => handleRemoveWallet(wallet.id)}
-                          disabled={isRemovingWallet}
-                          className="text-white/70 p-1.5 rounded-full hover:bg-white/5 transition ml-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {isRemovingWallet ? (
-                            <Loader2 className="h-5 w-5 animate-spin" />
-                          ) : (
-                            <Trash2 className="h-5 w-5" />
-                          )}
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <div className="mt-2">
-                    <p className="text-white/60 text-sm">
-                      {getChainName(wallet.chainId)}
-                    </p>
-                  </div>
-                </div>
-              ))
-            ) : (
-              <div className="py-8 text-center text-white/50">
-                You don't have any wallets yet. Add one to get started.
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Add Wallet Modal */}
-      <AddWalletModal
-        isOpen={isWalletModalOpen}
-        onClose={() => {
-          setIsWalletModalOpen(false);
-          // Optionally, refetch user wallets or user profile here if needed
-          // handleWalletAdded();
-        }}
-      />
-
-      {/* Remove Wallet Confirmation Modal */}
-      <AnimatePresence>
-        {isRemoveConfirmOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            {/* Backdrop */}
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-              onClick={cancelRemoveWallet}
-            />
-
-            {/* Modal */}
-            <motion.div
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              className="relative bg-[#1A1A1D] border border-white/10 rounded-2xl p-6 w-full max-w-md shadow-2xl"
-            >
-              <div className="text-center">
-                <h3 className="text-xl font-semibold text-white mb-2">
-                  Remove Wallet
-                </h3>
-
-                <p className="text-white/70 mb-6">
-                  Are you sure you want to remove this wallet? This action
-                  cannot be undone.
-                </p>
-
-                <div className="flex gap-3">
-                  <button
-                    onClick={cancelRemoveWallet}
-                    disabled={isRemovingWallet}
-                    className="flex-1 px-4 py-2.5 bg-transparent border border-white/20 text-white rounded-lg hover:bg-white/5 transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
-                  >
-                    Cancel
-                  </button>
-
-                  <button
-                    onClick={confirmRemoveWallet}
-                    disabled={isRemovingWallet}
-                    className="flex-1 px-4 py-2.5 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                  >
-                    {isRemovingWallet ? (
-                      <>
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Removing...
-                      </>
-                    ) : (
-                      "Remove Wallet"
-                    )}
-                  </button>
-                </div>
-              </div>
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
-    </motion.div>
-  );
+  return React.createElement(SettingsPageContent, {
+    user,
+    displayName,
+    setDisplayName,
+    preferredCurrency,
+    setPreferredCurrency,
+    hasChanges,
+    handleSaveChanges,
+    isUpdatatingUser,
+    wallets,
+    handleRemoveWallet,
+    handleSetAsPrimary,
+    getChainName,
+    isAddingWallet,
+    isWalletModalOpen,
+    setIsWalletModalOpen,
+    isRemovingWallet,
+    isRemoveConfirmOpen,
+    confirmRemoveWallet,
+    cancelRemoveWallet,
+    isUploadingImage,
+    uploadProgress,
+    uploadError,
+    handleImageUpload,
+    selectedCurrencies,
+    setSelectedCurrencies,
+    isLoadingWallets,
+    onLogout: handleLogout,
+    isLoggingOut: isLoggingOut,
+  });
 }

--- a/app/settings/settings-page-content.tsx
+++ b/app/settings/settings-page-content.tsx
@@ -104,11 +104,15 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
   const Row = ({
     children,
     style = {},
+    onClick,
   }: {
     children: React.ReactNode;
     style?: React.CSSProperties;
+    onClick?: () => void;
   }) => (
     <div
+      role={onClick ? "button" : undefined}
+      onClick={onClick}
       style={{
         display: "flex",
         alignItems: "center",

--- a/app/settings/settings-page-content.tsx
+++ b/app/settings/settings-page-content.tsx
@@ -1,0 +1,540 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import { Loader2, Trash2, Save, Info } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { Currency } from "@/features/currencies/api/client";
+import type { Wallet } from "@/features/wallets/api/client";
+import CurrencyDropdown from "@/components/currency-dropdown";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { AddWalletModal } from "@/components/add-wallet-modal";
+import type { User } from "@/api-helpers/modelSchema/UserSchema";
+import { Card, Btn, T, Icons, A } from "@/lib/splito-design";
+
+export interface SettingsPageContentProps {
+  user: User;
+  displayName: string;
+  setDisplayName: (v: string) => void;
+  preferredCurrency: string;
+  setPreferredCurrency: (v: string) => void;
+  hasChanges: boolean;
+  handleSaveChanges: () => void;
+  isUpdatatingUser: boolean;
+  wallets: Wallet[];
+  handleRemoveWallet: (walletId: string) => void;
+  handleSetAsPrimary?: (walletId: string) => void;
+  getChainName: (chainId: string) => string;
+  isAddingWallet: boolean;
+  isWalletModalOpen: boolean;
+  setIsWalletModalOpen: (v: boolean) => void;
+  isRemovingWallet: boolean;
+  isRemoveConfirmOpen: boolean;
+  confirmRemoveWallet: () => void;
+  cancelRemoveWallet: () => void;
+  isUploadingImage: boolean;
+  uploadProgress: number;
+  uploadError: string;
+  handleImageUpload: (file: File) => void;
+  selectedCurrencies: string[];
+  setSelectedCurrencies: (v: string[]) => void;
+  isLoadingWallets: boolean;
+  onLogout?: () => void;
+  isLoggingOut?: boolean;
+}
+
+export function SettingsPageContent(props: SettingsPageContentProps) {
+  const {
+    user,
+    displayName,
+    setDisplayName,
+    preferredCurrency,
+    setPreferredCurrency,
+    hasChanges,
+    handleSaveChanges,
+    isUpdatatingUser,
+    wallets,
+    handleRemoveWallet,
+    handleSetAsPrimary,
+    getChainName,
+    isAddingWallet,
+    isWalletModalOpen,
+    setIsWalletModalOpen,
+    isRemovingWallet,
+    isRemoveConfirmOpen,
+    confirmRemoveWallet,
+    cancelRemoveWallet,
+    isUploadingImage,
+    uploadProgress,
+    uploadError,
+    handleImageUpload,
+    selectedCurrencies,
+    setSelectedCurrencies,
+    isLoadingWallets,
+    onLogout,
+    isLoggingOut = false,
+  } = props;
+
+  const [notificationsOn, setNotificationsOn] = React.useState(true);
+
+  const SLabel = ({ children, style = {} }: { children: React.ReactNode; style?: React.CSSProperties }) => (
+    <div
+      style={{
+        color: T.soft,
+        fontSize: 11,
+        fontWeight: 700,
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        marginBottom: 14,
+        marginTop: 28,
+        paddingBottom: 10,
+        borderBottom: "1px solid rgba(255,255,255,0.07)",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  const Row = ({
+    children,
+    style = {},
+  }: {
+    children: React.ReactNode;
+    style?: React.CSSProperties;
+  }) => (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "17px 0",
+        borderBottom: "1px solid rgba(255,255,255,0.06)",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  const Toggle = ({
+    on,
+    onChange,
+  }: {
+    on: boolean;
+    onChange: () => void;
+  }) => (
+    <div
+      onClick={onChange}
+      role="switch"
+      aria-checked={on}
+      style={{
+        width: 44,
+        height: 26,
+        borderRadius: 99,
+        background: on ? A : "rgba(255,255,255,0.1)",
+        cursor: "pointer",
+        position: "relative",
+        transition: "all 0.25s",
+        flexShrink: 0,
+      }}
+    >
+      <div
+        style={{
+          width: 20,
+          height: 20,
+          borderRadius: "50%",
+          background: "#fff",
+          position: "absolute",
+          top: 3,
+          left: on ? 21 : 3,
+          transition: "left 0.25s",
+          boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
+        }}
+      />
+    </div>
+  );
+
+  const userEmail = user?.email ?? "";
+  const userInitial = (displayName || user?.name || "Y").charAt(0).toUpperCase();
+
+  return (
+    <div className="flex w-full min-h-screen bg-black rounded-xl">
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Sticky header – design (matches Dashboard), responsive */}
+        <div
+          className="border-b border-white/[0.07] px-4 sm:px-7 flex items-center h-14 sm:h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
+        >
+          <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
+            Settings
+          </h1>
+        </div>
+        <div className="flex-1 p-4 sm:p-7 overflow-y-auto max-w-[660px] pb-24">
+          <SLabel style={{ marginTop: 0 }}>Profile</SLabel>
+          <Card className="p-4 sm:p-[22px] mb-1">
+            <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 22, paddingBottom: 22, borderBottom: "1px solid rgba(255,255,255,0.07)" }}>
+              <div style={{ position: "relative" }}>
+                <label htmlFor="profile-upload" style={{ cursor: isUploadingImage ? "not-allowed" : "pointer", display: "block" }}>
+                  <div
+                    style={{
+                      width: 64,
+                      height: 64,
+                      borderRadius: "50%",
+                      background: `${A}1a`,
+                      border: `2px solid ${A}44`,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: 22,
+                      fontWeight: 800,
+                      color: A,
+                      overflow: "hidden",
+                    }}
+                  >
+                    {user.image ? (
+                      <Image src={user.image} alt="Profile" width={64} height={64} className="h-full w-full object-cover" />
+                    ) : (
+                      <span>{userInitial}</span>
+                    )}
+                  </div>
+                  {isUploadingImage && (
+                    <div style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "rgba(0,0,0,0.7)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+                      <Loader2 className="h-5 w-5 animate-spin text-white" />
+                      <span style={{ fontSize: 10, color: "#fff" }}>{uploadProgress}%</span>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    style={{
+                      position: "absolute",
+                      bottom: -2,
+                      right: -2,
+                      width: 24,
+                      height: 24,
+                      borderRadius: "50%",
+                      background: "#222",
+                      border: "1.5px solid rgba(255,255,255,0.15)",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      cursor: isUploadingImage ? "not-allowed" : "pointer",
+                      color: T.body,
+                    }}
+                    onClick={(e) => { e.preventDefault(); document.getElementById("profile-upload")?.click(); }}
+                  >
+                    {Icons.camera({ size: 12 })}
+                  </button>
+                  <input
+                    id="profile-upload"
+                    type="file"
+                    accept="image/png, image/jpeg"
+                    className="hidden"
+                    disabled={isUploadingImage}
+                    onChange={(e) => { const file = e.target.files?.[0]; if (file) handleImageUpload(file); }}
+                  />
+                </label>
+                {uploadError && <p style={{ fontSize: 11, color: "#F87171", margin: "4px 0 0 0" }}>{uploadError}</p>}
+              </div>
+              <div>
+                <p style={{ color: T.bright, fontSize: 16, fontWeight: 800, letterSpacing: "-0.01em" }}>{displayName || "You"}</p>
+                <p style={{ color: T.muted, fontSize: 12, fontWeight: 500, marginTop: 2 }}>{userEmail || "you@email.com"}</p>
+              </div>
+            </div>
+            <Row>
+              <span style={{ color: T.body, fontSize: 14, fontWeight: 600 }}>Display Name</span>
+              <input
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                style={{
+                  background: "rgba(255,255,255,0.05)",
+                  border: "1.5px solid rgba(255,255,255,0.09)",
+                  borderRadius: 12,
+                  padding: "10px 14px",
+                  color: "#fff",
+                  fontSize: 14,
+                  outline: "none",
+                  fontFamily: "inherit",
+                  width: 220,
+                  fontWeight: 500,
+                }}
+              />
+            </Row>
+            <Row style={{ borderBottom: "none" }}>
+              <span style={{ color: T.body, fontSize: 14, fontWeight: 600 }}>Email</span>
+              <input
+                value={userEmail}
+                readOnly
+                style={{
+                  background: "rgba(255,255,255,0.05)",
+                  border: "1.5px solid rgba(255,255,255,0.09)",
+                  borderRadius: 12,
+                  padding: "10px 14px",
+                  color: T.muted,
+                  fontSize: 14,
+                  outline: "none",
+                  fontFamily: "inherit",
+                  width: 220,
+                  fontWeight: 500,
+                }}
+              />
+            </Row>
+            <div style={{ paddingTop: 18, display: "flex", justifyContent: "flex-end" }}>
+              {hasChanges && (
+                <button
+                  onClick={handleSaveChanges}
+                  disabled={isUpdatatingUser}
+                  style={{
+                    background: A,
+                    border: "none",
+                    borderRadius: 12,
+                    padding: "10px 22px",
+                    color: "#0a0a0a",
+                    fontWeight: 800,
+                    fontSize: 13,
+                    cursor: isUpdatatingUser ? "not-allowed" : "pointer",
+                    fontFamily: "inherit",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    opacity: isUpdatatingUser ? 0.7 : 1,
+                  }}
+                >
+                  {isUpdatatingUser ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                  {isUpdatatingUser ? "Saving..." : "Save Changes"}
+                </button>
+              )}
+            </div>
+          </Card>
+
+          <SLabel>Preferences</SLabel>
+          <Card className="px-4 sm:px-[22px] py-0">
+            <Row>
+              <div>
+                <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Notifications</p>
+                <p style={{ color: T.muted, fontSize: 12, marginTop: 2, fontWeight: 500 }}>Email reminders and updates</p>
+              </div>
+              <Toggle on={notificationsOn} onChange={() => setNotificationsOn((p) => !p)} />
+            </Row>
+            <Row style={{ borderBottom: "none", alignItems: "center" }}>
+              <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Default Currency</p>
+              <div style={{ minWidth: 220 }}>
+                <CurrencyDropdown
+                  selectedCurrencies={preferredCurrency ? [preferredCurrency] : []}
+                  setSelectedCurrencies={(currencies) => setPreferredCurrency(currencies[0] || "")}
+                  mode="single"
+                  showFiatCurrencies={true}
+                  filterCurrencies={(currency: Currency) => currency.symbol !== "ETH" && currency.symbol !== "USDC"}
+                  disableChainCurrencies={true}
+                />
+              </div>
+            </Row>
+          </Card>
+
+          {wallets.length > 0 && (
+            <>
+              <SLabel>Accept Payments in</SLabel>
+              <Card className="p-[22px] mb-4" id="settings-accept-payments-tokens">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <p style={{ color: T.muted, fontSize: 12, marginBottom: 12 }}>Select the tokens you want to accept payments in</p>
+                    </TooltipTrigger>
+                    <TooltipContent><p>Based on your connected wallets</p></TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <CurrencyDropdown
+                  selectedCurrencies={selectedCurrencies}
+                  setSelectedCurrencies={setSelectedCurrencies}
+                  filterCurrencies={(currency: Currency) =>
+                    currency.symbol !== "ETH" &&
+                    currency.symbol !== "USDC" &&
+                    wallets.some((w) => w.chainId === currency.chainId)
+                  }
+                  showFiatCurrencies={false}
+                />
+              </Card>
+            </>
+          )}
+
+          <SLabel>Security</SLabel>
+          <Card className="px-4 sm:px-[22px] py-0">
+            <Row
+              style={{ borderBottom: "none", cursor: "pointer" }}
+              onClick={() => { if (typeof window !== "undefined") window.location.href = "/settings/change-password"; }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <span style={{ color: T.body, display: "flex" }}>{Icons.shield({})}</span>
+                <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Change Password</p>
+              </div>
+              <span style={{ color: T.dim, display: "flex" }}>{Icons.chevR({})}</span>
+            </Row>
+          </Card>
+
+          <SLabel>Connected Wallets</SLabel>
+          <Card style={{ marginBottom: 4 }}>
+            {isLoadingWallets ? (
+              <div style={{ display: "flex", justifyContent: "center", padding: "28px" }}>
+                <Loader2 className="h-8 w-8 animate-spin" style={{ color: T.muted }} />
+              </div>
+            ) : wallets.length > 0 ? (
+              wallets.map((wallet, idx) => (
+                <div
+                  key={wallet.id}
+                  className="flex flex-col sm:flex-row sm:items-center gap-3 py-4 px-4 sm:py-[17px] sm:px-[22px] border-b border-white/[0.06] last:border-b-0"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2 mb-1">
+                      <p className="text-sm font-bold text-[#e8e8e8]">{getChainName(wallet.chainId)}</p>
+                      {wallet.isDefault && (
+                        <span style={{ fontSize: 10, padding: "3px 10px", borderRadius: 99, fontWeight: 700, background: `${A}1a`, color: A, border: `1px solid ${A}2a` }}>Primary</span>
+                      )}
+                    </div>
+                    <p className="text-xs text-[#999] font-mono truncate" title={wallet.address}>
+                      {wallet.address.length > 20 ? wallet.address.slice(0, 10) + "..." + wallet.address.slice(-8) : wallet.address}
+                    </p>
+                  </div>
+                  <div className="flex gap-2 flex-shrink-0">
+                    {!wallet.isDefault && handleSetAsPrimary && (
+                      <Btn variant="ghost" className="py-1.5 px-3 text-[11px]" onClick={() => handleSetAsPrimary(wallet.id)}>Set Primary</Btn>
+                    )}
+                    <button
+                      onClick={() => handleRemoveWallet(wallet.id)}
+                      className="flex items-center gap-1 py-1.5 px-3 rounded-lg text-[11px] font-semibold border border-[rgba(248,113,113,0.15)] bg-[rgba(248,113,113,0.07)] text-[#F87171]"
+                    >
+                      {Icons.trash({ size: 12 })}
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div style={{ padding: "24px 22px", color: T.body, fontSize: 13 }}>You don&apos;t have any wallets yet.</div>
+            )}
+          </Card>
+          <button
+            id="settings-add-wallet-button"
+            onClick={() => setIsWalletModalOpen(true)}
+            disabled={isAddingWallet}
+            style={{
+              width: "100%",
+              padding: 14,
+              background: "rgba(255,255,255,0.03)",
+              border: "1.5px dashed rgba(255,255,255,0.12)",
+              borderRadius: 18,
+              color: T.muted,
+              fontSize: 14,
+              fontWeight: 700,
+              cursor: isAddingWallet ? "not-allowed" : "pointer",
+              fontFamily: "inherit",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+              transition: "all 0.2s",
+              marginTop: 10,
+              opacity: isAddingWallet ? 0.7 : 1,
+            }}
+          >
+            {Icons.plus({ size: 16 })}
+            Add Wallet
+          </button>
+
+          <SLabel>Account</SLabel>
+          <Card className="px-4 sm:px-[22px] py-0">
+            <Row
+              style={{
+                borderBottom: "none",
+                cursor: onLogout && !isLoggingOut ? "pointer" : undefined,
+                opacity: isLoggingOut ? 0.7 : 1,
+              }}
+              onClick={() => !isLoggingOut && onLogout?.()}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <span style={{ color: "#F87171", display: "flex" }}>{Icons.logout({})}</span>
+                <p style={{ color: "#F87171", fontSize: 14, fontWeight: 700 }}>Sign Out</p>
+              </div>
+              <span style={{ color: T.dim, display: "flex" }}>{Icons.chevR({})}</span>
+            </Row>
+          </Card>
+          <div style={{ height: 40 }} />
+        </div>
+
+        {/* Add Wallet Modal */}
+        <AddWalletModal
+          isOpen={isWalletModalOpen}
+          onClose={() => setIsWalletModalOpen(false)}
+        />
+
+        {/* Remove Wallet Confirmation Modal – design */}
+        <AnimatePresence>
+          {isRemoveConfirmOpen && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+                onClick={cancelRemoveWallet}
+              />
+              <motion.div
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                className="relative w-full max-w-md rounded-2xl p-6 shadow-2xl"
+                style={{
+                  background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)",
+                  border: "1px solid rgba(255,255,255,0.08)",
+                  boxShadow:
+                    "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)",
+                }}
+              >
+                <div className="text-center">
+                  <h3
+                    className="text-xl font-semibold mb-2"
+                    style={{ color: T.bright }}
+                  >
+                    Remove Wallet
+                  </h3>
+                  <p className="mb-6" style={{ color: T.body, fontSize: 14 }}>
+                    Are you sure you want to remove this wallet? This action
+                    cannot be undone.
+                  </p>
+                  <div className="flex gap-3 justify-center">
+                    <Btn variant="ghost" onClick={cancelRemoveWallet}>
+                      Cancel
+                    </Btn>
+                    <Btn
+                      variant="danger"
+                      onClick={confirmRemoveWallet}
+                      style={{
+                        opacity: isRemovingWallet ? 0.7 : 1,
+                        cursor: isRemovingWallet ? "not-allowed" : "pointer",
+                      }}
+                    >
+                      {isRemovingWallet ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <span>Removing...</span>
+                        </>
+                      ) : (
+                        <>
+                          {Icons.trash({ size: 14 })}
+                          <span>Remove Wallet</span>
+                        </>
+                      )}
+                    </Btn>
+                  </div>
+                </div>
+              </motion.div>
+            </div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -11,6 +11,17 @@ import { defaultPostLoginPath } from "@/lib/app-mode";
 import { toast } from "sonner";
 import { ApiError } from "@/types/api-error";
 
+function GoogleIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0">
+      <path d="M19.8055 10.2298C19.8055 9.51795 19.7434 8.83835 19.6299 8.18213H10.2002V11.9624H15.6016C15.3853 13.1709 14.6875 14.1933 13.6543 14.8622V17.311H16.8564C18.7502 15.5938 19.8055 13.1499 19.8055 10.2298Z" fill="#4285F4" />
+      <path d="M10.1999 20.0001C12.8999 20.0001 15.1499 19.115 16.8561 17.3113L13.654 14.8625C12.7754 15.4513 11.6077 15.7968 10.1999 15.7968C7.5938 15.7968 5.38819 14.0732 4.58777 11.7H1.28149V14.2318C2.9752 17.6232 6.3313 20.0001 10.1999 20.0001Z" fill="#34A853" />
+      <path d="M4.58753 11.7002C4.18753 10.4917 4.18753 9.17 4.58753 7.9615V5.42969H1.28126C-0.119933 8.00938 -0.119933 11.6523 1.28126 14.232L4.58753 11.7002Z" fill="#FBBC05" />
+      <path d="M10.1999 4.20378C11.6218 4.18533 12.9998 4.73503 14.0345 5.72847L16.8959 2.8671C15.1044 1.18895 12.6958 0.200905 10.1999 0.229336C6.3313 0.229336 2.9752 2.60621 1.28149 5.99761L4.58777 8.52941C5.38819 6.15621 7.5938 4.43261 10.1999 4.20378Z" fill="#EA4335" />
+    </svg>
+  );
+}
+
 export default function SignupPage() {
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
@@ -97,7 +108,7 @@ export default function SignupPage() {
         {/* Card container only visible on desktop */}
         <div className="hidden sm:block animate-border-light">
           <div className="relative rounded-[24px] !bg-[#0f0f10] p-8 space-y-6">
-            <div className="flex justify-center mb-6">
+            <div className="flex justify-center mb-4">
               <Image
                 src="/logo.svg"
                 alt="Splito"
@@ -110,60 +121,79 @@ export default function SignupPage() {
             <h1 className="text-2xl font-semibold text-white text-center">
               Create account
             </h1>
+            <p className="text-center text-sm text-white/60 -mt-2">
+              Already have an account?{" "}
+              <Link href="/login" className="text-white hover:underline font-medium">
+                Sign in
+              </Link>
+            </p>
+
+            {/* Google as full-width strip first */}
+            <button
+              type="button"
+              onClick={handleGoogleSignup}
+              className="w-full h-[52px] flex items-center justify-center gap-3 rounded-xl
+                bg-[#1a1a1c] border border-white/10
+                text-base font-medium text-white
+                transition-all duration-200 hover:bg-white/[0.06] hover:border-white/20 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoadingEmail || isLoadingGoogle}
+            >
+              {isLoadingGoogle ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <>
+                  <GoogleIcon />
+                  <span>Sign up with Google</span>
+                </>
+              )}
+            </button>
+
+            <div className="relative flex items-center">
+              <div className="flex-grow border-t border-white/10" />
+              <span className="px-4 text-sm text-white/40">OR</span>
+              <div className="flex-grow border-t border-white/10" />
+            </div>
 
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="form-group">
-                <label htmlFor="name-desktop" className="form-label">
-                  Name
-                </label>
+                <label htmlFor="name-desktop" className="form-label">Name</label>
                 <input
                   type="text"
                   id="name-desktop"
-                  className="form-input !rounded-[19px] !bg-[#0D0D0F] !pl-4"
+                  className="form-input !rounded-[12px] !bg-[#0D0D0F] !pl-4 !border-white/10"
                   placeholder="Your name"
                   value={formData.name}
-                  onChange={(e) =>
-                    setFormData({ ...formData, name: e.target.value })
-                  }
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   required
                   disabled={isLoadingEmail || isLoadingGoogle}
                 />
               </div>
               <div className="form-group">
-                <label htmlFor="email-desktop" className="form-label">
-                  Email
-                </label>
+                <label htmlFor="email-desktop" className="form-label">Email</label>
                 <div className="relative">
                   <input
                     type="email"
                     id="email-desktop"
-                    className="form-input !rounded-[19px] !bg-[#0D0D0F] !pl-12"
-                    placeholder="name@gmail.com"
+                    className="form-input !rounded-[12px] !bg-[#0D0D0F] !pl-12 !border-white/10"
+                    placeholder="email address"
                     value={formData.email}
-                    onChange={(e) =>
-                      setFormData({ ...formData, email: e.target.value })
-                    }
+                    onChange={(e) => setFormData({ ...formData, email: e.target.value })}
                     required
                     disabled={isLoadingEmail || isLoadingGoogle}
                   />
                   <Mail className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-white/50" />
                 </div>
               </div>
-
               <div className="form-group">
-                <label htmlFor="password-desktop" className="form-label">
-                  Password
-                </label>
+                <label htmlFor="password-desktop" className="form-label">Password</label>
                 <div className="relative">
                   <input
                     type={showPassword ? "text" : "password"}
                     id="password-desktop"
-                    className="form-input !rounded-[19px] !bg-[#0D0D0F] !pl-12"
-                    placeholder="●●●●●●●●"
+                    className="form-input !rounded-[12px] !bg-[#0D0D0F] !pl-12 !border-white/10"
+                    placeholder="Password"
                     value={formData.password}
-                    onChange={(e) =>
-                      setFormData({ ...formData, password: e.target.value })
-                    }
+                    onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                     required
                     disabled={isLoadingEmail || isLoadingGoogle}
                   />
@@ -174,96 +204,48 @@ export default function SignupPage() {
                     onClick={() => setShowPassword(!showPassword)}
                     disabled={isLoadingEmail || isLoadingGoogle}
                   >
-                    {showPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
+                    {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                   </button>
                 </div>
-                <Link
-                  href="/forgot-password"
-                  className="text-sm text-white/50 hover:text-white/70 mt-2 inline-block"
-                >
-                  Forgot Password?
-                </Link>
               </div>
-
-              <div className="flex items-center gap-2 mt-4">
+              <div className="flex items-center gap-2">
                 <input
                   type="checkbox"
                   id="terms-desktop"
-                  className="appearance-none rounded-[7px] accent-zinc-700 border border-white/10 w-5 h-5 
-                  checked:border-white cursor-pointer relative
-                  checked:after:content-['✓'] checked:after:absolute checked:after:left-1/2 
-                  checked:after:top-1/2 checked:after:-translate-x-1/2 checked:after:-translate-y-1/2
-                  checked:after:text-white"
+                  className="appearance-none rounded-[7px] border border-white/10 w-5 h-5 bg-[#0D0D0F] cursor-pointer relative
+                    checked:border-[#22D3EE] checked:bg-[#22D3EE]/20
+                    checked:after:content-['✓'] checked:after:absolute checked:after:left-1/2 checked:after:top-1/2
+                    checked:after:-translate-x-1/2 checked:after:-translate-y-1/2 checked:after:text-[#22D3EE] checked:after:text-sm"
                   checked={formData.agreeToTerms}
-                  onChange={(e) =>
-                    setFormData({ ...formData, agreeToTerms: e.target.checked })
-                  }
+                  onChange={(e) => setFormData({ ...formData, agreeToTerms: e.target.checked })}
                   required
                   disabled={isLoadingEmail || isLoadingGoogle}
                 />
-                <label
-                  htmlFor="terms-desktop"
-                  className="text-sm text-white/70"
-                >
+                <label htmlFor="terms-desktop" className="text-sm text-white/70">
                   I agree with the{" "}
-                  <Link href="/terms" className="text-white hover:underline">
-                    Privacy & Policy
-                  </Link>
+                  <Link href="/terms" className="text-white hover:underline">Privacy & Policy</Link>
                 </label>
               </div>
-
-              <div className="flex justify-center">
-                <button
-                  type="submit"
-                  className="w-2/4 h-[58px] flex items-center justify-center mt-6
-                  bg-[#101012] border border-white/75 rounded-[19px]
-                  text-[21.5px] font-semibold text-white leading-[34px] tracking-[-0.03em]
-                  transition-all duration-200 hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled={isLoadingEmail || isLoadingGoogle}
-                >
-                  {isLoadingEmail ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    "Sign up"
-                  )}
-                </button>
-              </div>
-
-              <div className="flex justify-center mt-4">
-                <button
-                  type="button"
-                  onClick={handleGoogleSignup}
-                  className="w-full h-[58px] flex items-center justify-center mt-6
-                  bg-[#101012] border border-white/75 rounded-[19px]
-                  text-[21.5px] font-semibold text-white leading-[34px] tracking-[-0.03em]
-                  transition-all duration-200 hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled={isLoadingEmail || isLoadingGoogle}
-                >
-                  {isLoadingGoogle ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                  ) : (
-                    "Sign up with Google"
-                  )}
-                </button>
-              </div>
-
-              <p className="text-center text-sm text-white/70">
-                Already have an account?{" "}
-                <Link href="/login" className="text-white hover:underline">
-                  Sign in
-                </Link>
-              </p>
+              <button
+                type="submit"
+                className="w-full h-[52px] flex items-center justify-center rounded-xl
+                  bg-[#22D3EE] text-[#0a0a0a] font-semibold text-base
+                  transition-all duration-200 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={isLoadingEmail || isLoadingGoogle}
+              >
+                {isLoadingEmail ? (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                ) : (
+                  "Sign up"
+                )}
+              </button>
             </form>
           </div>
         </div>
 
-        {/* Mobile view - borderless design */}
+        {/* Mobile view - Google full-width strip first, then OR, then form */}
         <div className="sm:hidden w-full flex flex-col min-h-[calc(100vh-48px)] justify-between">
-          <div className="flex flex-col space-y-8 pt-10">
+          <div className="flex flex-col space-y-6 pt-10">
             <div className="flex justify-center">
               <Image
                 src="/logo.svg"
@@ -275,178 +257,129 @@ export default function SignupPage() {
               />
             </div>
 
-            <h1 className="text-mobile-xl md:text-2xl font-semibold text-white text-center">
+            <h1 className="text-xl font-semibold text-white text-center">
               Create account
             </h1>
+            <p className="text-center text-sm text-white/60 -mt-2">
+              Already have an account?{" "}
+              <Link href="/login" className="text-white hover:underline font-medium">
+                Sign in
+              </Link>
+            </p>
 
-            <form onSubmit={handleSubmit} className="space-y-6 pt-2">
+            {/* Google full-width strip first */}
+            <button
+              type="button"
+              onClick={handleGoogleSignup}
+              className="w-full h-[52px] flex items-center justify-center gap-3 rounded-xl
+                bg-[#1a1a1c] border border-white/10
+                text-base font-medium text-white
+                transition-all duration-200 hover:bg-white/[0.06] disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoadingEmail || isLoadingGoogle}
+            >
+              {isLoadingGoogle ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <>
+                  <GoogleIcon />
+                  <span>Sign up with Google</span>
+                </>
+              )}
+            </button>
+
+            <div className="relative flex items-center">
+              <div className="flex-grow border-t border-white/10" />
+              <span className="px-4 text-sm text-white/40">OR</span>
+              <div className="flex-grow border-t border-white/10" />
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
               <div className="form-group">
-                <label
-                  htmlFor="name-mobile"
-                  className="text-mobile-sm font-medium text-white/80 mb-2 block"
-                >
-                  Name
-                </label>
+                <label htmlFor="name-mobile" className="text-sm font-medium text-white/80 mb-2 block">Name</label>
                 <input
                   type="text"
                   id="name-mobile"
-                  className="w-full bg-transparent border-0 border-b border-white/20 px-0 py-2 text-mobile-base text-white focus:ring-0 focus:border-white/40 placeholder-white/30"
+                  className="w-full bg-[#0D0D0F] border border-white/10 rounded-xl px-4 py-3 text-white focus:ring-2 focus:ring-white/20 placeholder-white/40"
                   placeholder="Your name"
                   value={formData.name}
-                  onChange={(e) =>
-                    setFormData({ ...formData, name: e.target.value })
-                  }
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   required
                   disabled={isLoadingEmail || isLoadingGoogle}
                 />
               </div>
               <div className="form-group">
-                <label
-                  htmlFor="email-mobile"
-                  className="text-mobile-sm font-medium text-white/80 mb-2 block"
-                >
-                  Email
-                </label>
+                <label htmlFor="email-mobile" className="text-sm font-medium text-white/80 mb-2 block">Email</label>
                 <div className="relative">
                   <input
                     type="email"
                     id="email-mobile"
-                    className="w-full bg-transparent border-0 border-b border-white/20 px-0 py-2 text-mobile-base text-white focus:ring-0 focus:border-white/40 placeholder-white/30"
-                    placeholder="name@gmail.com"
+                    className="w-full bg-[#0D0D0F] border border-white/10 rounded-xl px-4 pl-11 py-3 text-white focus:ring-2 focus:ring-white/20 placeholder-white/40"
+                    placeholder="email address"
                     value={formData.email}
-                    onChange={(e) =>
-                      setFormData({ ...formData, email: e.target.value })
-                    }
+                    onChange={(e) => setFormData({ ...formData, email: e.target.value })}
                     required
                     disabled={isLoadingEmail || isLoadingGoogle}
                   />
+                  <Mail className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-white/50" />
                 </div>
               </div>
-
               <div className="form-group">
-                <label
-                  htmlFor="password-mobile"
-                  className="text-mobile-sm font-medium text-white/80 mb-2 block"
-                >
-                  Password
-                </label>
+                <label htmlFor="password-mobile" className="text-sm font-medium text-white/80 mb-2 block">Password</label>
                 <div className="relative">
                   <input
                     type={showPassword ? "text" : "password"}
                     id="password-mobile"
-                    className="w-full bg-transparent border-0 border-b border-white/20 px-0 py-2 text-mobile-base text-white focus:ring-0 focus:border-white/40 placeholder-white/30"
-                    placeholder="Your password"
+                    className="w-full bg-[#0D0D0F] border border-white/10 rounded-xl px-4 pl-11 py-3 text-white focus:ring-2 focus:ring-white/20 placeholder-white/40"
+                    placeholder="Password"
                     value={formData.password}
-                    onChange={(e) =>
-                      setFormData({ ...formData, password: e.target.value })
-                    }
+                    onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                     required
                     disabled={isLoadingEmail || isLoadingGoogle}
                   />
                   <button
                     type="button"
-                    className="absolute right-0 top-1/2 -translate-y-1/2 text-white/50 hover:text-white/70 transition-colors"
+                    className="absolute right-4 top-1/2 -translate-y-1/2 text-white/50 hover:text-white/70"
                     onClick={() => setShowPassword(!showPassword)}
                     disabled={isLoadingEmail || isLoadingGoogle}
                   >
-                    {showPassword ? (
-                      <EyeOff className="h-5 w-5" />
-                    ) : (
-                      <Eye className="h-5 w-5" />
-                    )}
+                    {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                   </button>
                 </div>
-                <Link
-                  href="/forgot-password"
-                  className="text-mobile-sm text-green-400 hover:text-green-300 mt-2 inline-block"
-                >
-                  Forgot Password?
-                </Link>
               </div>
-
-              <input
-                type="checkbox"
-                id="terms-mobile"
-                className="sr-only"
-                checked={formData.agreeToTerms}
-                onChange={(e) =>
-                  setFormData({ ...formData, agreeToTerms: e.target.checked })
-                }
-                required
-                disabled={isLoadingEmail || isLoadingGoogle}
-              />
-
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="terms-mobile"
+                  className="rounded border border-white/10 w-5 h-5 bg-[#0D0D0F] cursor-pointer accent-[#22D3EE]"
+                  checked={formData.agreeToTerms}
+                  onChange={(e) => setFormData({ ...formData, agreeToTerms: e.target.checked })}
+                  required
+                  disabled={isLoadingEmail || isLoadingGoogle}
+                />
+                <label htmlFor="terms-mobile" className="text-sm text-white/70">
+                  I agree with the <Link href="/terms" className="text-white hover:underline">Privacy & Policy</Link>
+                </label>
+              </div>
               <button
                 type="submit"
-                className="w-full h-[50px] flex items-center justify-center mt-4
-                bg-white rounded-full
-                text-mobile-lg font-semibold text-black
-                transition-all duration-200 hover:bg-white/90 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full h-[52px] flex items-center justify-center rounded-xl
+                  bg-[#22D3EE] text-[#0a0a0a] font-semibold text-base
+                  transition-all duration-200 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={isLoadingEmail || isLoadingGoogle}
               >
                 {isLoadingEmail ? (
-                  <Loader2 className="h-5 w-5 animate-spin text-black" />
+                  <Loader2 className="h-5 w-5 animate-spin" />
                 ) : (
                   "Sign up"
                 )}
               </button>
             </form>
-
-            <div className="relative flex items-center justify-center">
-              <div className="flex-grow border-t border-white/20"></div>
-              <span className="mx-4 text-white/50 text-mobile-sm">OR</span>
-              <div className="flex-grow border-t border-white/20"></div>
-            </div>
-
-            <button
-              type="button"
-              onClick={handleGoogleSignup}
-              className="w-full h-[50px] flex items-center justify-center
-              bg-transparent border border-white/20 rounded-full
-              text-mobile-lg font-medium text-white
-              transition-all duration-200 hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled={isLoadingEmail || isLoadingGoogle}
-            >
-              <div className="flex items-center gap-2">
-                {isLoadingGoogle ? (
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                ) : (
-                  <>
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 20 20"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19.8055 10.2298C19.8055 9.51795 19.7434 8.83835 19.6299 8.18213H10.2002V11.9624H15.6016C15.3853 13.1709 14.6875 14.1933 13.6543 14.8622V17.311H16.8564C18.7502 15.5938 19.8055 13.1499 19.8055 10.2298Z"
-                        fill="#4285F4"
-                      />
-                      <path
-                        d="M10.1999 20.0001C12.8999 20.0001 15.1499 19.115 16.8561 17.3113L13.654 14.8625C12.7754 15.4513 11.6077 15.7968 10.1999 15.7968C7.5938 15.7968 5.38819 14.0732 4.58777 11.7H1.28149V14.2318C2.9752 17.6232 6.3313 20.0001 10.1999 20.0001Z"
-                        fill="#34A853"
-                      />
-                      <path
-                        d="M4.58753 11.7002C4.18753 10.4917 4.18753 9.17 4.58753 7.9615V5.42969H1.28126C-0.119933 8.00938 -0.119933 11.6523 1.28126 14.232L4.58753 11.7002Z"
-                        fill="#FBBC05"
-                      />
-                      <path
-                        d="M10.1999 4.20378C11.6218 4.18533 12.9998 4.73503 14.0345 5.72847L16.8959 2.8671C15.1044 1.18895 12.6958 0.200905 10.1999 0.229336C6.3313 0.229336 2.9752 2.60621 1.28149 5.99761L4.58777 8.52941C5.38819 6.15621 7.5938 4.43261 10.1999 4.20378Z"
-                        fill="#EA4335"
-                      />
-                    </svg>
-                    <span>Continue with Google</span>
-                  </>
-                )}
-              </div>
-            </button>
           </div>
 
-          <div className="mt-auto pb-10 space-y-6">
-            <p className="text-center text-mobile-sm text-white/70">
+          <div className="mt-auto pb-10">
+            <p className="text-center text-sm text-white/60">
               Already have an account?{" "}
-              <Link href="/login" className="text-white hover:underline">
+              <Link href="/login" className="text-white hover:underline font-medium">
                 Sign in
               </Link>
             </p>

--- a/components/add-expense-modal.tsx
+++ b/components/add-expense-modal.tsx
@@ -1,22 +1,8 @@
 "use client";
 
 import type React from "react";
-
 import { useGroups, type Split, type Debt } from "@/stores/groups";
 import { useState, useEffect } from "react";
-import { useWallet } from "@/hooks/useWallet";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Label } from "@/components/ui/label";
-import { Loader2 } from "lucide-react";
-import { useCreateGroup } from "@/features/groups/hooks/use-create-group";
 import { useAuthStore } from "@/stores/authStore";
 import { User } from "@/api-helpers/modelSchema";
 import { useCreateExpense } from "@/features/expenses/hooks/use-create-expense";
@@ -24,16 +10,30 @@ import type { CreateExpenseParams } from "@/features/expenses/hooks/use-create-e
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "@/lib/constants";
-import Image from "next/image";
 import {
-  useGetFiatCurrencies,
   useGetAllCurrencies,
+  useGetFiatCurrencies,
 } from "@/features/currencies/hooks/use-currencies";
 import { CurrencyType } from "@/api-helpers/types";
 import ResolverSelector from "./ResolverSelector";
 import axios from "axios";
 import CurrencyDropdown from "./currency-dropdown";
 import TimeLockToggle from "./ui/TimeLockToggle";
+import { Card, Avatar, A, T } from "@/lib/splito-design";
+import { useGroupLayout } from "@/contexts/group-layout-context";
+
+const CATEGORY_OPTIONS: { emoji: string; api: string }[] = [
+  { emoji: "🍽", api: "FOOD" },
+  { emoji: "🏠", api: "ACCOMMODATION" },
+  { emoji: "🚗", api: "TRAVEL" },
+  { emoji: "✈️", api: "TRAVEL" },
+  { emoji: "🛒", api: "OTHER" },
+  { emoji: "🎟", api: "OTHER" },
+  { emoji: "🎵", api: "OTHER" },
+  { emoji: "💊", api: "OTHER" },
+  { emoji: "🏄", api: "OTHER" },
+  { emoji: "⚡️", api: "OTHER" },
+];
 
 interface AddExpenseModalProps {
   isOpen: boolean;
@@ -53,6 +53,7 @@ interface ExpenseFormData {
   tokenId?: string;
   timeLockIn: boolean;
   paidBy: string;
+  category: string;
 }
 
 // Define an interface for the expense payload (matches CreateExpenseParams)
@@ -138,16 +139,17 @@ export function AddExpenseModal({
     return `${symbol}${amount}`;
   };
 
-  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
   const [formData, setFormData] = useState<ExpenseFormData>({
     name: "",
     description: "",
     amount: "",
     splitType: "equal",
     currency: "USD",
-    currencyType: "FIAT", // Default to FIAT
-    timeLockIn: false, // Default to not locked in
+    currencyType: "FIAT",
+    timeLockIn: false,
     paidBy: user?.id || "",
+    category: "OTHER",
   });
 
   const [lockPrice, setLockPrice] = useState(true);
@@ -155,7 +157,9 @@ export function AddExpenseModal({
   const [percentages, setPercentages] = useState<{ [key: string]: number }>({});
   const expenseMutation = useCreateExpense(groupId);
 
-  // Reset to step 1 when modal opens
+  const group = useGroupLayout().group;
+  const groupName = group?.name ?? "Group";
+
   useEffect(() => {
     if (isOpen) setStep(1);
   }, [isOpen]);
@@ -286,9 +290,8 @@ export function AddExpenseModal({
       return;
     }
 
-    // Create a properly typed payload
     const payload: ExpensePayload = {
-      category: "OTHER",
+      category: formData.category || "OTHER",
       name: formData.name || "Expense",
       description: formData.description || "",
       amount: parseFloat(formData.amount),
@@ -411,8 +414,13 @@ export function AddExpenseModal({
   };
 
   const isCrypto = formData.currencyType === "TOKEN";
-  const canProceedStep1 = formData.name.trim() !== "" && formData.currency !== "";
-  const canProceedStep2 = formData.amount !== "" && Number(formData.amount) > 0 && formData.paidBy !== "";
+  const canProceedStep1 = formData.name.trim() !== "";
+  const canProceedStep2 = formData.currency !== "";
+  const canProceedStep3 =
+    formData.amount !== "" &&
+    Number(formData.amount) > 0 &&
+    formData.paidBy !== "";
+  const canSubmit = validateSplits();
 
   // Only allow tokens (with chainId) as resolver
   const handleResolverChange = (option: Option | undefined) => {
@@ -424,481 +432,729 @@ export function AddExpenseModal({
     setResolver(option);
   };
 
-  return (
-    <div className="fixed inset-0 z-50 h-screen w-screen">
-      <div
-        className="fixed inset-0 bg-black/80 brightness-50"
-        onClick={onClose}
-      />
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[550px] max-h-[90vh] overflow-auto">
-        <div className="relative z-10 rounded-[20px] bg-black p-6 border border-white/20">
-          {/* Progress indicator */}
-          <div className="flex gap-1.5 mb-6">
-            {([1, 2, 3] as const).map((s) => (
-              <div
-                key={s}
-                className={`h-1 flex-1 rounded-full ${
-                  step >= s ? "bg-[#53E45E]" : "bg-white/20"
-                }`}
-              />
-            ))}
-          </div>
-          <form onSubmit={handleSubmit} className="space-y-6">
-            {/* Step 1: What's the expense? — Name + Currency */}
-            {step === 1 && (
-              <>
-                <h2 className="text-2xl font-medium text-white mb-2">
-                  What&apos;s the expense?
-                </h2>
-                <div>
-                  <input
-                    type="text"
-                    value={formData.name}
-                    onChange={(e) =>
-                      setFormData((prev) => ({ ...prev, name: e.target.value }))
-                    }
-                    placeholder="e.g. Dinner, Airbnb, Groceries..."
-                    className="w-full h-12 px-4 rounded-xl bg-[#17171A] text-white border border-white/10 focus:outline-none focus:ring-1 focus:ring-white/20 placeholder:text-white/50"
-                  />
-                </div>
-                <div>
-                  <label className="text-white/60 text-xs font-medium uppercase tracking-wider block mb-2">
-                    Currency
-                  </label>
-                  <CurrencyDropdown
-                    selectedCurrencies={
-                      formData.currency ? [formData.currency] : []
-                    }
-                    setSelectedCurrencies={handleCurrencySelect}
-                    showFiatCurrencies={true}
-                    disableChainCurrencies={false}
-                    mode="single"
-                    placeholder="Select currency..."
-                  />
-                </div>
-                <div className="flex justify-between items-center pt-2">
-                  <Button
-                    type="button"
-                    onClick={onClose}
-                    variant="ghost"
-                    className="text-white/80 hover:text-white hover:bg-white/10"
-                  >
-                    Close
-                  </Button>
-                  <Button
-                    type="button"
-                    onClick={() => setStep(2)}
-                    disabled={!canProceedStep1}
-                    className="rounded-full bg-white/15 text-white hover:bg-white/25 disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Continue →
-                  </Button>
-                </div>
-              </>
-            )}
+  const inp = {
+    width: "100%",
+    background: "rgba(255,255,255,0.05)",
+    border: "1.5px solid rgba(255,255,255,0.09)",
+    borderRadius: 14,
+    padding: "12px 16px",
+    color: "#fff",
+    fontSize: 14,
+    outline: "none",
+    boxSizing: "border-box" as const,
+    fontFamily: "inherit",
+  };
+  const lbl = {
+    color: T.label,
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase" as const,
+    marginBottom: 8,
+    display: "block",
+  };
+  const StepBackBtn = ({ onClick }: { onClick: () => void }) => {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        style={{
+          flex: 1,
+          padding: 13,
+          background: "rgba(255,255,255,0.05)",
+          color: T.body,
+          border: "1px solid rgba(255,255,255,0.09)",
+          borderRadius: 14,
+          fontSize: 14,
+          fontWeight: 700,
+          cursor: "pointer",
+          fontFamily: "inherit",
+        }}
+      >
+        ← Back
+      </button>
+    );
+  };
+  const PrimaryBtn = ({
+    children,
+    onClick,
+    disabled = false,
+    style = {},
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    style?: React.CSSProperties;
+  }) => {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        style={{
+          flex: 2,
+          padding: 13,
+          background: disabled ? "rgba(255,255,255,0.05)" : A,
+          color: disabled ? "#555" : "#0a0a0a",
+          border: "none",
+          borderRadius: 14,
+          fontSize: 14,
+          fontWeight: 800,
+          cursor: disabled ? "default" : "pointer",
+          fontFamily: "inherit",
+          transition: "all 0.2s",
+          ...style,
+        }}
+      >
+        {children}
+      </button>
+    );
+  };
 
-            {/* Step 2: Amount & who paid — Amount + Paid by + Lock-in (crypto only) */}
-            {step === 2 && (
-              <>
-                <h2 className="text-2xl font-medium text-white mb-2">
-                  Amount & who paid
-                </h2>
-                <div>
-                  <div className="relative flex items-center rounded-xl bg-[#17171A] border border-white/10 overflow-hidden">
-                    <span className="pl-4 text-[#53E45E] font-medium">
-                      {getCurrencySymbol(formData.currency)}{" "}
-                    </span>
-                    <input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      value={formData.amount}
-                      onChange={(e) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          amount: e.target.value,
-                        }))
-                      }
-                      placeholder="0.00"
-                      className="flex-1 h-14 px-2 bg-transparent text-[#53E45E] font-medium text-lg focus:outline-none focus:ring-0 placeholder:text-[#53E45E]/60"
-                    />
-                  </div>
+  const overlayStyle = {
+    position: "fixed" as const,
+    inset: 0,
+    background: "rgba(0,0,0,0.88)",
+    backdropFilter: "blur(16px)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 200,
+    padding: 24,
+  };
+
+  return (
+    <div onClick={onClose} style={overlayStyle}>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
+          border: "1px solid rgba(255,255,255,0.09)",
+          borderRadius: 28,
+          width: "100%",
+          maxWidth: 460,
+          padding: "28px 28px 32px",
+          maxHeight: "90vh",
+          overflowY: "auto",
+          boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 24,
+          }}
+        >
+          <div>
+            <p
+              style={{
+                color: "#fff",
+                fontSize: 20,
+                fontWeight: 800,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              Add Expense
+            </p>
+            <p style={{ color: T.mid, fontSize: 12, marginTop: 3 }}>{groupName}</p>
+            <div style={{ display: "flex", gap: 5, marginTop: 12 }}>
+              {[1, 2, 3, 4].map((s) => (
+                <div
+                  key={s}
+                  style={{
+                    height: 3,
+                    width: 26,
+                    borderRadius: 99,
+                    background: step >= s ? A : "#2a2a2a",
+                    transition: "background 0.3s",
+                    boxShadow: step >= s ? `0 0 8px ${A}88` : "none",
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: "rgba(255,255,255,0.07)",
+              border: "1px solid rgba(255,255,255,0.1)",
+              color: T.soft,
+              width: 34,
+              height: 34,
+              borderRadius: "50%",
+              cursor: "pointer",
+              fontSize: 18,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          {/* Step 1: Description + Category */}
+          {step === 1 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+              <div>
+                <label style={lbl}>Description</label>
+                <input
+                  placeholder="e.g. Dinner, Hotel, Taxi…"
+                  value={formData.name}
+                  onChange={(e) =>
+                    setFormData((prev) => ({ ...prev, name: e.target.value }))
+                  }
+                  style={inp}
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label style={lbl}>Category</label>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(5, 1fr)",
+                    gap: 8,
+                  }}
+                >
+                  {CATEGORY_OPTIONS.map(({ emoji, api }) => {
+                    const sel = formData.category === api;
+                    return (
+                      <button
+                        key={emoji + api}
+                        type="button"
+                        onClick={() =>
+                          setFormData((prev) => ({ ...prev, category: api }))
+                        }
+                        style={{
+                          background: sel ? `${A}15` : "rgba(255,255,255,0.04)",
+                          border: `1.5px solid ${sel ? A + "44" : "rgba(255,255,255,0.08)"}`,
+                          borderRadius: 14,
+                          padding: "12px 0",
+                          fontSize: 20,
+                          cursor: "pointer",
+                          transition: "all 0.2s",
+                          boxShadow: sel ? `0 0 12px ${A}22` : "none",
+                        }}
+                      >
+                        {emoji}
+                      </button>
+                    );
+                  })}
                 </div>
-                <div>
-                  <label className="text-white/60 text-xs font-medium uppercase tracking-wider block mb-2">
-                    Paid by
-                  </label>
-                  <div className="flex flex-wrap gap-2">
-                    {members.map((member) => (
+              </div>
+              <PrimaryBtn
+                onClick={() => setStep(2)}
+                disabled={!canProceedStep1}
+                style={{ flex: "none" }}
+              >
+                {canProceedStep1 ? "Continue →" : "Enter a description"}
+              </PrimaryBtn>
+            </div>
+          )}
+
+          {/* Step 2: Spent in (currency) */}
+          {step === 2 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+              <div
+                style={{
+                  background: "rgba(255,255,255,0.04)",
+                  borderRadius: 14,
+                  padding: "14px 16px",
+                  border: "1px solid rgba(255,255,255,0.07)",
+                }}
+              >
+                <p
+                  style={{
+                    color: T.mid,
+                    fontSize: 12,
+                    marginBottom: 2,
+                    fontWeight: 600,
+                  }}
+                >
+                  Group default
+                </p>
+                <p
+                  style={{
+                    color: T.body,
+                    fontSize: 13,
+                    fontWeight: 700,
+                  }}
+                >
+                  {formData.currency || "USD"}{" "}
+                  <span style={{ color: T.sub, fontWeight: 400 }}>
+                    — change below if needed
+                  </span>
+                </p>
+              </div>
+              <div>
+                <label style={lbl}>Spent in</label>
+                <CurrencyDropdown
+                  selectedCurrencies={
+                    formData.currency ? [formData.currency] : []
+                  }
+                  setSelectedCurrencies={handleCurrencySelect}
+                  showFiatCurrencies={true}
+                  disableChainCurrencies={false}
+                  mode="single"
+                  placeholder="Select currency..."
+                />
+              </div>
+              {formData.currencyType === "FIAT" && formData.currency && (
+                <div
+                  style={{
+                    background: "rgba(52,211,153,0.06)",
+                    border: "1px solid rgba(52,211,153,0.15)",
+                    borderRadius: 14,
+                    padding: "12px 16px",
+                    display: "flex",
+                    gap: 10,
+                  }}
+                >
+                  <span style={{ color: "#34D399", fontSize: 14 }}>ℹ</span>
+                  <p
+                    style={{
+                      color: "#34D399aa",
+                      fontSize: 12,
+                      lineHeight: 1.6,
+                    }}
+                  >
+                    Fiat amounts will be converted to the group&apos;s settlement
+                    currency at time of settling.
+                  </p>
+                </div>
+              )}
+              <div style={{ display: "flex", gap: 8 }}>
+                <StepBackBtn onClick={() => setStep(1)} />
+                <PrimaryBtn onClick={() => setStep(3)}>Continue →</PrimaryBtn>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: Amount + Paid by */}
+          {step === 3 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+              <div>
+                <label style={lbl}>
+                  Amount{" "}
+                  <span style={{ color: A }}>({formData.currency || "USD"})</span>
+                </label>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    background: "rgba(255,255,255,0.05)",
+                    border: "1.5px solid rgba(255,255,255,0.09)",
+                    borderRadius: 14,
+                    padding: "14px 16px",
+                  }}
+                >
+                  <span
+                    style={{
+                      color: A,
+                      fontSize: 20,
+                      fontWeight: 800,
+                      marginRight: 10,
+                      minWidth: 24,
+                    }}
+                  >
+                    {getCurrencySymbol(formData.currency)}
+                  </span>
+                  <input
+                    type="number"
+                    placeholder="0.00"
+                    value={formData.amount}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        amount: e.target.value,
+                      }))
+                    }
+                    style={{
+                      background: "none",
+                      border: "none",
+                      color: "#fff",
+                      fontSize: 26,
+                      fontWeight: 800,
+                      outline: "none",
+                      width: "100%",
+                      fontFamily: "inherit",
+                    }}
+                    autoFocus
+                  />
+                </div>
+              </div>
+              <div>
+                <label style={lbl}>Paid by</label>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `repeat(${Math.min(members.length, 4)}, 1fr)`,
+                    gap: 8,
+                  }}
+                >
+                  {members.map((member) => {
+                    const init =
+                      member.id === user?.id
+                        ? "Y"
+                        : (member.name || "?")
+                            .split(" ")
+                            .map((n) => n[0])
+                            .join("")
+                            .slice(0, 2)
+                            .toUpperCase();
+                    const isSelected = formData.paidBy === member.id;
+                    return (
                       <button
                         key={member.id}
                         type="button"
                         onClick={() =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            paidBy: member.id,
-                          }))
+                          setFormData((prev) => ({ ...prev, paidBy: member.id }))
                         }
-                        className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border transition-colors ${
-                          formData.paidBy === member.id
-                            ? "border-[#53E45E] bg-[#53E45E]/10 text-white"
-                            : "border-white/20 bg-[#17171A] text-white hover:border-white/30"
-                        }`}
+                        style={{
+                          padding: "10px 4px",
+                          background: isSelected ? `${A}18` : "rgba(255,255,255,0.04)",
+                          border: `1.5px solid ${isSelected ? A + "55" : "rgba(255,255,255,0.08)"}`,
+                          borderRadius: 14,
+                          cursor: "pointer",
+                          display: "flex",
+                          flexDirection: "column",
+                          alignItems: "center",
+                          gap: 6,
+                          transition: "all 0.2s",
+                          boxShadow: isSelected ? `0 0 14px ${A}22` : "none",
+                        }}
                       >
-                        <div className="h-8 w-8 rounded-full bg-white/20 flex items-center justify-center text-sm font-medium text-white">
+                        <div
+                          style={{
+                            width: 34,
+                            height: 34,
+                            borderRadius: "50%",
+                            background: isSelected ? A : "rgba(255,255,255,0.08)",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            fontSize: 10,
+                            fontWeight: 800,
+                            color: isSelected ? "#0a0a0a" : T.body,
+                          }}
+                        >
+                          {init}
+                        </div>
+                        <span
+                          style={{
+                            color: isSelected ? A : T.sub,
+                            fontSize: 10,
+                            fontWeight: 700,
+                          }}
+                        >
                           {member.id === user?.id
+                            ? "You"
+                            : (member.name || "?").split(" ")[0]}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <StepBackBtn onClick={() => setStep(2)} />
+                <PrimaryBtn
+                  onClick={() => setStep(4)}
+                  disabled={!canProceedStep3}
+                >
+                  Continue →
+                </PrimaryBtn>
+              </div>
+            </div>
+          )}
+
+          {/* Step 4: Split method + participants (excluding payer) + Lock In + submit */}
+          {step === 4 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+              <div>
+                <label style={lbl}>Split method</label>
+                <div style={{ display: "flex", gap: 8 }}>
+                  {(["equal", "custom", "percentage"] as const).map((type) => {
+                    const sel = formData.splitType === type;
+                    const label =
+                      type === "equal"
+                        ? "Equal"
+                        : type === "custom"
+                          ? "Custom"
+                          : "Percentage";
+                    return (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() =>
+                          setFormData((prev) => ({ ...prev, splitType: type }))
+                        }
+                        style={{
+                          flex: 1,
+                          padding: "12px 14px",
+                          background: sel ? `${A}18` : "rgba(255,255,255,0.04)",
+                          border: `1.5px solid ${sel ? A + "44" : "rgba(255,255,255,0.08)"}`,
+                          borderRadius: 14,
+                          color: sel ? A : T.body,
+                          fontSize: 13,
+                          fontWeight: 700,
+                          cursor: "pointer",
+                          transition: "all 0.2s",
+                        }}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div>
+                <label style={lbl}>Participants</label>
+                <Card
+                  style={{
+                    padding: 0,
+                    overflow: "hidden",
+                    background: "rgba(255,255,255,0.03)",
+                    border: "1px solid rgba(255,255,255,0.08)",
+                  }}
+                >
+                  <div
+                    style={{
+                      maxHeight: 200,
+                      overflowY: "auto",
+                      padding: "8px 0",
+                    }}
+                  >
+                    {members
+                      .filter((m) => m.id !== formData.paidBy)
+                      .map((member) => {
+                        const split = splits.find((s) => s.address === member.id);
+                        const amount = split?.amount || 0;
+                        const percentage = percentages[member.id] ?? 0;
+                        const isEqual = formData.splitType === "equal";
+                        const init =
+                          member.id === user?.id
                             ? "Y"
                             : (member.name || "?")
                                 .split(" ")
                                 .map((n) => n[0])
                                 .join("")
                                 .slice(0, 2)
-                                .toUpperCase()}
-                        </div>
-                        <span>
-                          {member.id === user?.id ? "You" : member.name}
-                        </span>
-                      </button>
-                    ))}
+                                .toUpperCase();
+                        return (
+                          <div
+                            key={member.id}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "space-between",
+                              padding: "12px 18px",
+                              borderBottom:
+                                "1px solid rgba(255,255,255,0.06)",
+                              gap: 12,
+                            }}
+                          >
+                            <div
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 10,
+                                minWidth: 0,
+                              }}
+                            >
+                              <Avatar
+                                size={28}
+                                init={init}
+                                color={T.body}
+                              />
+                              <span
+                                style={{
+                                  color: T.body,
+                                  fontSize: 14,
+                                  fontWeight: 600,
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {member.id === user?.id ? "You" : member.name}
+                              </span>
+                            </div>
+                            <div
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 6,
+                              }}
+                            >
+                              {isEqual ? (
+                                <span
+                                  style={{
+                                    color: T.sub,
+                                    fontSize: 12,
+                                    fontWeight: 600,
+                                  }}
+                                >
+                                  Equal
+                                </span>
+                              ) : formData.splitType === "percentage" ? (
+                                <input
+                                  type="number"
+                                  min={0}
+                                  max={100}
+                                  value={percentage || ""}
+                                  onChange={(e) => {
+                                    const value = Number(e.target.value);
+                                    if (value >= 0 && value <= 100) {
+                                      updatePercentage(member.id, value);
+                                    }
+                                  }}
+                                  style={{
+                                    width: 56,
+                                    padding: "6px 8px",
+                                    background: "rgba(255,255,255,0.06)",
+                                    border: "1px solid rgba(255,255,255,0.08)",
+                                    borderRadius: 8,
+                                    color: "#fff",
+                                    fontSize: 12,
+                                    textAlign: "right",
+                                    outline: "none",
+                                  }}
+                                />
+                              ) : (
+                                <input
+                                  type="number"
+                                  min={0}
+                                  step={0.01}
+                                  value={amount || ""}
+                                  onChange={(e) =>
+                                    updateCustomSplit(
+                                      member.id,
+                                      Number(e.target.value)
+                                    )
+                                  }
+                                  style={{
+                                    width: 72,
+                                    padding: "6px 8px",
+                                    background: "rgba(255,255,255,0.06)",
+                                    border: "1px solid rgba(255,255,255,0.08)",
+                                    borderRadius: 8,
+                                    color: "#fff",
+                                    fontSize: 12,
+                                    textAlign: "right",
+                                    outline: "none",
+                                  }}
+                                />
+                              )}
+                              {!isEqual && (
+                                <span
+                                  style={{
+                                    color: T.sub,
+                                    fontSize: 11,
+                                    width: 18,
+                                  }}
+                                >
+                                  {formData.splitType === "percentage"
+                                    ? "%"
+                                    : getCurrencySymbol(formData.currency)}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
                   </div>
-                </div>
-                {isCrypto && (
-                  <div className="pt-2">
-                    <TimeLockToggle
-                      value={formData.timeLockIn}
-                      onChange={(val) =>
-                        setFormData((prev) => ({ ...prev, timeLockIn: val }))
-                      }
-                      label="Lock exchange rate (Fix the value at current exchange rate)"
-                    />
-                  </div>
-                )}
-                <div className="flex justify-between items-center pt-2">
-                  <div className="flex items-center gap-2">
-                    <Button
-                      type="button"
-                      onClick={onClose}
-                      variant="ghost"
-                      className="text-white/80 hover:text-white hover:bg-white/10"
-                    >
-                      Close
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={() => setStep(1)}
-                      variant="ghost"
-                      className="text-white/80 hover:text-white hover:bg-white/10"
-                    >
-                      ← Back
-                    </Button>
-                  </div>
-                  <Button
-                    type="button"
-                    onClick={() => setStep(3)}
-                    disabled={!canProceedStep2}
-                    className="rounded-full bg-white/15 text-white hover:bg-white/25 disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Continue →
-                  </Button>
-                </div>
-              </>
-            )}
-
-            {/* Step 3: How to split */}
-            {step === 3 && (
-              <>
-                <h2 className="text-2xl font-medium text-white mb-2">
-                  How to split
-                </h2>
-                <div className="flex gap-2">
-                  {(["equal", "custom", "percentage"] as const).map((type) => (
-                    <button
-                      key={type}
-                      type="button"
-                      onClick={() =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          splitType: type,
-                        }))
-                      }
-                      className={`flex-1 py-2.5 px-3 rounded-xl border font-medium capitalize ${
-                        formData.splitType === type
-                          ? "border-[#53E45E] bg-[#53E45E]/10 text-white"
-                          : "border-white/20 bg-[#17171A] text-white hover:border-white/30"
-                      }`}
-                    >
-                      {type === "equal"
-                        ? "Equal"
-                        : type === "percentage"
-                          ? "Percentage"
-                          : "Custom"}
-                    </button>
-                  ))}
-                </div>
-                {/* Member splits list */}
-                <div className="max-h-[200px] overflow-y-auto space-y-4 pr-2 mt-4">
-              {members.map((member) => {
-                const split = splits.find((s) => s.address === member.id);
-                const amount = split?.amount || 0;
-                const percentage = percentages[member.id] || 0;
-                return (
-                  <div
-                    key={member.id}
-                    className="flex items-center justify-between"
-                  >
-                    <div className="flex items-center space-x-3">
-                      <div className="h-10 w-10 overflow-hidden rounded-full">
-                        <Image
-                          src={
-                            member.image ||
-                            `https://api.dicebear.com/9.x/identicon/svg?seed=${member.id}`
-                          }
-                          alt={member.name || "User"}
-                          width={40}
-                          height={40}
-                          className="h-full w-full object-cover"
-                          onError={(e) => {
-                            const target = e.target as HTMLImageElement;
-                            target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${member.id}`;
-                          }}
-                        />
-                      </div>
-                      <span className="text-white">
-                        {member.id === user?.id ? "You" : member.name}
-                      </span>
-                    </div>
-
-                    {formData.splitType === "custom" ? (
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="number"
-                          value={amount || ""}
-                          onChange={(e) =>
-                            updateCustomSplit(member.id, Number(e.target.value))
-                          }
-                          className="w-20 h-8 px-2 rounded-lg bg-[#17171A] text-white border border-white/20 focus:outline-none focus:ring-1 focus:ring-white/40"
-                          placeholder="0.00"
-                        />
-                        <span className="text-white/70 text-sm">
-                          {formData.currency}
-                        </span>
-                      </div>
-                    ) : formData.splitType === "percentage" ? (
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="number"
-                          value={percentage || ""}
-                          onChange={(e) => {
-                            const value = Number(e.target.value);
-                            if (value >= 0 && value <= 100) {
-                              updatePercentage(member.id, value);
-                            }
-                          }}
-                          className="w-16 h-8 px-2 rounded-lg bg-[#17171A] text-white border border-white/20 focus:outline-none focus:ring-1 focus:ring-white/40"
-                          placeholder="0"
-                        />
-                        <span className="text-white/70 text-sm">%</span>
-                        <span className="text-white/70 text-sm ml-1">
-                          ({formatCurrency(amount, formData.currency)})
-                        </span>
-                      </div>
-                    ) : (
-                      <div className="bg-[#17171A] rounded-lg px-3 py-1 min-w-[60px] text-[#53E45E] font-medium">
-                        {formatCurrency(amount, formData.currency)}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-
-                {/* Total summary for custom and percentage splits */}
+                </Card>
+              </div>
               {(formData.splitType === "custom" ||
                 formData.splitType === "percentage") && (
-                <div className="flex justify-between items-center mt-4 border-t border-white/10 pt-3">
-                  <span className="text-white">Total Split</span>
-                  <div className="flex items-center">
-                    <span
-                      className={`text-white ${
-                        validateSplits() ? "" : "text-red-500"
-                      }`}
-                    >
-                      {formatCurrency(
-                        splits.reduce(
-                          (sum, split) => sum + (split.amount || 0),
-                          0
-                        ),
-                        formData.currency
-                      )}{" "}
-                      /{" "}
-                      {formatCurrency(
-                        Number(formData.amount),
-                        formData.currency
-                      )}
-                    </span>
-
-                    {formData.splitType === "percentage" && (
-                      <span
-                        className={`ml-3 text-sm ${
-                          Math.abs(
-                            Object.values(percentages).reduce(
-                              (sum, p) => sum + p,
-                              0
-                            ) - 100
-                          ) < 0.01
-                            ? "text-green-500"
-                            : "text-red-500"
-                        }`}
-                      >
-                        (
-                        {Object.values(percentages)
-                          .reduce((sum, p) => sum + p, 0)
-                          .toFixed(0)}
-                        %)
-                      </span>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Quick actions for distribution */}
-              {(formData.splitType === "custom" ||
-                formData.splitType === "percentage") && (
-                <div className="flex gap-2 mt-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (formData.splitType === "custom") {
-                        // Distribute equally
-                        const equalAmount =
-                          Number(formData.amount) / members.length;
-                        members.forEach((member) => {
-                          updateCustomSplit(member.id, equalAmount);
-                        });
-                      } else {
-                        // Reset to equal percentages
-                        const equalPercentage = 100 / members.length;
-                        members.forEach((member) => {
-                          updatePercentage(member.id, equalPercentage);
-                        });
-                      }
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    padding: "10px 0",
+                    borderTop: "1px solid rgba(255,255,255,0.06)",
+                    gap: 8,
+                  }}
+                >
+                  <span style={{ color: T.body, fontSize: 12, fontWeight: 600 }}>
+                    Total split
+                  </span>
+                  <span
+                    style={{
+                      color: canSubmit ? A : "#ef4444",
+                      fontSize: 12,
+                      fontWeight: 700,
                     }}
-                    className="text-xs text-white/70 px-2 py-1 bg-[#17171A] rounded hover:bg-[#252525] transition-colors"
                   >
-                    Equal
-                  </button>
-                  {formData.paidBy && (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        if (formData.splitType === "custom") {
-                          // Paid by one, rest split the amount
-                          const otherMembers = members.filter(
-                            (m) => m.id !== formData.paidBy
-                          );
-                          const equalAmount =
-                            Number(formData.amount) / otherMembers.length;
-
-                          members.forEach((member) => {
-                            if (member.id === formData.paidBy) {
-                              updateCustomSplit(member.id, 0);
-                            } else {
-                              updateCustomSplit(member.id, equalAmount);
-                            }
-                          });
-                        } else {
-                          // Percentage version
-                          const otherMembers = members.filter(
-                            (m) => m.id !== formData.paidBy
-                          );
-                          const equalPercentage = 100 / otherMembers.length;
-
-                          members.forEach((member) => {
-                            if (member.id === formData.paidBy) {
-                              updatePercentage(member.id, 0);
-                            } else {
-                              updatePercentage(member.id, equalPercentage);
-                            }
-                          });
-                        }
-                      }}
-                      className="text-xs text-white/70 px-2 py-1 bg-[#17171A] rounded hover:bg-[#252525] transition-colors"
-                    >
-                      Paid by{" "}
-                      {formData.paidBy === user?.id
-                        ? "you"
-                        : getPaidByUserName(formData.paidBy)}
-                    </button>
-                  )}
+                    {formatCurrency(
+                      splits.reduce((sum, s) => sum + (s.amount || 0), 0),
+                      formData.currency
+                    )}{" "}
+                    / {formatCurrency(Number(formData.amount), formData.currency)}
+                    {formData.splitType === "percentage" &&
+                      ` (${Object.values(percentages).reduce((a, b) => a + b, 0).toFixed(0)}%)`}
+                  </span>
                 </div>
               )}
-                </div>
-
+              {isCrypto && (
                 <div>
-                  <label className="text-white/60 text-xs font-medium uppercase tracking-wider block mb-2">
-                    Description (optional)
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.description}
-                    onChange={(e) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        description: e.target.value,
-                      }))
+                  <TimeLockToggle
+                    value={formData.timeLockIn}
+                    onChange={(val) =>
+                      setFormData((prev) => ({ ...prev, timeLockIn: val }))
                     }
-                    placeholder="What's this expense for?"
-                    className="w-full h-12 px-4 rounded-xl bg-[#17171A] text-white border border-white/10 focus:outline-none focus:ring-1 focus:ring-white/20 placeholder:text-white/50"
+                    label="Lock exchange rate (Fix the value at current exchange rate)"
                   />
                 </div>
-
+              )}
+              {isCrypto && (
                 <div>
-                  <label className="text-white mb-2 block text-base font-semibold">
-                    Settle in
-                  </label>
+                  <label style={lbl}>Settle in</label>
                   <ResolverSelector
                     value={resolver}
                     onChange={handleResolverChange}
                   />
                 </div>
-
-                <div className="flex justify-between items-center pt-4">
-                  <div className="flex items-center gap-2">
-                    <Button
-                      type="button"
-                      onClick={onClose}
-                      variant="ghost"
-                      className="text-white/80 hover:text-white hover:bg-white/10"
-                    >
-                      Close
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={() => setStep(2)}
-                      variant="ghost"
-                      className="text-white/80 hover:text-white hover:bg-white/10"
-                    >
-                      ← Back
-                    </Button>
-                  </div>
-                  <Button
-                    type="submit"
-                    className="rounded-full bg-[#53E45E] text-white font-medium hover:bg-[#53E45E]/90 px-6 disabled:opacity-50"
-                    disabled={expenseMutation.isPending || !validateSplits()}
-                  >
-                    {expenseMutation.isPending ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Adding...
-                      </>
-                    ) : (
-                      "Add Expense"
-                    )}
-                  </Button>
-                </div>
-              </>
-            )}
-          </form>
-        </div>
+              )}
+              <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                <StepBackBtn onClick={() => setStep(3)} />
+                <button
+                  type="submit"
+                  disabled={!canSubmit || expenseMutation.isPending}
+                  style={{
+                    flex: 2,
+                    padding: 13,
+                    background:
+                      !canSubmit || expenseMutation.isPending
+                        ? "rgba(255,255,255,0.05)"
+                        : A,
+                    color:
+                      !canSubmit || expenseMutation.isPending ? "#555" : "#0a0a0a",
+                    border: "none",
+                    borderRadius: 14,
+                    fontSize: 14,
+                    fontWeight: 800,
+                    cursor:
+                      canSubmit && !expenseMutation.isPending
+                        ? "pointer"
+                        : "default",
+                    fontFamily: "inherit",
+                    transition: "all 0.2s",
+                  }}
+                >
+                  {expenseMutation.isPending ? "Adding…" : "Add Expense ✓"}
+                </button>
+              </div>
+            </div>
+          )}
+        </form>
       </div>
     </div>
   );

--- a/components/add-expense-modal.tsx
+++ b/components/add-expense-modal.tsx
@@ -18,7 +18,6 @@ import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
 import { useCreateGroup } from "@/features/groups/hooks/use-create-group";
 import { useAuthStore } from "@/stores/authStore";
-import { X } from "lucide-react";
 import { User } from "@/api-helpers/modelSchema";
 import { useCreateExpense } from "@/features/expenses/hooks/use-create-expense";
 import type { CreateExpenseParams } from "@/features/expenses/hooks/use-create-expense";
@@ -139,6 +138,7 @@ export function AddExpenseModal({
     return `${symbol}${amount}`;
   };
 
+  const [step, setStep] = useState<1 | 2 | 3>(1);
   const [formData, setFormData] = useState<ExpenseFormData>({
     name: "",
     description: "",
@@ -154,6 +154,11 @@ export function AddExpenseModal({
   const [splits, setSplits] = useState<Split[]>([]);
   const [percentages, setPercentages] = useState<{ [key: string]: number }>({});
   const expenseMutation = useCreateExpense(groupId);
+
+  // Reset to step 1 when modal opens
+  useEffect(() => {
+    if (isOpen) setStep(1);
+  }, [isOpen]);
 
   const allChainTokenOptions = useAllChainsTokens();
   const [resolver, setResolver] = useState<Option | undefined>(undefined);
@@ -284,7 +289,7 @@ export function AddExpenseModal({
     // Create a properly typed payload
     const payload: ExpensePayload = {
       category: "OTHER",
-      name: formData.description || "Expense",
+      name: formData.name || "Expense",
       description: formData.description || "",
       amount: parseFloat(formData.amount),
       currency: formData.currency,
@@ -385,6 +390,30 @@ export function AddExpenseModal({
     return member?.name || "You";
   };
 
+  // When currency is selected (step 1), sync currencyType, chainId, tokenId from API currency
+  const handleCurrencySelect = (currencies: string[]) => {
+    const currencyId = currencies[0] || "";
+    const currency = allCurrencies?.currencies?.find((c) => c.id === currencyId);
+    setFormData((prev) => {
+      const next = { ...prev, currency: currencyId };
+      if (currency) {
+        next.currencyType = currency.type === "FIAT" ? "FIAT" : "TOKEN";
+        if (next.currencyType === "TOKEN") {
+          next.chainId = currency.chainId ?? undefined;
+          next.tokenId = currency.id;
+        } else {
+          next.chainId = undefined;
+          next.tokenId = undefined;
+        }
+      }
+      return next;
+    });
+  };
+
+  const isCrypto = formData.currencyType === "TOKEN";
+  const canProceedStep1 = formData.name.trim() !== "" && formData.currency !== "";
+  const canProceedStep2 = formData.amount !== "" && Number(formData.amount) > 0 && formData.paidBy !== "";
+
   // Only allow tokens (with chainId) as resolver
   const handleResolverChange = (option: Option | undefined) => {
     if (option && !option.chainId) {
@@ -403,162 +432,211 @@ export function AddExpenseModal({
       />
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[550px] max-h-[90vh] overflow-auto">
         <div className="relative z-10 rounded-[20px] bg-black p-6 border border-white/20">
-          <h2 className="text-2xl font-medium text-white mb-6">Add Expense</h2>
-
+          {/* Progress indicator */}
+          <div className="flex gap-1.5 mb-6">
+            {([1, 2, 3] as const).map((s) => (
+              <div
+                key={s}
+                className={`h-1 flex-1 rounded-full ${
+                  step >= s ? "bg-[#53E45E]" : "bg-white/20"
+                }`}
+              />
+            ))}
+          </div>
           <form onSubmit={handleSubmit} className="space-y-6">
-            <div>
-              <label className="text-white mb-2 block">Split Amount</label>
-              <div className="relative">
-                <input
-                  type="number"
-                  value={formData.amount}
-                  onChange={(e) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      amount: e.target.value,
-                    }))
-                  }
-                  placeholder={getCurrencyPlaceholder(formData.currency)}
-                  className="w-full h-12 px-4 rounded-lg bg-[#17171A] text-white border-none focus:outline-none focus:ring-1 focus:ring-white/20"
-                  required
-                />
-              </div>
-            </div>
+            {/* Step 1: What's the expense? — Name + Currency */}
+            {step === 1 && (
+              <>
+                <h2 className="text-2xl font-medium text-white mb-2">
+                  What&apos;s the expense?
+                </h2>
+                <div>
+                  <input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, name: e.target.value }))
+                    }
+                    placeholder="e.g. Dinner, Airbnb, Groceries..."
+                    className="w-full h-12 px-4 rounded-xl bg-[#17171A] text-white border border-white/10 focus:outline-none focus:ring-1 focus:ring-white/20 placeholder:text-white/50"
+                  />
+                </div>
+                <div>
+                  <label className="text-white/60 text-xs font-medium uppercase tracking-wider block mb-2">
+                    Currency
+                  </label>
+                  <CurrencyDropdown
+                    selectedCurrencies={
+                      formData.currency ? [formData.currency] : []
+                    }
+                    setSelectedCurrencies={handleCurrencySelect}
+                    showFiatCurrencies={true}
+                    disableChainCurrencies={false}
+                    mode="single"
+                    placeholder="Select currency..."
+                  />
+                </div>
+                <div className="flex justify-between items-center pt-2">
+                  <Button
+                    type="button"
+                    onClick={onClose}
+                    variant="ghost"
+                    className="text-white/80 hover:text-white hover:bg-white/10"
+                  >
+                    Close
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => setStep(2)}
+                    disabled={!canProceedStep1}
+                    className="rounded-full bg-white/15 text-white hover:bg-white/25 disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Continue →
+                  </Button>
+                </div>
+              </>
+            )}
 
-            <div>
-              <label className="text-white mb-2 block">Spent in </label>
-              {formData.currencyType === "FIAT" ? (
-                <CurrencyDropdown
-                  selectedCurrencies={
-                    formData.currency ? [formData.currency] : []
-                  }
-                  setSelectedCurrencies={(currencies) => {
-                    setFormData((prev) => ({
-                      ...prev,
-                      currency: currencies[0] || "",
-                    }));
-                  }}
-                  showFiatCurrencies={true}
-                  mode="single"
-                />
-              ) : (
-                <Select
-                  value={formData.currency}
-                  onValueChange={(value) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      currency: value,
-                    }))
-                  }
-                >
-                  <SelectTrigger className="w-full h-12 bg-[#17171A] text-white border-none focus:ring-1 focus:ring-white/20">
-                    <SelectValue placeholder="Select currency" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-[#17171A] border-white/10">
-                    {isLoadingAll ? (
-                      <SelectItem value="loading">Loading...</SelectItem>
-                    ) : (
-                      (() => {
-                        const tokens =
-                          allCurrencies?.currencies?.filter(
-                            (c) =>
-                              c.type === "token" &&
-                              c.chainId === formData.chainId
-                          ) || [];
-                        return tokens.length > 0 ? (
-                          tokens.map((token) => (
-                            <SelectItem key={token.id} value={token.id}>
-                              {token.symbol} - {token.name}
-                            </SelectItem>
-                          ))
-                        ) : (
-                          <span className="block px-4 py-2 text-white/60">
-                            No tokens found
-                          </span>
-                        );
-                      })()
-                    )}
-                  </SelectContent>
-                </Select>
-              )}
-            </div>
-
-            {/* Time Lock-In toggle */}
-            <TimeLockToggle
-              value={formData.timeLockIn}
-              onChange={(val) =>
-                setFormData((prev) => ({ ...prev, timeLockIn: val }))
-              }
-              label="Lock exchange rate (Fix the value at current exchange rate)"
-            />
-
-            <div>
-              <label className="text-white mb-2 block">Who Paid</label>
-              <Select
-                value={formData.paidBy}
-                onValueChange={(value) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    paidBy: value,
-                  }))
-                }
-              >
-                <SelectTrigger className="w-full h-12 bg-[#17171A] text-white border-none focus:ring-1 focus:ring-white/20">
-                  <SelectValue placeholder="Select who paid" />
-                </SelectTrigger>
-                <SelectContent className="bg-[#17171A] border-white/10">
-                  {members.map((member) => (
-                    <SelectItem
-                      key={member.id}
-                      value={member.id}
-                      className="text-white hover:bg-white/10"
+            {/* Step 2: Amount & who paid — Amount + Paid by + Lock-in (crypto only) */}
+            {step === 2 && (
+              <>
+                <h2 className="text-2xl font-medium text-white mb-2">
+                  Amount & who paid
+                </h2>
+                <div>
+                  <div className="relative flex items-center rounded-xl bg-[#17171A] border border-white/10 overflow-hidden">
+                    <span className="pl-4 text-[#53E45E] font-medium">
+                      {getCurrencySymbol(formData.currency)}{" "}
+                    </span>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={formData.amount}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          amount: e.target.value,
+                        }))
+                      }
+                      placeholder="0.00"
+                      className="flex-1 h-14 px-2 bg-transparent text-[#53E45E] font-medium text-lg focus:outline-none focus:ring-0 placeholder:text-[#53E45E]/60"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label className="text-white/60 text-xs font-medium uppercase tracking-wider block mb-2">
+                    Paid by
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    {members.map((member) => (
+                      <button
+                        key={member.id}
+                        type="button"
+                        onClick={() =>
+                          setFormData((prev) => ({
+                            ...prev,
+                            paidBy: member.id,
+                          }))
+                        }
+                        className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border transition-colors ${
+                          formData.paidBy === member.id
+                            ? "border-[#53E45E] bg-[#53E45E]/10 text-white"
+                            : "border-white/20 bg-[#17171A] text-white hover:border-white/30"
+                        }`}
+                      >
+                        <div className="h-8 w-8 rounded-full bg-white/20 flex items-center justify-center text-sm font-medium text-white">
+                          {member.id === user?.id
+                            ? "Y"
+                            : (member.name || "?")
+                                .split(" ")
+                                .map((n) => n[0])
+                                .join("")
+                                .slice(0, 2)
+                                .toUpperCase()}
+                        </div>
+                        <span>
+                          {member.id === user?.id ? "You" : member.name}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                {isCrypto && (
+                  <div className="pt-2">
+                    <TimeLockToggle
+                      value={formData.timeLockIn}
+                      onChange={(val) =>
+                        setFormData((prev) => ({ ...prev, timeLockIn: val }))
+                      }
+                      label="Lock exchange rate (Fix the value at current exchange rate)"
+                    />
+                  </div>
+                )}
+                <div className="flex justify-between items-center pt-2">
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      onClick={onClose}
+                      variant="ghost"
+                      className="text-white/80 hover:text-white hover:bg-white/10"
                     >
-                      {member.id === user?.id ? "You" : member.name}
-                    </SelectItem>
+                      Close
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={() => setStep(1)}
+                      variant="ghost"
+                      className="text-white/80 hover:text-white hover:bg-white/10"
+                    >
+                      ← Back
+                    </Button>
+                  </div>
+                  <Button
+                    type="button"
+                    onClick={() => setStep(3)}
+                    disabled={!canProceedStep2}
+                    className="rounded-full bg-white/15 text-white hover:bg-white/25 disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Continue →
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {/* Step 3: How to split */}
+            {step === 3 && (
+              <>
+                <h2 className="text-2xl font-medium text-white mb-2">
+                  How to split
+                </h2>
+                <div className="flex gap-2">
+                  {(["equal", "custom", "percentage"] as const).map((type) => (
+                    <button
+                      key={type}
+                      type="button"
+                      onClick={() =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          splitType: type,
+                        }))
+                      }
+                      className={`flex-1 py-2.5 px-3 rounded-xl border font-medium capitalize ${
+                        formData.splitType === type
+                          ? "border-[#53E45E] bg-[#53E45E]/10 text-white"
+                          : "border-white/20 bg-[#17171A] text-white hover:border-white/30"
+                      }`}
+                    >
+                      {type === "equal"
+                        ? "Equal"
+                        : type === "percentage"
+                          ? "Percentage"
+                          : "Custom"}
+                    </button>
                   ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div>
-              <label className="text-white mb-2 block">Choose Split Type</label>
-              <Select
-                value={formData.splitType}
-                onValueChange={(value) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    splitType: value,
-                  }))
-                }
-              >
-                <SelectTrigger className="w-full h-12 bg-[#17171A] text-white border-none focus:ring-1 focus:ring-white/20">
-                  <SelectValue placeholder="Select expense type" />
-                </SelectTrigger>
-                <SelectContent className="bg-[#17171A] border-white/10">
-                  <SelectItem
-                    value="equal"
-                    className="text-white hover:bg-white/10"
-                  >
-                    Equal Split
-                  </SelectItem>
-                  <SelectItem
-                    value="percentage"
-                    className="text-white hover:bg-white/10"
-                  >
-                    Percentage Split
-                  </SelectItem>
-                  <SelectItem
-                    value="custom"
-                    className="text-white hover:bg-white/10"
-                  >
-                    Custom Split
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {/* Member splits list */}
-            <div className="max-h-[200px] overflow-y-auto space-y-4 pr-2">
+                </div>
+                {/* Member splits list */}
+                <div className="max-h-[200px] overflow-y-auto space-y-4 pr-2 mt-4">
               {members.map((member) => {
                 const split = splits.find((s) => s.address === member.id);
                 const amount = split?.amount || 0;
@@ -625,7 +703,7 @@ export function AddExpenseModal({
                         </span>
                       </div>
                     ) : (
-                      <div className="bg-[#17171A] rounded-lg px-3 py-1 min-w-[60px] text-white">
+                      <div className="bg-[#17171A] rounded-lg px-3 py-1 min-w-[60px] text-[#53E45E] font-medium">
                         {formatCurrency(amount, formData.currency)}
                       </div>
                     )}
@@ -633,7 +711,7 @@ export function AddExpenseModal({
                 );
               })}
 
-              {/* Total summary for custom and percentage splits */}
+                {/* Total summary for custom and percentage splits */}
               {(formData.splitType === "custom" ||
                 formData.splitType === "percentage") && (
                 <div className="flex justify-between items-center mt-4 border-t border-white/10 pt-3">
@@ -753,52 +831,72 @@ export function AddExpenseModal({
                   )}
                 </div>
               )}
-            </div>
+                </div>
 
-            <div>
-              <label className="text-white mb-2 block">Description</label>
-              <div className="relative">
-                <input
-                  type="text"
-                  value={formData.description}
-                  onChange={(e) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      description: e.target.value,
-                    }))
-                  }
-                  placeholder="What's this expense for?"
-                  className="w-full h-12 px-4 rounded-lg bg-[#17171A] text-white border-none focus:outline-none focus:ring-1 focus:ring-white/20"
-                  required
-                />
-              </div>
-            </div>
+                <div>
+                  <label className="text-white/60 text-xs font-medium uppercase tracking-wider block mb-2">
+                    Description (optional)
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.description}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        description: e.target.value,
+                      }))
+                    }
+                    placeholder="What's this expense for?"
+                    className="w-full h-12 px-4 rounded-xl bg-[#17171A] text-white border border-white/10 focus:outline-none focus:ring-1 focus:ring-white/20 placeholder:text-white/50"
+                  />
+                </div>
 
-            {/* Resolver Selector */}
-            <div>
-              <label className="text-white mb-2 block text-base font-semibold">
-                Settle in
-              </label>
-              <ResolverSelector
-                value={resolver}
-                onChange={handleResolverChange}
-              />
-            </div>
+                <div>
+                  <label className="text-white mb-2 block text-base font-semibold">
+                    Settle in
+                  </label>
+                  <ResolverSelector
+                    value={resolver}
+                    onChange={handleResolverChange}
+                  />
+                </div>
 
-            <Button
-              type="submit"
-              className="w-full h-12 rounded-full bg-white text-black font-medium hover:bg-white/90 transition-colors mt-6"
-              disabled={expenseMutation.isPending}
-            >
-              {expenseMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Adding...
-                </>
-              ) : (
-                "Add Expense"
-              )}
-            </Button>
+                <div className="flex justify-between items-center pt-4">
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      onClick={onClose}
+                      variant="ghost"
+                      className="text-white/80 hover:text-white hover:bg-white/10"
+                    >
+                      Close
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={() => setStep(2)}
+                      variant="ghost"
+                      className="text-white/80 hover:text-white hover:bg-white/10"
+                    >
+                      ← Back
+                    </Button>
+                  </div>
+                  <Button
+                    type="submit"
+                    className="rounded-full bg-[#53E45E] text-white font-medium hover:bg-[#53E45E]/90 px-6 disabled:opacity-50"
+                    disabled={expenseMutation.isPending || !validateSplits()}
+                  >
+                    {expenseMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Adding...
+                      </>
+                    ) : (
+                      "Add Expense"
+                    )}
+                  </Button>
+                </div>
+              </>
+            )}
           </form>
         </div>
       </div>

--- a/components/create-group-form.tsx
+++ b/components/create-group-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useWallet } from "@/hooks/useWallet";
-import { ChevronDown, Plus, Check, X } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import {
   useCreateGroup,
   useAddMembersToGroup,
@@ -12,14 +12,23 @@ import { useRouter } from "next/navigation";
 import { useUploadFile } from "@/features/files/hooks/use-balances";
 import { toast } from "sonner";
 import { motion, AnimatePresence } from "framer-motion";
-import { fadeIn } from "@/utils/animations";
 import { isValidEmail } from "@/utils/validation";
 import { useAuthStore } from "@/stores/authStore";
 import { apiClient } from "@/api-helpers/client";
-import Image from "next/image";
 import ResolverSelector, { Option as ResolverOption } from "./ResolverSelector";
-import CurrencyDropdown from "./currency-dropdown";
-import type { Currency } from "@/features/currencies/api/client";
+import { Card, Avatar, GroupAvatar, A, T, Icons } from "@/lib/splito-design";
+
+const GROUP_COLORS = [
+  "#22D3EE",
+  "#A78BFA",
+  "#34D399",
+  "#FB923C",
+  "#F472B6",
+  "#FBBF24",
+  "#F87171",
+  "#818CF8",
+];
+const MEMBER_COLORS = ["#22D3EE", "#A78BFA", "#34D399", "#FB923C", "#F472B6"];
 
 interface CreateGroupFormProps {
   isOpen: boolean;
@@ -72,6 +81,8 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
   const router = useRouter();
   const [isCheckingEmail, setIsCheckingEmail] = useState(false);
 
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
+  const [groupColor, setGroupColor] = useState(GROUP_COLORS[0]);
   const [formData, setFormData] = useState({
     name: "",
     memberEmail: "",
@@ -80,6 +91,10 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
 
   // State for tracking added members
   const [members, setMembers] = useState<Member[]>([]);
+
+  useEffect(() => {
+    if (isOpen) setStep(1);
+  }, [isOpen]);
 
   const allChainTokenOptions = useAllChainsTokens();
   const [resolver, setResolver] = useState<ResolverOption | undefined>(undefined);
@@ -272,73 +287,370 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
 
   if (!isOpen) return null;
 
+  const inp = {
+    width: "100%",
+    background: "rgba(255,255,255,0.05)",
+    border: "1.5px solid rgba(255,255,255,0.09)",
+    borderRadius: 14,
+    padding: "12px 16px",
+    color: "#fff",
+    fontSize: 14,
+    outline: "none",
+    boxSizing: "border-box" as const,
+    fontFamily: "inherit",
+  };
+  const lbl = {
+    color: T.label,
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase" as const,
+    marginBottom: 8,
+    display: "block",
+  };
+
   return (
     <AnimatePresence>
-      <motion.div
-        className="fixed inset-0 z-50 flex items-center justify-center p-4"
-        {...fadeIn}
+      <div
+        onClick={onClose}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,0.88)",
+          backdropFilter: "blur(16px)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          zIndex: 200,
+          padding: 24,
+        }}
       >
-        {/* Backdrop with brightness reduction */}
         <div
-          className="fixed inset-0 bg-black/70 brightness-50"
-          onClick={onClose}
-        />
-
-        {/* Modal content with normal brightness */}
-        <div
-          className="relative z-10 bg-black rounded-3xl w-full max-w-md border border-white/70"
           onClick={(e) => e.stopPropagation()}
-          style={{ overflow: 'visible' }}
+          style={{
+            background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
+            border: "1px solid rgba(255,255,255,0.09)",
+            borderRadius: 28,
+            width: "100%",
+            maxWidth: 460,
+            padding: "28px 28px 32px",
+            maxHeight: "90vh",
+            overflowY: "auto",
+            boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
+          }}
         >
-          <div className="p-8">
-            <h2 className="text-xl font-semibold text-white mb-6">
-              Create Group
-            </h2>
-
-            <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Group Name */}
-              <div className="space-y-2">
-                <label className="block text-base text-white">Group Name</label>
-                <input
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) =>
-                    setFormData((prev) => ({ ...prev, name: e.target.value }))
-                  }
-                  className="w-full h-12 bg-transparent rounded-lg px-4 
-                    text-base text-white border border-white/10"
-                  placeholder="New Split Group"
-                />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 24,
+            }}
+          >
+            <div>
+              <p
+                style={{
+                  color: "#fff",
+                  fontSize: 20,
+                  fontWeight: 800,
+                  letterSpacing: "-0.02em",
+                }}
+              >
+                Create Group
+              </p>
+              <div
+                style={{
+                  display: "flex",
+                  gap: 5,
+                  marginTop: 12,
+                }}
+              >
+                {[1, 2, 3, 4].map((s) => (
+                  <div
+                    key={s}
+                    style={{
+                      height: 3,
+                      width: 34,
+                      borderRadius: 99,
+                      background: step >= s ? groupColor : "#2a2a2a",
+                      transition: "background 0.3s",
+                      boxShadow:
+                        step >= s ? `0 0 8px ${groupColor}88` : "none",
+                    }}
+                  />
+                ))}
               </div>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                background: "rgba(255,255,255,0.07)",
+                border: "1px solid rgba(255,255,255,0.1)",
+                color: T.soft,
+                width: 34,
+                height: 34,
+                borderRadius: "50%",
+                cursor: "pointer",
+                fontSize: 18,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              ×
+            </button>
+          </div>
 
-              {/* Choose Payment Token (Resolver) */}
-              <div style={{ overflow: 'visible' }}>
-                <label className="block text-base text-white mb-2">Choose Payment Token</label>
-                <ResolverSelector value={resolver} onChange={handleResolverChange} />
-              </div>
-
-              {/* Currency Dropdown */}
-              {/* <div style={{ overflow: 'visible' }}>
-                <label className="block text-base text-white mb-2">Choose Currency</label>
-                <CurrencyDropdown
-                  selectedCurrencies={formData.currency ? [formData.currency] : []}
-                  setSelectedCurrencies={(currencies) => {
-                    setFormData((prev) => ({
-                      ...prev,
-                      currency: currencies[0] || "",
-                    }));
+          <form
+            onSubmit={handleSubmit}
+            style={{ display: "flex", flexDirection: "column", gap: 18 }}
+          >
+            {/* Step 1: Name + vibe + color */}
+            {step === 1 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+                <p
+                  style={{
+                    color: T.muted,
+                    fontSize: 14,
+                    lineHeight: 1.5,
                   }}
-                  showFiatCurrencies={true}
-                  filterCurrencies={(currency: Currency) => currency.symbol !== "ETH" && currency.symbol !== "USDC"}
-                />
-              </div> */}
+                >
+                  Name your group and give it a vibe.
+                </p>
+                <div style={{ display: "flex", justifyContent: "center" }}>
+                  <div
+                    style={{
+                      padding: 3,
+                      borderRadius: 22,
+                      background: `${groupColor}22`,
+                      border: `2px solid ${groupColor}44`,
+                      boxShadow: `0 0 24px ${groupColor}33`,
+                    }}
+                  >
+                    <GroupAvatar
+                      items={[
+                        { init: "Y", color: groupColor },
+                        ...members.slice(0, 3).map((m, i) => ({
+                          init: (m.name || m.email).slice(0, 2).toUpperCase(),
+                          color: MEMBER_COLORS[i % MEMBER_COLORS.length],
+                        })),
+                      ]}
+                      size={80}
+                      radius={18}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label style={lbl}>Group name</label>
+                  <input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, name: e.target.value }))
+                    }
+                    placeholder="e.g. Japan Trip, Roommates…"
+                    style={inp}
+                    autoFocus
+                  />
+                </div>
+                <div>
+                  <label style={lbl}>Color</label>
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: 8,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {GROUP_COLORS.map((c) => (
+                      <button
+                        key={c}
+                        type="button"
+                        onClick={() => setGroupColor(c)}
+                        style={{
+                          width: 30,
+                          height: 30,
+                          borderRadius: "50%",
+                          background: c,
+                          border:
+                            groupColor === c
+                              ? "3px solid #fff"
+                              : "3px solid transparent",
+                          cursor: "pointer",
+                          transition: "all 0.2s",
+                          boxShadow:
+                            groupColor === c ? `0 0 14px ${c}88` : "none",
+                        }}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => formData.name.trim() && setStep(2)}
+                  disabled={!formData.name.trim()}
+                  style={{
+                    padding: 13,
+                    background: formData.name.trim() ? groupColor : "rgba(255,255,255,0.05)",
+                    color: formData.name.trim() ? "#0a0a0a" : "#555",
+                    border: "none",
+                    borderRadius: 14,
+                    fontSize: 14,
+                    fontWeight: 800,
+                    cursor: formData.name.trim() ? "pointer" : "default",
+                    fontFamily: "inherit",
+                    transition: "all 0.2s",
+                  }}
+                >
+                  {formData.name.trim() ? "Continue →" : "Enter a group name"}
+                </button>
+              </div>
+            )}
 
-              {/* Invite Members (moved to bottom) */}
-              <div className="space-y-2">
-                <label className="block text-base text-white">Invite members</label>
-                <div className="flex gap-2">
+            {/* Step 2: Default settlement currency */}
+            {step === 2 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <p
+                  style={{
+                    color: T.muted,
+                    fontSize: 14,
+                    lineHeight: 1.6,
+                  }}
+                >
+                  Set the default settlement currency for this group.
+                </p>
+                <div style={{ overflow: "visible" }}>
+                  <label style={lbl}>Default settlement currency</label>
+                  <ResolverSelector
+                    value={resolver}
+                    onChange={handleResolverChange}
+                  />
+                </div>
+                {resolver?.chainId ? (
+                  <div
+                    style={{
+                      background: "rgba(52,211,153,0.06)",
+                      border: "1px solid rgba(52,211,153,0.15)",
+                      borderRadius: 14,
+                      padding: "14px 16px",
+                    }}
+                  >
+                    <p
+                      style={{
+                        color: "#34D399",
+                        fontSize: 12,
+                        fontWeight: 700,
+                        marginBottom: 5,
+                      }}
+                    >
+                      On-chain settlement
+                    </p>
+                    <p
+                      style={{
+                        color: "#34D39977",
+                        fontSize: 11,
+                        lineHeight: 1.6,
+                      }}
+                    >
+                      Members will be prompted to settle via blockchain.
+                    </p>
+                  </div>
+                ) : (
+                  <div
+                    style={{
+                      background: "rgba(255,255,255,0.03)",
+                      border: "1px solid rgba(255,255,255,0.08)",
+                      borderRadius: 14,
+                      padding: "14px 16px",
+                    }}
+                  >
+                    <p
+                      style={{
+                        color: T.body,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        marginBottom: 4,
+                      }}
+                    >
+                      Bank / Fiat settlement
+                    </p>
+                    <p
+                      style={{
+                        color: T.sub,
+                        fontSize: 11,
+                        lineHeight: 1.6,
+                      }}
+                    >
+                      Members will settle outside the app and mark as paid.
+                    </p>
+                  </div>
+                )}
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button
+                    type="button"
+                    onClick={() => setStep(1)}
+                    style={{
+                      flex: 1,
+                      padding: 13,
+                      background: "rgba(255,255,255,0.05)",
+                      color: T.body,
+                      border: "1px solid rgba(255,255,255,0.09)",
+                      borderRadius: 14,
+                      fontSize: 14,
+                      fontWeight: 700,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    ← Back
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setStep(3)}
+                    style={{
+                      flex: 2,
+                      padding: 13,
+                      background: groupColor,
+                      color: "#0a0a0a",
+                      border: "none",
+                      borderRadius: 14,
+                      fontSize: 14,
+                      fontWeight: 800,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                      transition: "all 0.2s",
+                    }}
+                  >
+                    Continue →
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Step 3: Add friends */}
+            {step === 3 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+                <p style={{ color: T.muted, fontSize: 14 }}>
+                  Add friends to this group.
+                </p>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    background: "rgba(255,255,255,0.05)",
+                    border: "1.5px solid rgba(255,255,255,0.09)",
+                    borderRadius: 14,
+                    padding: "11px 16px",
+                    gap: 8,
+                  }}
+                >
+                  <span style={{ color: T.muted, display: "flex" }}>
+                    <Icons.search />
+                  </span>
                   <input
                     type="email"
+                    placeholder="Invite by email (e.g. friend@email.com)"
                     value={formData.memberEmail}
                     onChange={(e) =>
                       setFormData((prev) => ({
@@ -352,16 +664,49 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
                         handleAddMember(e);
                       }
                     }}
-                    className="flex-1 h-12 bg-transparent rounded-lg px-4 
-                      text-base text-white border border-white/10"
-                    placeholder="me@email.com"
                     disabled={isCheckingEmail}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      color: "#fff",
+                      fontSize: 14,
+                      outline: "none",
+                      width: "100%",
+                      fontFamily: "inherit",
+                    }}
                   />
                   <button
                     type="button"
                     onClick={handleAddMember}
-                    className="w-12 h-12 bg-white rounded-full flex items-center justify-center"
-                    disabled={isCheckingEmail || !formData.memberEmail.trim() || !isValidEmail(formData.memberEmail.trim())}
+                    disabled={
+                      isCheckingEmail ||
+                      !formData.memberEmail.trim() ||
+                      !isValidEmail(formData.memberEmail.trim())
+                    }
+                    style={{
+                      width: 36,
+                      height: 36,
+                      borderRadius: 10,
+                      background:
+                        formData.memberEmail.trim() &&
+                        isValidEmail(formData.memberEmail.trim())
+                          ? A
+                          : "rgba(255,255,255,0.05)",
+                      color:
+                        formData.memberEmail.trim() &&
+                        isValidEmail(formData.memberEmail.trim())
+                          ? "#0a0a0a"
+                          : T.sub,
+                      border: "none",
+                      cursor:
+                        formData.memberEmail.trim() &&
+                        isValidEmail(formData.memberEmail.trim())
+                          ? "pointer"
+                          : "default",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
                   >
                     {isCheckingEmail ? (
                       <motion.div
@@ -371,109 +716,424 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
                           repeat: Infinity,
                           ease: "linear",
                         }}
-                      >
-                        <svg
-                          className="h-5 w-5 text-black"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                        >
-                          <circle
-                            className="opacity-25"
-                            cx="12"
-                            cy="12"
-                            r="10"
-                            stroke="currentColor"
-                            strokeWidth="4"
-                          ></circle>
-                          <path
-                            className="opacity-75"
-                            fill="currentColor"
-                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                          ></path>
-                        </svg>
-                      </motion.div>
+                        style={{
+                          width: 14,
+                          height: 14,
+                          border: "2px solid transparent",
+                          borderTopColor: "currentColor",
+                          borderRadius: "50%",
+                        }}
+                      />
                     ) : (
-                      <Plus className="h-5 w-5 text-black" />
+                      <Plus size={16} style={{ color: "inherit" }} />
                     )}
                   </button>
                 </div>
-
-                {/* Display added members list */}
                 {members.length > 0 && (
-                  <div className="mt-4">
-                    <div
-                      className="max-h-[140px] overflow-y-auto pr-1 space-y-2"
-                      style={{
-                        scrollbarWidth: "thin",
-                        scrollbarColor: "rgba(255, 255, 255, 0.1) transparent",
-                      }}
-                    >
-                      <AnimatePresence>
-                        {members.map((member) => (
-                          <motion.div
-                            key={member.id}
-                            initial={{ opacity: 0, y: -10 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, x: -10 }}
-                            transition={{ duration: 0.2 }}
-                            className="flex items-center justify-between p-3 bg-white/5 rounded-lg"
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: 8,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {members.map((member, i) => {
+                      const init = (member.name || member.email)
+                        .slice(0, 2)
+                        .toUpperCase();
+                      const color =
+                        MEMBER_COLORS[i % MEMBER_COLORS.length];
+                      return (
+                        <div
+                          key={member.id}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 6,
+                            background: `${color}14`,
+                            border: `1px solid ${color}33`,
+                            borderRadius: 99,
+                            padding: "5px 10px 5px 5px",
+                          }}
+                        >
+                          <Avatar
+                            init={init}
+                            color={color}
+                            size={22}
+                          />
+                          <span
+                            style={{
+                              fontSize: 12,
+                              color,
+                              fontWeight: 700,
+                            }}
                           >
-                            <div className="flex items-center overflow-hidden">
-                              {member.image ? (
-                                <div className="w-8 h-8 rounded-full mr-3 flex-shrink-0 overflow-hidden">
-                                  <Image
-                                    src={member.image}
-                                    alt={member.name || member.email}
-                                    width={32}
-                                    height={32}
-                                    className="h-full w-full object-cover"
-                                  />
-                                </div>
-                              ) : (
-                                <div className="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center mr-3 flex-shrink-0">
-                                  {(member.name || member.email)
-                                    .charAt(0)
-                                    .toUpperCase()}
-                                </div>
-                              )}
-                              <div className="overflow-hidden">
-                                {member.name && (
-                                  <p className="text-white text-sm font-medium truncate">
-                                    {member.name}
-                                  </p>
-                                )}
-                                <p className="text-white/60 text-xs truncate">
-                                  {member.email}
-                                </p>
-                              </div>
-                            </div>
-                            <button
-                              type="button"
-                              onClick={() => removeMember(member.id)}
-                              className="text-white/70 hover:text-white p-1 ml-2 flex-shrink-0"
-                            >
-                              <X className="h-4 w-4" />
-                            </button>
-                          </motion.div>
-                        ))}
-                      </AnimatePresence>
-                    </div>
+                            {(member.name || member.email).split(" ")[0] ||
+                              (member.name || member.email).slice(0, 8)}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => removeMember(member.id)}
+                            style={{
+                              background: "none",
+                              border: "none",
+                              color: `${color}88`,
+                              cursor: "pointer",
+                              fontSize: 12,
+                              display: "flex",
+                              alignItems: "center",
+                              marginLeft: 2,
+                            }}
+                          >
+                            <Icons.x />
+                          </button>
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
+                <Card style={{ maxHeight: 220, overflowY: "auto" }}>
+                  {members.length === 0 ? (
+                    <div
+                      style={{
+                        padding: 24,
+                        textAlign: "center",
+                        color: T.sub,
+                        fontSize: 13,
+                      }}
+                    >
+                      Add members by entering their email above.
+                    </div>
+                  ) : (
+                    members.map((member, idx) => {
+                      const init = (member.name || member.email)
+                        .slice(0, 2)
+                        .toUpperCase();
+                      const color =
+                        MEMBER_COLORS[idx % MEMBER_COLORS.length];
+                      return (
+                        <div
+                          key={member.id}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 12,
+                            padding: "13px 18px",
+                            borderBottom:
+                              idx < members.length - 1
+                                ? "1px solid rgba(255,255,255,0.05)"
+                                : "none",
+                          }}
+                        >
+                          <Avatar
+                            init={init}
+                            color={color}
+                            size={36}
+                          />
+                          <div style={{ flex: 1, minWidth: 0 }}>
+                            <p
+                              style={{
+                                fontSize: 13,
+                                fontWeight: 700,
+                                color: T.bright,
+                              }}
+                            >
+                              {member.name || member.email}
+                            </p>
+                            <p
+                              style={{
+                                fontSize: 12,
+                                color: T.sub,
+                              }}
+                            >
+                              {member.email}
+                            </p>
+                          </div>
+                          <div
+                            style={{
+                              width: 22,
+                              height: 22,
+                              borderRadius: 8,
+                              border: `1.5px solid ${color}`,
+                              background: color,
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              boxShadow: `0 0 10px ${color}44`,
+                            }}
+                          >
+                            <svg
+                              width="10"
+                              height="10"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="#0a0a0a"
+                              strokeWidth="3"
+                              strokeLinecap="round"
+                            >
+                              <path d="M20 6L9 17l-5-5" />
+                            </svg>
+                          </div>
+                        </div>
+                      );
+                    })
+                  )}
+                </Card>
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button
+                    type="button"
+                    onClick={() => setStep(2)}
+                    style={{
+                      flex: 1,
+                      padding: 13,
+                      background: "rgba(255,255,255,0.05)",
+                      color: T.body,
+                      border: "1px solid rgba(255,255,255,0.09)",
+                      borderRadius: 14,
+                      fontSize: 14,
+                      fontWeight: 700,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    ← Back
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setStep(4)}
+                    style={{
+                      flex: 2,
+                      padding: 13,
+                      background: groupColor,
+                      color: "#0a0a0a",
+                      border: "none",
+                      borderRadius: 14,
+                      fontSize: 14,
+                      fontWeight: 800,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                      transition: "all 0.2s",
+                    }}
+                  >
+                    Continue →
+                  </button>
+                </div>
               </div>
+            )}
 
-              {/* Submit Button */}
-              <button
-                type="submit"
-                className="w-full h-12 bg-white text-black rounded-full font-medium hover:bg-white/90 transition-colors mt-8"
-                disabled={createGroupMutation.isPending}
-              >
-                {createGroupMutation.isPending ? "Creating..." : "Create Group"}
-              </button>
-            </form>
-          </div>
+            {/* Step 4: Review */}
+            {step === 4 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <p style={{ color: T.muted, fontSize: 14 }}>
+                  Review your group before creating.
+                </p>
+                <div
+                  style={{
+                    background: "rgba(255,255,255,0.04)",
+                    border: "1px solid rgba(255,255,255,0.08)",
+                    borderRadius: 18,
+                    padding: 20,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 16,
+                  }}
+                >
+                  <div
+                    style={{
+                      padding: 3,
+                      borderRadius: 18,
+                      background: `${groupColor}22`,
+                      border: `2px solid ${groupColor}44`,
+                      boxShadow: `0 0 20px ${groupColor}33`,
+                    }}
+                  >
+                    <GroupAvatar
+                      items={[
+                        { init: "Y", color: groupColor },
+                        ...members.slice(0, 3).map((m, i) => ({
+                          init: (m.name || m.email).slice(0, 2).toUpperCase(),
+                          color: MEMBER_COLORS[i % MEMBER_COLORS.length],
+                        })),
+                      ]}
+                      size={58}
+                      radius={14}
+                    />
+                  </div>
+                  <div>
+                    <p
+                      style={{
+                        fontSize: 19,
+                        fontWeight: 800,
+                        color: "#fff",
+                        letterSpacing: "-0.02em",
+                      }}
+                    >
+                      {formData.name || "New Group"}
+                    </p>
+                    <p
+                      style={{
+                        fontSize: 13,
+                        color: T.mid,
+                        marginTop: 4,
+                      }}
+                    >
+                      {members.length + 1} member
+                      {members.length !== 0 ? "s" : ""}
+                    </p>
+                  </div>
+                </div>
+                <div
+                  style={{
+                    background: "rgba(255,255,255,0.04)",
+                    borderRadius: 16,
+                    padding: "15px 18px",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    border: "1px solid rgba(255,255,255,0.07)",
+                  }}
+                >
+                  <div>
+                    <p
+                      style={{
+                        color: T.sub,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        marginBottom: 4,
+                        letterSpacing: "0.05em",
+                      }}
+                    >
+                      DEFAULT SETTLEMENT
+                    </p>
+                    <p
+                      style={{
+                        color: T.bright,
+                        fontSize: 13,
+                        fontWeight: 700,
+                      }}
+                    >
+                      {resolver
+                        ? `${resolver.symbol}${resolver.chainId ? ` · ${resolver.name}` : ""}`
+                        : "USD (Fiat)"}
+                    </p>
+                  </div>
+                </div>
+                <div>
+                  <label style={lbl}>Members</label>
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: 6,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 6,
+                        background: `${groupColor}14`,
+                        border: `1px solid ${groupColor}33`,
+                        borderRadius: 99,
+                        padding: "5px 12px 5px 5px",
+                      }}
+                    >
+                      <Avatar init="Y" color={groupColor} size={24} />
+                      <span
+                        style={{
+                          fontSize: 12,
+                          color: groupColor,
+                          fontWeight: 700,
+                        }}
+                      >
+                        You
+                      </span>
+                    </div>
+                    {members.map((m, i) => {
+                      const color = MEMBER_COLORS[i % MEMBER_COLORS.length];
+                      const init = (m.name || m.email)
+                        .slice(0, 2)
+                        .toUpperCase();
+                      return (
+                        <div
+                          key={m.id}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 6,
+                            background: `${color}14`,
+                            border: `1px solid ${color}33`,
+                            borderRadius: 99,
+                            padding: "5px 12px 5px 5px",
+                          }}
+                        >
+                          <Avatar init={init} color={color} size={24} />
+                          <span
+                            style={{
+                              fontSize: 12,
+                              color,
+                              fontWeight: 700,
+                            }}
+                          >
+                            {(m.name || m.email).split(" ")[0] ||
+                              (m.name || m.email).slice(0, 8)}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button
+                    type="button"
+                    onClick={() => setStep(3)}
+                    style={{
+                      flex: 1,
+                      padding: 13,
+                      background: "rgba(255,255,255,0.05)",
+                      color: T.body,
+                      border: "1px solid rgba(255,255,255,0.09)",
+                      borderRadius: 14,
+                      fontSize: 14,
+                      fontWeight: 700,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    ← Back
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={createGroupMutation.isPending}
+                    style={{
+                      flex: 2,
+                      padding: 13,
+                      background: createGroupMutation.isPending
+                        ? "rgba(255,255,255,0.05)"
+                        : groupColor,
+                      color: createGroupMutation.isPending ? "#555" : "#0a0a0a",
+                      border: "none",
+                      borderRadius: 14,
+                      fontSize: 14,
+                      fontWeight: 800,
+                      cursor: createGroupMutation.isPending
+                        ? "default"
+                        : "pointer",
+                      fontFamily: "inherit",
+                      boxShadow: `0 0 24px ${groupColor}44`,
+                      transition: "all 0.2s",
+                    }}
+                  >
+                    {createGroupMutation.isPending
+                      ? "Creating…"
+                      : "Create Group ✓"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </form>
         </div>
-      </motion.div>
+      </div>
     </AnimatePresence>
   );
 }

--- a/components/currency-dropdown.tsx
+++ b/components/currency-dropdown.tsx
@@ -2,16 +2,71 @@
 
 import { useState, useRef, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { Loader2, ChevronDown, Check, X, Search } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useOrganizedCurrencies } from "@/features/currencies/hooks/use-currencies";
 import type { Currency } from "@/features/currencies/api/client";
+import { A, T } from "@/lib/splito-design";
+import { Icons } from "@/lib/splito-design";
+
+// Flag emoji for common fiat currencies (id/code -> emoji)
+const FIAT_FLAGS: Record<string, string> = {
+  USD: "🇺🇸",
+  EUR: "🇪🇺",
+  GBP: "🇬🇧",
+  JPY: "🇯🇵",
+  THB: "🇹🇭",
+  INR: "🇮🇳",
+  AUD: "🇦🇺",
+  CAD: "🇨🇦",
+  SGD: "🇸🇬",
+  CHF: "🇨🇭",
+  CNY: "🇨🇳",
+  KRW: "🇰🇷",
+  MXN: "🇲🇽",
+  BRL: "🇧🇷",
+};
+
+const getCurrencyFlag = (c: Currency): string => {
+  if (c.type !== "FIAT") return "";
+  return FIAT_FLAGS[c.id] || FIAT_FLAGS[c.symbol] || "💱";
+};
+
+// Chain ID → display name and icon for section headers (Fiat, Aptos, Solana, Stellar, Base, etc.)
+const CHAIN_DISPLAY: Record<string, { name: string; icon: string; color: string }> = {
+  stellar: { name: "Stellar", icon: "✦", color: "#34D399" },
+  Stellar: { name: "Stellar", icon: "✦", color: "#34D399" },
+  solana: { name: "Solana", icon: "◎", color: "#A78BFA" },
+  Solana: { name: "Solana", icon: "◎", color: "#A78BFA" },
+  aptos: { name: "Aptos", icon: "⬡", color: "#22D3EE" },
+  Aptos: { name: "Aptos", icon: "⬡", color: "#22D3EE" },
+  base: { name: "Base", icon: "🔵", color: "#3B82F6" },
+  Base: { name: "Base", icon: "🔵", color: "#3B82F6" },
+  ethereum: { name: "Ethereum", icon: "◆", color: "#818CF8" },
+  Ethereum: { name: "Ethereum", icon: "◆", color: "#818CF8" },
+  polygon: { name: "Polygon", icon: "⬟", color: "#A855F7" },
+  Polygon: { name: "Polygon", icon: "⬟", color: "#A855F7" },
+  // Numeric chain IDs (string keys)
+  "1": { name: "Ethereum", icon: "◆", color: "#818CF8" },
+  "137": { name: "Polygon", icon: "⬟", color: "#A855F7" },
+  "8453": { name: "Base", icon: "🔵", color: "#3B82F6" },
+};
+
+const CHAIN_ORDER = ["Stellar", "Solana", "Aptos", "Base", "Ethereum", "Polygon"];
+
+function getChainDisplay(chainId: string): { name: string; icon: string; color: string } {
+  const key = chainId.toString();
+  return (
+    CHAIN_DISPLAY[key] ||
+    CHAIN_DISPLAY[key.toLowerCase()] || { name: chainId, icon: "◆", color: T.mid }
+  );
+}
 
 const dropdownVariants = {
   hidden: {
     opacity: 0,
-    y: -5,
-    scale: 0.95,
+    y: -6,
+    scale: 0.98,
   },
   visible: {
     opacity: 1,
@@ -20,8 +75,8 @@ const dropdownVariants = {
   },
   exit: {
     opacity: 0,
-    y: -5,
-    scale: 0.95,
+    y: -6,
+    scale: 0.98,
   },
 };
 
@@ -104,6 +159,22 @@ export default function CurrencyDropdown({
 
   const currencies = [...filteredChainCurrencies, ...filteredFiatCurrencies];
 
+  // Build ordered list of chain IDs for section headers (Stellar, Solana, Aptos, Base, etc.)
+  const orderedChainIds = (() => {
+    const ids = Object.keys(chainGroups);
+    const byName = (a: string, b: string) => {
+      const nameA = getChainDisplay(a).name;
+      const nameB = getChainDisplay(b).name;
+      const iA = CHAIN_ORDER.indexOf(nameA);
+      const iB = CHAIN_ORDER.indexOf(nameB);
+      if (iA !== -1 && iB !== -1) return iA - iB;
+      if (iA !== -1) return -1;
+      if (iB !== -1) return 1;
+      return nameA.localeCompare(nameB);
+    };
+    return ids.sort(byName);
+  })();
+
   const toggleDropdown = (dropdown: string) => {
     setActiveDropdown(activeDropdown === dropdown ? null : dropdown);
   };
@@ -138,11 +209,84 @@ export default function CurrencyDropdown({
     );
   };
 
+  const renderCurrencyRow = (
+    currency: Currency,
+    isFiat: boolean,
+    isSelected: boolean
+  ) => (
+    <button
+      key={currency.id}
+      type="button"
+      onClick={() => toggleCurrencySelection(currency.id)}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "10px 16px",
+        borderBottom: "1px solid rgba(255,255,255,0.04)",
+        cursor: "pointer",
+        background: isSelected ? "rgba(34,211,238,0.06)" : "transparent",
+        width: "100%",
+        textAlign: "left",
+        fontFamily: "inherit",
+        transition: "background 0.15s",
+        border: "none",
+      }}
+      onMouseEnter={(e) => {
+        if (!isSelected) e.currentTarget.style.background = "rgba(255,255,255,0.04)";
+      }}
+      onMouseLeave={(e) => {
+        if (!isSelected) e.currentTarget.style.background = "transparent";
+      }}
+    >
+      <span style={{ fontSize: 17 }}>
+        {isFiat ? getCurrencyFlag(currency) : "◆"}
+      </span>
+      <span
+        style={{
+          fontWeight: 700,
+          fontSize: 13,
+          color: isSelected ? "#fff" : T.body,
+          minWidth: isFiat ? 36 : 44,
+        }}
+      >
+        {isFiat ? currency.id : currency.symbol}
+      </span>
+      <span
+        style={{
+          color: T.sub,
+          fontSize: 12,
+          flex: 1,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {currency.name}
+      </span>
+      {isSelected && (
+        <span style={{ color: A, fontSize: 12, flexShrink: 0 }}>✓</span>
+      )}
+    </button>
+  );
+
   const renderCurrencyDropdown = () => {
     if (isLoadingCurrencies) {
       return (
-        <div className="px-4 py-3 text-white/60 flex items-center">
-          <Loader2 className="h-4 w-4 animate-spin mr-2" />
+        <div
+          style={{
+            padding: "16px 18px",
+            color: T.muted,
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <Loader2
+            style={{ width: 16, height: 16, flexShrink: 0 }}
+            className="animate-spin"
+          />
           <span>Loading currencies...</span>
         </div>
       );
@@ -151,187 +295,272 @@ export default function CurrencyDropdown({
     const fiatList = filteredFiatCurrencies.filter((c) =>
       matchesSearch(c, searchQuery)
     );
+    // Per-chain filtered lists for sectioned display
+    const chainLists: { chainId: string; tokens: Currency[] }[] = orderedChainIds
+      .map((chainId) => {
+        const tokens = (chainGroups[chainId] || []).filter(
+          (c) =>
+            (filterCurrencies ? filterCurrencies(c) : true) &&
+            matchesSearch(c, searchQuery)
+        );
+        return { chainId, tokens };
+      })
+      .filter((g) => g.tokens.length > 0);
     const cryptoList = filteredChainCurrencies.filter((c) =>
       matchesSearch(c, searchQuery)
     );
 
     return (
-      <>
-        <div className="sticky top-0 bg-[#17171A] px-3 py-2 border-b border-white/10 z-10">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/50 pointer-events-none" />
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              placeholder="Search currency..."
-              className="w-full h-9 pl-9 pr-3 rounded-lg bg-black/50 border border-white/10 text-white placeholder:text-white/50 text-sm focus:outline-none focus:ring-1 focus:ring-white/20"
-            />
-          </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          maxHeight: 280,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "10px 14px",
+            borderBottom: "1px solid rgba(255,255,255,0.06)",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <span style={{ color: T.muted, display: "flex" }}>
+            <Icons.search />
+          </span>
+          <input
+            type="text"
+            autoFocus
+            placeholder="Search currency…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            style={{
+              background: "none",
+              border: "none",
+              color: "#fff",
+              fontSize: 13,
+              outline: "none",
+              width: "100%",
+              fontFamily: "inherit",
+            }}
+          />
         </div>
-        <div className="py-2">
-          {showFiatCurrencies && (
+        <div style={{ overflowY: "auto" }}>
+          {showFiatCurrencies && fiatList.length > 0 && (
             <>
-              <div className="px-4 py-2 text-xs font-medium text-white/50 uppercase tracking-wider">
+              <div
+                style={{
+                  padding: "8px 16px 4px",
+                  color: T.dim,
+                  fontSize: 10,
+                  fontWeight: 700,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                }}
+              >
                 Fiat
               </div>
-              {fiatList.length === 0 ? (
-                <div className="px-4 py-2 text-sm text-white/50">
-                  No matching fiat currencies
-                </div>
-              ) : (
-                fiatList.map((currency) => (
-                  <button
-                    key={`fiat-${currency.id}`}
-                    type="button"
-                    className={`w-full px-4 py-2 text-left text-white hover:bg-white/5 flex items-center ${
-                      selectedCurrencies.includes(currency.id) ? "bg-white/5" : ""
-                    }`}
-                    onClick={() => toggleCurrencySelection(currency.id)}
-                  >
-                    <div
-                      className={`w-5 h-5 flex items-center justify-center rounded-md border mr-3 ${
-                        selectedCurrencies.includes(currency.id)
-                          ? "border-white bg-white"
-                          : "border-white/30 bg-transparent"
-                      }`}
-                    >
-                      {selectedCurrencies.includes(currency.id) && (
-                        <Check className="h-3.5 w-3.5 text-black" />
-                      )}
-                    </div>
-                    <div>
-                      <span className="font-medium">{currency.id}</span>
-                      <span className="text-white/70"> • {currency.name}</span>
-                    </div>
-                  </button>
-                ))
+              {fiatList.map((currency) =>
+                renderCurrencyRow(
+                  currency,
+                  true,
+                  selectedCurrencies.includes(currency.id)
+                )
               )}
             </>
           )}
-
-          {!disableChainCurrencies && (
-            <>
-              <div className="px-4 py-2 text-xs font-medium text-white/50 uppercase tracking-wider mt-1">
-                Crypto
-              </div>
-              {cryptoList.length === 0 ? (
-                <div className="px-4 py-2 text-sm text-white/50">
-                  No matching crypto
-                </div>
-              ) : (
-                cryptoList.map((currency) => (
-                  <button
-                    key={`crypto-${currency.id}`}
-                    type="button"
-                    className={`w-full px-4 py-2 text-left text-white hover:bg-white/5 flex items-center ${
-                      selectedCurrencies.includes(currency.id) ? "bg-white/5" : ""
-                    }`}
-                    onClick={() => toggleCurrencySelection(currency.id)}
+          {showFiatCurrencies && fiatList.length === 0 && searchQuery.trim() && (
+            <div
+              style={{
+                padding: "12px 16px",
+                color: T.sub,
+                fontSize: 12,
+              }}
+            >
+              No matching fiat currencies
+            </div>
+          )}
+          {!disableChainCurrencies &&
+            chainLists.map(({ chainId, tokens }) => {
+              const { name: chainName, icon: chainIcon, color: chainColor } =
+                getChainDisplay(chainId);
+              return (
+                <div key={chainId}>
+                  <div
+                    style={{
+                      padding: "10px 16px 4px",
+                      color: T.dim,
+                      fontSize: 10,
+                      fontWeight: 700,
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                    }}
                   >
-                    <div
-                      className={`w-5 h-5 flex items-center justify-center rounded-md border mr-3 ${
-                        selectedCurrencies.includes(currency.id)
-                          ? "border-white bg-white"
-                          : "border-white/30 bg-transparent"
-                      }`}
-                    >
-                      {selectedCurrencies.includes(currency.id) && (
-                        <Check className="h-3.5 w-3.5 text-black" />
-                      )}
-                    </div>
-                    <div>
-                      <span className="font-medium">{currency.symbol}</span>
-                      <span className="text-white/70"> • {currency.name}</span>
-                    </div>
-                  </button>
-                ))
-              )}
-            </>
+                    <span style={{ color: chainColor }}>{chainIcon}</span>
+                    {chainName}
+                  </div>
+                  {tokens.map((currency) =>
+                    renderCurrencyRow(
+                      currency,
+                      false,
+                      selectedCurrencies.includes(currency.id)
+                    )
+                  )}
+                </div>
+              );
+            })}
+          {!disableChainCurrencies && chainLists.length === 0 && searchQuery.trim() && (
+            <div
+              style={{
+                padding: "12px 16px",
+                color: T.sub,
+                fontSize: 12,
+              }}
+            >
+              No matching crypto
+            </div>
           )}
         </div>
-      </>
+      </div>
     );
   };
 
   const defaultPlaceholder =
     mode === "single" ? "Select currency..." : "Select Payment Token...";
 
+  const isOpen = activeDropdown === "currency";
+  const selected =
+    selectedCurrencies.length > 0
+      ? currencies.find((c) => c.id === selectedCurrencies[0])
+      : null;
+
   return (
     <div className="relative" ref={triggerRef}>
       <button
         type="button"
         onClick={() => toggleDropdown("currency")}
-        className="w-full min-h-12 bg-black border border-white/20 text-white rounded-lg px-4 py-2
-          flex items-center justify-between focus:outline-none focus:ring-1 focus:ring-white/40"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          width: "100%",
+          minHeight: 44,
+          background: "rgba(255,255,255,0.04)",
+          border: `1.5px solid ${isOpen ? "rgba(255,255,255,0.14)" : "rgba(255,255,255,0.08)"}`,
+          borderRadius: 14,
+          padding: "12px 16px",
+          cursor: "pointer",
+          transition: "all 0.2s",
+          fontFamily: "inherit",
+        }}
       >
         {mode === "single" ? (
-          // Single select mode - show selected currency inline
-          <span className="truncate text-left">
-            {isLoadingCurrencies ? (
-              "Loading currencies..."
-            ) : selectedCurrencies.length > 0 ? (
-              (() => {
-                const selected = currencies.find(
-                  (c) => c.id === selectedCurrencies[0]
-                );
-                return selected ? (
-                  <span>
-                    <span className="font-medium">
-                      {selected.type === "FIAT" ? selected.id : selected.symbol}
-                    </span>
-                    <span className="text-white/70"> • {selected.name}</span>
-                  </span>
-                ) : (
-                  selectedCurrencies[0]
-                );
-              })()
-            ) : (
-              <span className="text-white/70">
-                {placeholder || defaultPlaceholder}
-              </span>
-            )}
+          <span
+            style={{
+              color: selected ? T.bright : T.muted,
+              fontSize: 14,
+              fontWeight: 600,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              textAlign: "left",
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
+            {isLoadingCurrencies
+              ? "Loading currencies..."
+              : selected
+                ? `${selected.type === "FIAT" ? selected.id : selected.symbol} · ${selected.name}`
+                : placeholder || defaultPlaceholder}
           </span>
         ) : (
-          // Multi-select mode - show chips with wrapping
-          <div className="flex flex-wrap gap-2 items-center flex-1 min-w-0">
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 8,
+              alignItems: "center",
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
             {isLoadingCurrencies ? (
-              <span className="py-1">Loading currencies...</span>
+              <span style={{ color: T.muted, fontSize: 13 }}>
+                Loading currencies...
+              </span>
             ) : selectedCurrencies.length > 0 ? (
               selectedCurrencies.map((currencyId) => {
-                const selected = currencies.find((c) => c.id === currencyId);
-                if (!selected) return null;
-
+                const c = currencies.find((x) => x.id === currencyId);
+                if (!c) return null;
                 return (
                   <div
                     key={currencyId}
-                    className="bg-white/10 rounded-md px-2 py-1 flex items-center flex-shrink-0"
+                    style={{
+                      background: "rgba(255,255,255,0.1)",
+                      borderRadius: 8,
+                      padding: "4px 8px 4px 8px",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      flexShrink: 0,
+                    }}
                   >
-                    <span className="font-medium mr-1 text-sm">
-                      {selected.type === "FIAT" ? selected.id : selected.symbol}
-                    </span>
-                    <div
-                      onClick={(e) => removeCurrency(currencyId, e)}
-                      className="text-white/70 hover:text-white cursor-pointer"
+                    <span
+                      style={{
+                        fontWeight: 700,
+                        fontSize: 12,
+                        color: "#fff",
+                      }}
                     >
-                      <X className="h-3 w-3" />
-                    </div>
+                      {c.type === "FIAT" ? c.id : c.symbol}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={(e) => removeCurrency(currencyId, e)}
+                      style={{
+                        background: "none",
+                        border: "none",
+                        color: "rgba(255,255,255,0.7)",
+                        cursor: "pointer",
+                        padding: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <X size={12} />
+                    </button>
                   </div>
                 );
               })
             ) : (
-              <span className="py-1 text-white/70">
+              <span style={{ color: T.muted, fontSize: 13 }}>
                 {placeholder || defaultPlaceholder}
               </span>
             )}
           </div>
         )}
-        <ChevronDown
-          className={`h-5 w-5 text-white/70 transition-transform duration-200 ${
-            activeDropdown === "currency" ? "rotate-180" : ""
-          } ml-2 flex-shrink-0`}
-        />
+        <span
+          style={{
+            color: T.muted,
+            fontSize: 12,
+            transition: "transform 0.2s",
+            display: "inline-block",
+            transform: isOpen ? "rotate(180deg)" : "none",
+            marginLeft: 8,
+            flexShrink: 0,
+          }}
+        >
+          ▾
+        </span>
       </button>
 
       {typeof document !== "undefined" &&
@@ -352,8 +581,12 @@ export default function CurrencyDropdown({
                 width: dropdownRect.width,
                 maxHeight: dropdownRect.maxHeight,
                 zIndex: 99999,
+                background: "#141414",
+                border: "1px solid rgba(255,255,255,0.09)",
+                borderRadius: 18,
+                overflow: "hidden",
+                boxShadow: "0 20px 60px rgba(0,0,0,0.7)",
               }}
-              className="bg-[#17171A] rounded-lg py-2 overflow-y-auto shadow-xl border border-white/10"
             >
               {renderCurrencyDropdown()}
             </motion.div>

--- a/components/currency-dropdown.tsx
+++ b/components/currency-dropdown.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
-import { Loader2, ChevronDown, Check, X } from "lucide-react";
+import { useState, useRef, useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+import { Loader2, ChevronDown, Check, X, Search } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useOrganizedCurrencies } from "@/features/currencies/hooks/use-currencies";
 import type { Currency } from "@/features/currencies/api/client";
@@ -44,6 +45,47 @@ export default function CurrencyDropdown({
   disableChainCurrencies = false,
 }: Props) {
   const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const [dropdownRect, setDropdownRect] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    if (activeDropdown !== "currency" || !triggerRef.current) {
+      setDropdownRect(null);
+      setSearchQuery("");
+      return;
+    }
+    const el = triggerRef.current;
+    const rect = el.getBoundingClientRect();
+    const padding = 8;
+    const spaceBelow = window.innerHeight - rect.bottom - padding;
+    const spaceAbove = rect.top - padding;
+    const maxH = 320;
+    const maxHeight = Math.min(maxH, spaceBelow > spaceAbove ? spaceBelow : spaceAbove, window.innerHeight - padding * 2);
+    setDropdownRect({
+      top: spaceBelow >= maxH ? rect.bottom + 4 : rect.top - maxHeight - 4,
+      left: rect.left,
+      width: rect.width,
+      maxHeight: Math.max(120, maxHeight),
+    });
+  }, [activeDropdown]);
+
+  // Close on click outside
+  useLayoutEffect(() => {
+    if (activeDropdown !== "currency") return;
+    const handleClick = (e: MouseEvent) => {
+      if (triggerRef.current?.contains(e.target as Node)) return;
+      if ((e.target as Element).closest("[data-currency-dropdown-portal]")) return;
+      setActiveDropdown(null);
+    };
+    document.addEventListener("mousedown", handleClick, true);
+    return () => document.removeEventListener("mousedown", handleClick, true);
+  }, [activeDropdown]);
 
   const { data: organizedCurrencies, isLoading: isLoadingCurrencies } =
     useOrganizedCurrencies();
@@ -88,6 +130,14 @@ export default function CurrencyDropdown({
     setSelectedCurrencies(newCurrencies);
   };
 
+  const matchesSearch = (c: Currency, q: string) => {
+    if (!q.trim()) return true;
+    const lower = q.toLowerCase().trim();
+    return [c.id, c.symbol, c.name].some(
+      (s) => s && String(s).toLowerCase().includes(lower)
+    );
+  };
+
   const renderCurrencyDropdown = () => {
     if (isLoadingCurrencies) {
       return (
@@ -98,97 +148,109 @@ export default function CurrencyDropdown({
       );
     }
 
-    // Use the cached organized currencies from our hook
-    const fiatCurrencies = organizedCurrencies?.fiatCurrencies || [];
-    const chainGroups = organizedCurrencies?.chainGroups || {};
-
-    // Apply filter if provided
-    const filteredFiatCurrencies = filterCurrencies
-      ? fiatCurrencies.filter(filterCurrencies)
-      : fiatCurrencies;
-
-    // Filter chain groups
-    const filteredChainGroups: Record<string, Currency[]> = {};
-    Object.entries(chainGroups).forEach(([chainId, currencies]) => {
-      const filteredCurrencies = filterCurrencies
-        ? currencies.filter(filterCurrencies)
-        : currencies;
-      if (filteredCurrencies.length > 0) {
-        filteredChainGroups[chainId] = filteredCurrencies;
-      }
-    });
+    const fiatList = filteredFiatCurrencies.filter((c) =>
+      matchesSearch(c, searchQuery)
+    );
+    const cryptoList = filteredChainCurrencies.filter((c) =>
+      matchesSearch(c, searchQuery)
+    );
 
     return (
       <>
-        {showFiatCurrencies && (
-          <>
-            <div className="px-4 py-2 text-sm text-white/50 font-medium">
-              Fiat
-            </div>
-            {filteredFiatCurrencies.map((currency) => (
-              <button
-                key={`fiat-${currency.id}`}
-                type="button"
-                className={`w-full px-4 py-2 text-left text-white hover:bg-white/5 flex items-center ${
-                  selectedCurrencies.includes(currency.id) ? "bg-white/5" : ""
-                }`}
-                onClick={() => toggleCurrencySelection(currency.id)}
-              >
-                <div
-                  className={`w-5 h-5 flex items-center justify-center rounded-md border ${
-                    selectedCurrencies.includes(currency.id)
-                      ? "border-white bg-white"
-                      : "border-white/30 bg-transparent"
-                  } mr-3`}
-                >
-                  {selectedCurrencies.includes(currency.id) && (
-                    <Check className="h-3.5 w-3.5 text-black" />
-                  )}
-                </div>
-                <div>
-                  <span className="font-medium">{currency.id}</span>
-                  <span className="text-white/70"> • {currency.name}</span>
-                </div>
-              </button>
-            ))}
-          </>
-        )}
-
-        {/* Chain Currencies */}
-        {!disableChainCurrencies &&
-          Object.entries(filteredChainGroups).map(([chainId, currencies]) => (
-            <div key={`chain-${chainId}`}>
-              <div className="px-4 py-2 text-sm text-white/50 font-medium">
-                {chainId.charAt(0).toUpperCase() + chainId.slice(1).toLowerCase()}
+        <div className="sticky top-0 bg-[#17171A] px-3 py-2 border-b border-white/10 z-10">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/50 pointer-events-none" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
+              placeholder="Search currency..."
+              className="w-full h-9 pl-9 pr-3 rounded-lg bg-black/50 border border-white/10 text-white placeholder:text-white/50 text-sm focus:outline-none focus:ring-1 focus:ring-white/20"
+            />
+          </div>
+        </div>
+        <div className="py-2">
+          {showFiatCurrencies && (
+            <>
+              <div className="px-4 py-2 text-xs font-medium text-white/50 uppercase tracking-wider">
+                Fiat
               </div>
-              {currencies.map((currency) => (
-                <button
-                  key={`chain-${chainId}-${currency.id}`}
-                  type="button"
-                  className={`w-full px-4 py-2 text-left text-white hover:bg-white/5 flex items-center ${
-                    selectedCurrencies.includes(currency.id) ? "bg-white/5" : ""
-                  }`}
-                  onClick={() => toggleCurrencySelection(currency.id)}
-                >
-                  <div
-                    className={`w-5 h-5 flex items-center justify-center rounded-md border ${
-                      selectedCurrencies.includes(currency.id)
-                        ? "border-white bg-white"
-                        : "border-white/30 bg-transparent"
-                    } mr-3`}
+              {fiatList.length === 0 ? (
+                <div className="px-4 py-2 text-sm text-white/50">
+                  No matching fiat currencies
+                </div>
+              ) : (
+                fiatList.map((currency) => (
+                  <button
+                    key={`fiat-${currency.id}`}
+                    type="button"
+                    className={`w-full px-4 py-2 text-left text-white hover:bg-white/5 flex items-center ${
+                      selectedCurrencies.includes(currency.id) ? "bg-white/5" : ""
+                    }`}
+                    onClick={() => toggleCurrencySelection(currency.id)}
                   >
-                    {selectedCurrencies.includes(currency.id) && (
-                      <Check className="h-3.5 w-3.5 text-black" />
-                    )}
-                  </div>
-                  <div>
-                    <span className="font-medium">{currency.symbol}</span>
-                    <span className="text-white/70"> • {currency.name}</span>
-                  </div>
-                </button>
-              ))}
-            </div>
-          ))}
+                    <div
+                      className={`w-5 h-5 flex items-center justify-center rounded-md border mr-3 ${
+                        selectedCurrencies.includes(currency.id)
+                          ? "border-white bg-white"
+                          : "border-white/30 bg-transparent"
+                      }`}
+                    >
+                      {selectedCurrencies.includes(currency.id) && (
+                        <Check className="h-3.5 w-3.5 text-black" />
+                      )}
+                    </div>
+                    <div>
+                      <span className="font-medium">{currency.id}</span>
+                      <span className="text-white/70"> • {currency.name}</span>
+                    </div>
+                  </button>
+                ))
+              )}
+            </>
+          )}
+
+          {!disableChainCurrencies && (
+            <>
+              <div className="px-4 py-2 text-xs font-medium text-white/50 uppercase tracking-wider mt-1">
+                Crypto
+              </div>
+              {cryptoList.length === 0 ? (
+                <div className="px-4 py-2 text-sm text-white/50">
+                  No matching crypto
+                </div>
+              ) : (
+                cryptoList.map((currency) => (
+                  <button
+                    key={`crypto-${currency.id}`}
+                    type="button"
+                    className={`w-full px-4 py-2 text-left text-white hover:bg-white/5 flex items-center ${
+                      selectedCurrencies.includes(currency.id) ? "bg-white/5" : ""
+                    }`}
+                    onClick={() => toggleCurrencySelection(currency.id)}
+                  >
+                    <div
+                      className={`w-5 h-5 flex items-center justify-center rounded-md border mr-3 ${
+                        selectedCurrencies.includes(currency.id)
+                          ? "border-white bg-white"
+                          : "border-white/30 bg-transparent"
+                      }`}
+                    >
+                      {selectedCurrencies.includes(currency.id) && (
+                        <Check className="h-3.5 w-3.5 text-black" />
+                      )}
+                    </div>
+                    <div>
+                      <span className="font-medium">{currency.symbol}</span>
+                      <span className="text-white/70"> • {currency.name}</span>
+                    </div>
+                  </button>
+                ))
+              )}
+            </>
+          )}
+        </div>
       </>
     );
   };
@@ -197,7 +259,7 @@ export default function CurrencyDropdown({
     mode === "single" ? "Select currency..." : "Select Payment Token...";
 
   return (
-    <div className="relative">
+    <div className="relative" ref={triggerRef}>
       <button
         type="button"
         onClick={() => toggleDropdown("currency")}
@@ -272,19 +334,32 @@ export default function CurrencyDropdown({
         />
       </button>
 
-      <AnimatePresence>
-        {activeDropdown === "currency" && (
-          <motion.div
-            variants={dropdownVariants}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-            className="absolute top-full left-0 right-0 mt-1 bg-[#17171A] rounded-lg py-2 z-[9999] max-h-[320px] overflow-y-auto shadow-xl border border-white/10"
-          >
-            {renderCurrencyDropdown()}
-          </motion.div>
+      {typeof document !== "undefined" &&
+        activeDropdown === "currency" &&
+        dropdownRect &&
+        createPortal(
+          <AnimatePresence>
+            <motion.div
+              data-currency-dropdown-portal
+              variants={dropdownVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+              style={{
+                position: "fixed",
+                top: dropdownRect.top,
+                left: dropdownRect.left,
+                width: dropdownRect.width,
+                maxHeight: dropdownRect.maxHeight,
+                zIndex: 99999,
+              }}
+              className="bg-[#17171A] rounded-lg py-2 overflow-y-auto shadow-xl border border-white/10"
+            >
+              {renderCurrencyDropdown()}
+            </motion.div>
+          </AnimatePresence>,
+          document.body
         )}
-      </AnimatePresence>
     </div>
   );
 }

--- a/components/friends-list.tsx
+++ b/components/friends-list.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { motion } from "framer-motion";
 import { staggerContainer, slideUp } from "@/utils/animations";
 import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
@@ -10,8 +9,35 @@ import { toast } from "sonner";
 import { useEffect } from "react";
 import { ApiError } from "@/types/api-error";
 import { UserPlus } from "lucide-react";
+import { Card, Avatar, Icons, T, fmt, G } from "@/lib/splito-design";
 
-export function FriendsList() {
+const AVATAR_COLORS = [
+  "#A78BFA",
+  "#34D399",
+  "#FB923C",
+  "#F472B6",
+  "#FBBF24",
+  "#22D3EE",
+  "#F87171",
+  "#818CF8",
+];
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase() || "?";
+}
+
+function getFriendBalance(
+  balances: Array<{ currency: string; amount: number }> | undefined
+): number {
+  if (!balances?.length) return 0;
+  return balances.reduce((sum, b) => sum + b.amount, 0);
+}
+
+export function FriendsList({ search = "" }: { search?: string }) {
   const { data: friends, isLoading, error } = useGetFriends();
   const router = useRouter();
 
@@ -31,90 +57,260 @@ export function FriendsList() {
     }
   }, [error, router]);
 
+  const searchLower = search.trim().toLowerCase();
+  const filtered =
+    friends?.filter(
+      (f) =>
+        !searchLower ||
+        f.name.toLowerCase().includes(searchLower) ||
+        (f.email ?? "").toLowerCase().includes(searchLower)
+    ) ?? [];
+
   if (isLoading) {
     return (
-      <div className="text-mobile-base sm:text-base text-white/70 text-center py-6">
-        Loading friends...
-      </div>
+      <Card style={{ padding: "28px" }}>
+        <p
+          style={{
+            color: T.body,
+            fontSize: 14,
+            textAlign: "center",
+            margin: 0,
+          }}
+        >
+          Loading friends...
+        </p>
+      </Card>
     );
   }
 
   if (!friends?.length) {
     return (
-      <div className="flex flex-col items-center justify-center rounded-2xl sm:rounded-3xl bg-[#0f0f10] p-6 sm:p-12 min-h-[calc(100vh-160px)] sm:min-h-[calc(100vh-180px)]">
-        <div className="text-mobile-lg sm:text-xl text-white/70 mb-3 sm:mb-4">
+      <Card
+        style={{
+          padding: "48px 28px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          textAlign: "center",
+        }}
+      >
+        <p style={{ color: T.bright, fontSize: 18, fontWeight: 700, marginBottom: 8 }}>
           No friends added yet
-        </div>
-        <p className="text-mobile-sm sm:text-base text-white/50 text-center max-w-md mb-6 sm:mb-8">
+        </p>
+        <p style={{ color: T.muted, fontSize: 14, marginBottom: 24, maxWidth: 360 }}>
           Add friends to start tracking expenses and settle debts together
         </p>
         <button
           onClick={() =>
             document.dispatchEvent(new CustomEvent("open-add-friend-modal"))
           }
-          className="flex items-center justify-center gap-2 rounded-full bg-white text-black h-10 sm:h-12 px-4 sm:px-6 text-mobile-base sm:text-base font-medium hover:bg-white/90 transition-all"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+            borderRadius: 99,
+            background: "#fff",
+            color: "#0a0a0a",
+            height: 44,
+            paddingLeft: 20,
+            paddingRight: 20,
+            fontSize: 14,
+            fontWeight: 700,
+            border: "none",
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
         >
-          <UserPlus className="h-4 sm:h-5 w-4 sm:w-5" strokeWidth={1.5} />
-          <span>Add Friend</span>
+          <UserPlus size={18} strokeWidth={1.5} />
+          Add Friend
         </button>
-      </div>
+      </Card>
     );
   }
 
   return (
-    <motion.div
-      variants={staggerContainer}
-      initial="initial"
-      animate="animate"
-      className="bg-[#0f0f10] rounded-2xl sm:rounded-[20px] min-h-[calc(100vh-120px)] p-3 sm:p-5"
-    >
-      {friends.map((friend) => (
-        <motion.div
-          key={friend.id}
-          variants={slideUp}
-          className="relative py-4 border-b border-white/5 last:border-b-0"
+    <Card>
+      {filtered.length === 0 ? (
+        <div
+          style={{
+            padding: "28px 24px",
+            color: T.muted,
+            fontSize: 14,
+            textAlign: "center",
+          }}
         >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="h-10 w-10 sm:h-12 sm:w-12 overflow-hidden rounded-full bg-white/5">
-                <Image
-                  src={
-                    friend.image ||
-                    `https://api.dicebear.com/9.x/identicon/svg?seed=${
-                      friend.id || friend.name
-                    }`
-                  }
-                  alt={friend.name}
-                  width={48}
-                  height={48}
-                  className="h-full w-full object-cover"
-                  onError={(e) => {
-                    console.error(
-                      `Error loading image for friend ${friend.name}`
-                    );
-                    // @ts-expect-error - fallback to identicon on error
-                    e.target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${
-                      friend.id || friend.name
-                    }`;
-                  }}
-                />
-              </div>
-              <div>
-                <p className="text-mobile-base sm:text-xl font-medium text-white">
-                  {friend.name}
-                </p>
-                <p className="text-mobile-sm sm:text-sm text-white/60">
-                  {friend.email}
-                </p>
-              </div>
-            </div>
-
-            {/* <button className="text-white text-mobile-sm sm:text-sm rounded-full border border-white/20 px-3 sm:px-4 py-1.5 hover:bg-white/5 transition-colors">
-              View
-            </button> */}
-          </div>
+          No friends match &quot;{search}&quot;
+        </div>
+      ) : (
+        <motion.div
+          variants={staggerContainer}
+          initial="initial"
+          animate="animate"
+          style={{ overflow: "hidden" }}
+        >
+          {filtered.map((friend, idx) => (
+            <FriendRow
+              key={friend.id}
+              friend={friend}
+              index={idx}
+              isLast={idx === filtered.length - 1}
+            />
+          ))}
         </motion.div>
-      ))}
+      )}
+    </Card>
+  );
+}
+
+function FriendRow({
+  friend,
+  index,
+  isLast,
+}: {
+  friend: {
+    id: string;
+    name: string;
+    email?: string | null;
+    balances?: Array<{ currency: string; amount: number }>;
+  };
+  index: number;
+  isLast: boolean;
+}) {
+  const balance = getFriendBalance(friend.balances);
+  const color = AVATAR_COLORS[index % AVATAR_COLORS.length];
+  const init = getInitials(friend.name);
+
+  return (
+    <motion.div
+      variants={slideUp}
+      className="rw"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        padding: "15px 24px",
+        borderBottom: isLast
+          ? "none"
+          : "1px solid rgba(255,255,255,0.06)",
+        transition: "background 0.15s",
+        cursor: "pointer",
+      }}
+    >
+      <Avatar init={init} color={color} size={42} />
+      <div className="min-w-0 flex-1" style={{ overflow: "hidden" }}>
+        <p className="truncate" style={{ fontSize: 14, fontWeight: 700, color: T.bright }}>
+          {friend.name}
+        </p>
+        <p
+          className="truncate block"
+          style={{ fontSize: 12, color: T.muted, marginTop: 2, fontWeight: 500 }}
+          title={friend.email ?? undefined}
+        >
+          {friend.email ?? ""}
+        </p>
+      </div>
+      {balance < 0 && (
+        <button
+          type="button"
+          className="sbtn shrink-0"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 5,
+            background: "rgba(255,255,255,0.06)",
+            border: "1px solid rgba(255,255,255,0.11)",
+            borderRadius: 12,
+            padding: "8px 10px",
+            color: T.body,
+            fontSize: 12,
+            fontWeight: 700,
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          {Icons.wallet({})} Settle
+        </button>
+      )}
+      {balance > 0 && (
+        <button
+          type="button"
+          className="abtn shrink-0"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 5,
+            background: "rgba(255,255,255,0.06)",
+            border: "1px solid rgba(255,255,255,0.11)",
+            borderRadius: 12,
+            padding: "8px 10px",
+            color: T.body,
+            fontSize: 12,
+            fontWeight: 700,
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          {Icons.bell({})} Remind
+        </button>
+      )}
+      <div
+        className="shrink-0 text-right"
+        style={{ minWidth: 64 }}
+      >
+        {balance === 0 ? (
+          <p style={{ color: T.dim, fontSize: 12, fontWeight: 600 }}>Settled</p>
+        ) : balance > 0 ? (
+          <>
+            <p
+              style={{
+                color: G,
+                fontSize: 14,
+                fontWeight: 800,
+                fontFamily: "'DM Mono',monospace",
+              }}
+            >
+              +{fmt(balance)}
+            </p>
+            <p
+              style={{
+                color: "rgba(52,211,153,0.6)",
+                fontSize: 11,
+                marginTop: 2,
+                fontWeight: 600,
+              }}
+            >
+              owes you
+            </p>
+          </>
+        ) : (
+          <>
+            <p
+              style={{
+                color: "#F87171",
+                fontSize: 14,
+                fontWeight: 800,
+                fontFamily: "'DM Mono',monospace",
+              }}
+            >
+              -{fmt(Math.abs(balance))}
+            </p>
+            <p
+              style={{
+                color: "rgba(248,113,113,0.6)",
+                fontSize: 11,
+                marginTop: 2,
+                fontWeight: 600,
+              }}
+            >
+              you owe
+            </p>
+          </>
+        )}
+      </div>
     </motion.div>
   );
 }

--- a/components/group-info-header.tsx
+++ b/components/group-info-header.tsx
@@ -2,8 +2,6 @@
 
 import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
-import { useWallet } from "@/hooks/useWallet";
 import { DetailGroup } from "@/features/groups/api/client";
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
@@ -14,6 +12,7 @@ import { formatCurrency } from "@/utils/formatters";
 import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { cn } from "@/lib/utils";
+import { BackBtn, Btn, Icons, A, T } from "@/lib/splito-design";
 
 export function GroupInfoHeader({
   groupId,
@@ -30,7 +29,6 @@ export function GroupInfoHeader({
 }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { address } = useWallet();
   const [isAddingExpense, setIsAddingExpense] = useState(false);
   const [isSettling, setIsSettling] = useState(false);
   const queryClient = useQueryClient();
@@ -72,11 +70,6 @@ export function GroupInfoHeader({
   );
   const converting = loadingOwe || loadingOwed;
 
-  // Handle profile click to redirect to settings
-  const handleProfileClick = () => {
-    router.push("/settings");
-  };
-
   if (!group) return null;
 
   const handleAddExpenseClick = () => {
@@ -101,237 +94,129 @@ export function GroupInfoHeader({
   };
 
   const tabs = [
-    { label: "Expenses", href: `/groups/${groupId}/splits` },
-    { label: "Activity", href: `/groups/${groupId}/activity` },
+    { label: "Splits", href: `/groups/${groupId}/splits` },
     { label: "Members", href: `/groups/${groupId}/members` },
+    { label: "Activity", href: `/groups/${groupId}/activity` },
   ];
 
+  const memberCount = group.groupUsers?.length ?? 0;
+  const isOwedToUser = owed.length > 0;
+  const isUserOwes = owe.length > 0;
+  const balanceLabel = isOwedToUser ? "owed to you" : isUserOwes ? "you owe" : "all settled";
+
+  const desktopSubtitle = isOwedToUser
+    ? <>You are owed <span className="font-bold text-[#34D399]">{converting ? "…" : formatCurrency(totalOwedToUser, defaultCurrency)}</span></>
+    : isUserOwes
+      ? <>You owe <span className="font-bold text-[#F87171]">{converting ? "…" : formatCurrency(totalUserOwes, defaultCurrency)}</span></>
+      : <span className="font-bold text-[#34D399]">All settled ✓</span>;
+
   return (
-    <div className="mb-6">
-      <div className="flex justify-between items-start">
-        {/* Group Info */}
-        <div className="flex-1 min-w-0 pr-2">
-          <h1 className="text-xl sm:text-2xl font-semibold text-white mb-1 truncate">
-            {group.name}
-          </h1>
-          <p className="text-mobile-base sm:text-lg text-white/70">
-            {owed.length > 0 ? (
-              <>
-                Overall, you owe{" "}
-                <span className="text-[#FF4444]">
-                  {converting ? "…" : formatCurrency(totalUserOwes, defaultCurrency)}
-                </span>
-              </>
-            ) : owe.length > 0 ? (
-              <>
-                Overall, you are owed{" "}
-                <span className="text-[#53e45d]">
-                  {converting ? "…" : formatCurrency(totalOwedToUser, defaultCurrency)}
-                </span>
-              </>
-            ) : (
-              <>You're all settled up!</>
+    <div
+      className="flex flex-col sticky top-0 z-10 border-b"
+      style={{
+        borderBottom: "1px solid rgba(255,255,255,0.07)",
+        background: "rgba(11,11,11,0.95)",
+        backdropFilter: "blur(20px)",
+      }}
+    >
+      {/* Top row: mobile = [icon][name+members][balance]; desktop = [← Back][name+balance text][Settle all][Add Expense] */}
+      <div className="flex items-center justify-between gap-3 px-4 sm:px-7 h-14 sm:h-[70px] min-h-[56px]">
+        <div className="flex items-center gap-3 sm:gap-[14px] min-w-0 flex-1">
+          <BackBtn onClick={() => router.push("/groups")} className="hidden sm:flex" />
+          <div className="min-w-0">
+            <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.03em] text-white truncate">
+              {group.name}
+            </h1>
+            <p className="text-[11px] sm:text-[12px] font-medium mt-0.5" style={{ color: T.mid }}>
+              <span className="sm:hidden">{memberCount} member{memberCount !== 1 ? "s" : ""}</span>
+              <span className="hidden sm:inline">{desktopSubtitle}</span>
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col items-end flex-shrink-0 text-right sm:hidden">
+          <span
+            className={cn(
+              "text-[15px] font-bold tabular-nums",
+              isOwedToUser && "text-[#34D399]",
+              isUserOwes && "text-[#F87171]",
+              !isOwedToUser && !isUserOwes && "text-[#34D399]"
             )}
-          </p>
+          >
+            {converting ? "…" : isOwedToUser ? `+${formatCurrency(totalOwedToUser, defaultCurrency)}` : isUserOwes ? formatCurrency(totalUserOwes, defaultCurrency) : "All settled ✓"}
+          </span>
+          <span className="text-[11px] font-medium" style={{ color: T.mid }}>
+            {balanceLabel}
+          </span>
         </div>
-
-        {/* 2x2 Button Grid for Mobile / Row for Desktop */}
-        <div className="sm:hidden flex gap-3 flex-shrink-0">
-          {/* Left Column - Action Buttons */}
-          <div className="flex flex-col gap-2">
-            <button
-              onClick={handleAddExpenseClick}
-              disabled={isAddingExpense}
-              className="flex h-10 items-center justify-center gap-1 rounded-full bg-white text-black px-4 text-mobile-sm font-medium hover:bg-white/90 transition-all disabled:opacity-70 disabled:cursor-not-allowed truncate"
-            >
-              {isAddingExpense ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" />
-                  <span className="truncate">Adding...</span>
-                </>
-              ) : (
-                <>
-                  <Image
-                    src="/plus-sign-circle.svg"
-                    alt="Add Expense"
-                    width={20}
-                    height={20}
-                    className="invert h-4 w-4 flex-shrink-0"
-                  />
-                  <span className="truncate">Add Expense</span>
-                </>
-              )}
-            </button>
-
-            {/* Settle all debts button - mobile version - commented out */}
-            {/* <button
-              onClick={handleSettleClick}
-              disabled={isSettling}
-              className="flex h-10 items-center justify-center gap-1 rounded-full border border-white/80 bg-transparent px-4 text-mobile-sm font-medium text-white hover:bg-white/5 transition-all disabled:opacity-70 disabled:cursor-not-allowed truncate"
-            >
-              {isSettling ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" />
-                  <span className="truncate">Settling...</span>
-                </>
-              ) : (
-                <>
-                  <Image
-                    src="/coins-dollar.svg"
-                    alt="Settle Debts"
-                    width={20}
-                    height={20}
-                    className="h-4 w-4 flex-shrink-0"
-                  />
-                  <span className="truncate">Settle all debts</span>
-                </>
-              )}
-            </button> */}
-          </div>
-
-          {/* Right Column - Profile and Settings */}
-          <div className="flex flex-col gap-2">
-            <button
-              onClick={handleProfileClick}
-              className="h-10 w-10 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:from-purple-500/30 hover:to-blue-500/30 transition-all cursor-pointer"
-            >
-              <div className="h-full w-full rounded-full overflow-hidden bg-[#101012]">
-                {user?.image ? (
-                  <Image
-                    src={user.image}
-                    alt="Profile"
-                    width={48}
-                    height={48}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <Image
-                    src={`https://api.dicebear.com/9.x/identicon/svg?seed=${
-                      user?.id || user?.email || "user"
-                    }`}
-                    alt="Profile"
-                    width={48}
-                    height={48}
-                    className="h-full w-full"
-                    onError={(e) => {
-                      console.error(`Error loading identicon for user`);
-                      const target = e.target as HTMLImageElement;
-                      target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=user`;
-                    }}
-                  />
-                )}
-              </div>
-            </button>
-
-          </div>
-        </div>
-
-        {/* Horizontal layout for desktop */}
-        <div className="hidden sm:flex items-center gap-3">
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleAddExpenseClick}
-              disabled={isAddingExpense}
-              className="flex h-12 items-center justify-center gap-2 rounded-full bg-white text-black px-5 text-base font-medium hover:bg-white/90 transition-all disabled:opacity-70 disabled:cursor-not-allowed"
-            >
-              {isAddingExpense ? (
-                <>
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                  <span>Adding...</span>
-                </>
-              ) : (
-                <>
-                  <Image
-                    src="/plus-sign-circle.svg"
-                    alt="Add Expense"
-                    width={20}
-                    height={20}
-                    className="invert h-5 w-5"
-                  />
-                  <span>Add Expense</span>
-                </>
-              )}
-            </button>
-
-            {/* Settle all debts button - desktop version - commented out */}
-            {/* <button
-              onClick={handleSettleClick}
-              disabled={isSettling}
-              className="flex h-12 items-center justify-center gap-2 rounded-full border border-white/80 bg-transparent px-5 text-base font-medium text-white hover:bg-white/5 transition-all disabled:opacity-70 disabled:cursor-not-allowed"
-            >
-              {isSettling ? (
-                <>
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                  <span>Settling...</span>
-                </>
-              ) : (
-                <>
-                  <Image
-                    src="/coins-dollar.svg"
-                    alt="Settle Debts"
-                    width={20}
-                    height={20}
-                    className="h-5 w-5"
-                  />
-                  <span>Settle all debts</span>
-                </>
-              )}
-            </button> */}
-
-            <button
-              onClick={handleProfileClick}
-              className="h-12 w-12 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 hover:from-purple-500/30 hover:to-blue-500/30 transition-all cursor-pointer"
-            >
-              <div className="h-full w-full rounded-full overflow-hidden bg-[#101012]">
-                {user?.image ? (
-                  <Image
-                    src={user.image}
-                    alt="Profile"
-                    width={48}
-                    height={48}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <Image
-                    src={`https://api.dicebear.com/9.x/identicon/svg?seed=${
-                      user?.id || user?.email || "user"
-                    }`}
-                    alt="Profile"
-                    width={48}
-                    height={48}
-                    className="h-full w-full"
-                    onError={(e) => {
-                      console.error(`Error loading identicon for user`);
-                      const target = e.target as HTMLImageElement;
-                      target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=user`;
-                    }}
-                  />
-                )}
-              </div>
-            </button>
-          </div>
+        <div className="hidden sm:flex items-center gap-2 flex-shrink-0">
+          <Btn
+            onClick={handleSettleClick}
+            variant="ghost"
+            style={{ padding: "9px 16px", fontSize: 13 }}
+          >
+            <Icons.wallet /> Settle all
+          </Btn>
+          <button
+            onClick={handleAddExpenseClick}
+            disabled={isAddingExpense}
+            className="flex items-center gap-1.5 rounded-xl text-[13px] font-extrabold text-[#0a0a0a] transition-all disabled:opacity-70 hover:opacity-90"
+            style={{ background: A, padding: "10px 18px", gap: 6 }}
+          >
+            {isAddingExpense ? <Loader2 className="h-4 w-4 animate-spin" /> : <Icons.plus />}
+            Add Expense
+          </button>
         </div>
       </div>
 
-      {/* Tab bar */}
-      <div className="mt-5 flex gap-1">
-        {tabs.map((tab) => {
-          const isActive = pathname === tab.href;
-          return (
-            <Link
-              key={tab.href}
-              href={tab.href}
-              className={cn(
-                "px-4 py-2 rounded-full text-sm font-medium transition-all",
-                isActive
-                  ? "bg-white text-black"
-                  : "text-white/60 hover:text-white hover:bg-white/[0.06]"
-              )}
-            >
-              {tab.label}
-            </Link>
-          );
-        })}
+      {/* Action buttons row: mobile only */}
+      <div className="flex gap-2 px-4 sm:px-7 pb-3 sm:pb-4 sm:hidden">
+        <Btn
+          onClick={handleSettleClick}
+          variant="ghost"
+          className="flex-1"
+          style={{ padding: "10px 14px", fontSize: 13, justifyContent: "center" }}
+        >
+          <Icons.wallet /> Settle All
+        </Btn>
+        <button
+          onClick={handleAddExpenseClick}
+          disabled={isAddingExpense}
+          className="flex-1 flex items-center justify-center gap-1.5 rounded-xl text-[13px] font-extrabold text-[#0a0a0a] transition-all disabled:opacity-70 hover:opacity-90 min-h-[42px]"
+          style={{ background: A, padding: "10px 18px", gap: 6 }}
+        >
+          {isAddingExpense ? <Loader2 className="h-4 w-4 animate-spin" /> : <Icons.plus />}
+          Add Expense
+        </button>
+      </div>
+
+      {/* Tabs: Splits, Members, Activity */}
+      <div className="flex items-center px-4 sm:px-7 pb-4 sm:pb-6">
+        <div
+          className="flex rounded-[14px] transition-all w-full sm:w-auto"
+          style={{
+            gap: 3,
+            padding: 4,
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.08)",
+          }}
+        >
+          {tabs.map((tab) => {
+            const isActive = pathname === tab.href;
+            return (
+              <Link
+                key={tab.href}
+                href={tab.href}
+                className={cn(
+                  "flex-1 sm:flex-initial rounded-[10px] text-[13px] transition-all text-center",
+                  isActive ? "bg-white/10 text-white font-bold" : "text-white/60 font-medium"
+                )}
+                style={{ padding: "8px 12px" }}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/components/groups-list-content.tsx
+++ b/components/groups-list-content.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Loader2, AlertTriangle, X, CheckCircle } from "lucide-react";
+import { staggerContainer, slideUp } from "@/utils/animations";
+import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
+import { Card, GroupAvatar, Icons, Tag, G, T } from "@/lib/splito-design";
+
+const AVATAR_COLORS = ["#22D3EE", "#a78bfa", "#34D399", "#fb923c"];
+
+function getInit(name: string | null | undefined, fallback: string): string {
+  if (!name || !name.trim()) return fallback;
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2)
+    return (parts[0].charAt(0) + parts[1].charAt(0)).toUpperCase();
+  return name.charAt(0).toUpperCase();
+}
+
+function relativeTime(date: Date): string {
+  const now = new Date();
+  const d = new Date(date);
+  const sec = Math.floor((now.getTime() - d.getTime()) / 1000);
+  if (sec < 60) return "Just now";
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+  if (sec < 604800) return `${Math.floor(sec / 86400)}d ago`;
+  return `${Math.floor(sec / 604800)}w ago`;
+}
+
+type GroupItem = {
+  id: string;
+  name: string;
+  groupBalances?: { userId: string; currency: string; amount: number }[];
+  groupUsers?: { user: { id: string; name?: string | null } }[];
+  expenses?: unknown[];
+  updatedAt: Date;
+};
+
+function GroupCard({
+  group,
+  user,
+  defaultCurrency,
+  formatCurrency,
+}: {
+  group: GroupItem;
+  user: { id: string; name?: string | null } | null;
+  defaultCurrency: string;
+  formatCurrency: (amount: number, currency: string) => string;
+}) {
+  const balances = group.groupBalances || [];
+  const memberIds = Array.from(new Set(balances.map((b) => b.userId)));
+  // Prefer groupUsers for initials (like Dashboard); fallback to balance-derived list with "?" for others
+  const avatarItems =
+    group.groupUsers && group.groupUsers.length > 0
+      ? group.groupUsers.slice(0, 4).map((gu, i) => ({
+          init: getInit(gu.user.name, gu.user.id === user?.id ? "Y" : "?"),
+          color: AVATAR_COLORS[i % AVATAR_COLORS.length],
+        }))
+      : memberIds.slice(0, 4).map((userId, i) => ({
+          init:
+            userId === user?.id
+              ? getInit(user?.name ?? null, "Y")
+              : "?",
+          color: AVATAR_COLORS[i % AVATAR_COLORS.length],
+        }));
+  if (avatarItems.length === 0)
+    avatarItems.push({
+      init: group.name.charAt(0).toUpperCase() || "G",
+      color: AVATAR_COLORS[0],
+    });
+
+  const userBalances = balances.filter((b) => b.userId === user?.id);
+  const byCurrency: Record<string, number> = {};
+  userBalances.forEach((b) => {
+    byCurrency[b.currency] = (byCurrency[b.currency] ?? 0) + b.amount;
+  });
+  const oweItems = Object.entries(byCurrency)
+    .filter(([, a]) => a > 0)
+    .map(([currency, amount]) => ({ amount, currency }));
+  const owedItems = Object.entries(byCurrency)
+    .filter(([, a]) => a < 0)
+    .map(([currency, amount]) => ({ amount: Math.abs(amount), currency }));
+
+  const { total: totalOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
+  const { total: totalOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
+  const net = totalOwed - totalOwe;
+
+  const balanceLabel = (() => {
+    if (net === 0) return { text: "±$0", color: T.muted };
+    if (net > 0) return { text: `+$${net.toFixed(2)}`, color: G };
+    return { text: `-$${Math.abs(net).toFixed(2)}`, color: "#FF4444" };
+  })();
+  const totalMagnitude = Object.values(byCurrency).reduce((s, a) => s + Math.abs(a), 0);
+  const totalLabel = totalMagnitude > 0 ? formatCurrency(totalMagnitude, defaultCurrency) : formatCurrency(0, defaultCurrency);
+  const memberCount = memberIds.length;
+  const expenseCount = Array.isArray((group as { expenses?: unknown[] }).expenses)
+    ? (group as { expenses: unknown[] }).expenses.length
+    : 0;
+  const ago = relativeTime(group.updatedAt);
+  const groupUrl = `/groups/${group.id}`;
+
+  const isEmpty = net === 0 && expenseCount === 0;
+
+  return (
+    <motion.div variants={slideUp}>
+      <Link
+        href={groupUrl}
+        className="flex items-center w-full text-left transition-colors hover:bg-white/[0.03] gap-3 sm:gap-4 py-4 px-4 sm:py-[18px] sm:px-6"
+      >
+        <GroupAvatar items={avatarItems} size={52} radius={17} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 mb-0.5">
+            <p className="text-[15px] font-extrabold text-white truncate tracking-[-0.01em]" style={{ color: T.bright }}>
+              {group.name}
+            </p>
+            {isEmpty && <span className="shrink-0"><Tag color={T.sub}>Empty</Tag></span>}
+          </div>
+          <p className="text-[12px] font-semibold" style={{ color: T.muted }}>
+            {memberCount} members · {expenseCount} expenses · {ago}
+          </p>
+        </div>
+        <div className="flex items-center shrink-0" style={{ gap: 8 }}>
+          <div className="text-right">
+            <p
+              className="font-[family-name:var(--font-dm-mono)] text-[17px] font-extrabold"
+              style={{ color: balanceLabel.color }}
+            >
+              {balanceLabel.text}
+            </p>
+            <p className="text-[11px] font-semibold mt-[3px]" style={{ color: T.muted }}>
+              total {totalLabel}
+            </p>
+          </div>
+          <span className="text-white/40">{Icons.chevR({ size: 18 })}</span>
+        </div>
+      </Link>
+    </motion.div>
+  );
+}
+
+export interface GroupsListContentProps {
+  filteredGroups: GroupItem[];
+  user: { id: string; name?: string | null } | null;
+  defaultCurrency: string;
+  formatCurrency: (amount: number, currency: string) => string;
+  getCurrencySymbol: (id: string) => string;
+  netBalanceFormatted: string;
+  netBalanceColor: string;
+  totalSpentFormatted: string;
+  showDeleteModal: boolean;
+  setShowDeleteModal: (v: boolean) => void;
+  groupToDelete: { id: string; name: string } | null;
+  setGroupToDelete: (v: { id: string; name: string } | null) => void;
+  deleteSuccess: boolean;
+  deleteError: string | null;
+  isDeleting: boolean;
+  confirmDelete: () => void;
+}
+
+export function GroupsListContent(props: GroupsListContentProps) {
+  const {
+    filteredGroups,
+    user,
+    defaultCurrency,
+    formatCurrency,
+    netBalanceFormatted,
+    netBalanceColor,
+    totalSpentFormatted,
+    showDeleteModal,
+    setShowDeleteModal,
+    groupToDelete,
+    setGroupToDelete,
+    deleteSuccess,
+    deleteError,
+    isDeleting,
+    confirmDelete,
+  } = props;
+
+  return (
+    <div>
+      <div
+        className="grid grid-cols-3 gap-2 sm:gap-3 mb-4 sm:mb-6"
+      >
+        <Card className="p-3 sm:p-5 min-w-0">
+          <p className="uppercase mb-1 sm:mb-2 text-[10px] sm:text-[11px] font-bold tracking-wider truncate" style={{ color: T.muted }}>Groups</p>
+          <p className="font-[family-name:var(--font-dm-mono)] text-base sm:text-[22px] font-extrabold tracking-tight truncate" style={{ color: "#e8e8e8" }}>{filteredGroups.length}</p>
+        </Card>
+        <Card className="p-3 sm:p-5 min-w-0">
+          <p className="uppercase mb-1 sm:mb-2 text-[10px] sm:text-[11px] font-bold tracking-wider truncate" style={{ color: T.muted }}>Total spent</p>
+          <p className="font-[family-name:var(--font-dm-mono)] text-base sm:text-[22px] font-extrabold tracking-tight truncate" style={{ color: "#e8e8e8" }}>{totalSpentFormatted}</p>
+        </Card>
+        <Card className="p-3 sm:p-5 min-w-0">
+          <p className="uppercase mb-1 sm:mb-2 text-[10px] sm:text-[11px] font-bold tracking-wider truncate" style={{ color: T.muted }}>Net balance</p>
+          <p className="font-[family-name:var(--font-dm-mono)] text-base sm:text-[22px] font-extrabold tracking-tight truncate" style={{ color: netBalanceColor }}>{netBalanceFormatted}</p>
+        </Card>
+      </div>
+
+      <Card style={{ padding: 0 }}>
+        {filteredGroups.length === 0 ? (
+          <div style={{ padding: "50px", textAlign: "center" }}>
+            <p style={{ fontSize: 15, fontWeight: 600, color: T.muted }}>No groups found</p>
+          </div>
+        ) : (
+          <motion.div variants={staggerContainer} initial="initial" animate="animate">
+            {filteredGroups.map((group, idx) => (
+              <div
+                key={group.id}
+                style={{
+                  borderBottom: idx < filteredGroups.length - 1 ? "1px solid rgba(255,255,255,0.06)" : "none",
+                }}
+              >
+                <GroupCard
+                  group={group}
+                  user={user}
+                  defaultCurrency={defaultCurrency}
+                  formatCurrency={formatCurrency}
+                />
+              </div>
+            ))}
+          </motion.div>
+        )}
+      </Card>
+
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 brightness-50 p-4">
+          <div className="relative z-10 w-full max-w-[360px] sm:max-w-[400px] rounded-xl bg-[#101012] p-4 sm:p-6">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg sm:text-xl font-medium text-white">Delete Group</h3>
+              <button onClick={() => { setShowDeleteModal(false); setGroupToDelete(null); }} className="rounded-full p-1 hover:bg-white/10">
+                <X className="h-5 w-5 text-white/70" />
+              </button>
+            </div>
+            {deleteSuccess ? (
+              <div className="flex flex-col items-center justify-center py-4">
+                <CheckCircle className="mb-3 sm:mb-4 h-8 sm:h-10 w-8 sm:w-10 text-green-500" />
+                <p className="text-center text-mobile-base sm:text-base text-white">Group &quot;{groupToDelete?.name}&quot; has been deleted.</p>
+              </div>
+            ) : (
+              <>
+                {deleteError ? (
+                  <div className="mb-4 rounded-lg bg-red-500/10 p-3 text-red-400">
+                    <div className="flex items-start gap-2">
+                      <AlertTriangle className="mt-0.5 h-4 sm:h-5 w-4 sm:w-5 flex-shrink-0" />
+                      <p className="text-mobile-sm sm:text-sm">{deleteError}</p>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="mb-4 text-mobile-base sm:text-base text-white/70">
+                    Are you sure you want to delete &quot;{groupToDelete?.name}&quot;? This action cannot be undone.
+                  </p>
+                )}
+                <div className="flex justify-end gap-2">
+                  <button onClick={() => { setShowDeleteModal(false); setGroupToDelete(null); }} className="rounded-lg px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-white/70 hover:bg-white/5">Cancel</button>
+                  <button onClick={confirmDelete} disabled={isDeleting} className="flex items-center gap-1.5 sm:gap-2 rounded-lg bg-red-500/10 px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50">
+                    {isDeleting ? (<><Loader2 className="h-3.5 sm:h-4 w-3.5 sm:w-4 animate-spin" /><span>Deleting...</span></>) : <span>Delete</span>}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/groups-list.tsx
+++ b/components/groups-list.tsx
@@ -21,8 +21,56 @@ import Cookies from "js-cookie";
 import { toast } from "sonner";
 import { ApiError } from "@/types/api-error";
 import { useDeleteGroup } from "@/features/groups/hooks/use-create-group";
-import { useGetAllCurrencies } from "@/features/currencies/hooks/use-currencies";
+import { useGetAllCurrencies, useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
 import { useAuthStore } from "@/stores/authStore";
+
+/** Shows aggregated (converted to default currency) balance for one group */
+function GroupBalanceAggregated({
+  oweItems,
+  owedItems,
+  defaultCurrency,
+  formatCurrency,
+}: {
+  oweItems: { amount: number; currency: string }[];
+  owedItems: { amount: number; currency: string }[];
+  defaultCurrency: string;
+  formatCurrency: (amount: number, currency: string) => string;
+}) {
+  const { total: totalOwe, isLoading: loadingOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
+  const { total: totalOwed, isLoading: loadingOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
+  const hasOwe = oweItems.length > 0;
+  const hasOwed = owedItems.length > 0;
+  if (!hasOwe && !hasOwed) return <span className="text-white/60">Settled</span>;
+  if (loadingOwe || loadingOwed) return <span className="text-white/60">…</span>;
+  if (hasOwe && hasOwed) {
+    return (
+      <div className="text-mobile-xs sm:text-sm">
+        <div>
+          You owe{" "}
+          <span className="text-[#FF4444]">{formatCurrency(totalOwe, defaultCurrency)}</span>
+        </div>
+        <div>
+          Owes you{" "}
+          <span className="text-[#53e45d]">{formatCurrency(totalOwed, defaultCurrency)}</span>
+        </div>
+      </div>
+    );
+  }
+  if (hasOwe) {
+    return (
+      <span>
+        You owe{" "}
+        <span className="text-[#FF4444]">{formatCurrency(totalOwe, defaultCurrency)}</span>
+      </span>
+    );
+  }
+  return (
+    <span>
+      Owes you{" "}
+      <span className="text-[#53e45d]">{formatCurrency(totalOwed, defaultCurrency)}</span>
+    </span>
+  );
+}
 
 export function GroupsList() {
   const {
@@ -181,7 +229,7 @@ export function GroupsList() {
           className="flex items-center justify-center gap-2 rounded-full bg-white text-black h-10 sm:h-12 px-4 sm:px-6 text-mobile-base sm:text-base font-medium hover:bg-white/90 transition-all"
         >
           <Plus className="h-4 sm:h-5 w-4 sm:w-5" strokeWidth={1.5} />
-          <span>Create app</span>
+          <span>Create Group</span>
         </button>
       </div>
     );
@@ -225,74 +273,17 @@ export function GroupsList() {
               }
             });
 
-            const hasOwedBalances = Object.keys(owedBalances).length > 0;
-            const hasOweBalances = Object.keys(oweBalances).length > 0;
+            const oweItems = Object.entries(oweBalances).map(([currency, amount]) => ({ amount, currency }));
+            const owedItems = Object.entries(owedBalances).map(([currency, amount]) => ({ amount, currency }));
 
-            // Total owed to you in default currency (for "Owes you" line)
-            const owedInDefault = owedBalances[defaultCurrency] ?? 0;
-            const owedOtherCurrencies = Object.entries(owedBalances).filter(([c]) => c !== defaultCurrency);
-
-            if (hasOwedBalances && hasOweBalances) {
-              // Show both what you owe and what you're owed
-              balanceDisplay = (
-                <div className="text-mobile-xs sm:text-sm">
-                  <div>
-                    You owe{" "}
-                    {Object.entries(oweBalances).map(([curr, amount], index) => (
-                      <span key={curr}>
-                        <span className="text-[#FF4444]">{formatCurrency(amount, curr)}</span>
-                        {index < Object.entries(oweBalances).length - 1 && ", "}
-                      </span>
-                    ))}
-                  </div>
-                  <div>
-                    Owes you{" "}
-                    <span className="text-[#53e45d]">{formatCurrency(owedInDefault, defaultCurrency)}</span>
-                    {owedOtherCurrencies.length > 0 && (
-                      <>{" "}
-                        {owedOtherCurrencies.map(([curr, amount], index) => (
-                          <span key={curr}>
-                            <span className="text-[#53e45d]">{formatCurrency(amount, curr)}</span>
-                            {index < owedOtherCurrencies.length - 1 && ", "}
-                          </span>
-                        ))}
-                      </>
-                    )}
-                  </div>
-                </div>
-              );
-            } else if (hasOweBalances) {
-              balanceDisplay = (
-                <span>
-                  You owe{" "}
-                  {Object.entries(oweBalances).map(([curr, amount], index) => (
-                    <span key={curr}>
-                      <span className="text-[#FF4444]">{formatCurrency(amount, curr)}</span>
-                      {index < Object.entries(oweBalances).length - 1 && ", "}
-                    </span>
-                  ))}
-                </span>
-              );
-            } else if (hasOwedBalances) {
-              balanceDisplay = (
-                <span>
-                  Owes you{" "}
-                  <span className="text-[#53e45d]">{formatCurrency(owedInDefault, defaultCurrency)}</span>
-                  {owedOtherCurrencies.length > 0 && (
-                    <>{" "}
-                      {owedOtherCurrencies.map(([curr, amount], index) => (
-                        <span key={curr}>
-                          <span className="text-[#53e45d]">{formatCurrency(amount, curr)}</span>
-                          {index < owedOtherCurrencies.length - 1 && ", "}
-                        </span>
-                      ))}
-                    </>
-                  )}
-                </span>
-              );
-            } else {
-              balanceDisplay = <span className="text-white/60">Settled</span>;
-            }
+            balanceDisplay = (
+              <GroupBalanceAggregated
+                oweItems={oweItems}
+                owedItems={owedItems}
+                defaultCurrency={defaultCurrency}
+                formatCurrency={formatCurrency}
+              />
+            );
           } else {
             balanceDisplay = <span className="text-white/60">No balance</span>;
           }
@@ -307,22 +298,32 @@ export function GroupsList() {
                   href={groupUrl}
                   className="flex flex-1 min-w-0 items-center gap-3 cursor-pointer"
                 >
-                  <div className="flex-shrink-0 h-10 w-10 sm:h-12 sm:w-12 overflow-hidden rounded-full bg-white/5">
-                    <Image
-                      src={group.image || "/group_icon_placeholder.png"}
-                      alt={group.name}
-                      className="h-full w-full object-cover"
-                      width={48}
-                      height={48}
-                      onError={(e) => {
-                        console.error(
-                          `Error loading image for group ${group.name}:`,
-                          group.image
-                        );
-                        const target = e.target as HTMLImageElement;
-                        target.src = "/group_icon_placeholder.png";
-                      }}
-                    />
+                  <div className="flex-shrink-0 h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-xl bg-white/[0.03]">
+                    {group.image ? (
+                      <Image
+                        src={group.image}
+                        alt={group.name}
+                        width={56}
+                        height={56}
+                        className="h-full w-full object-cover"
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${group.id}`;
+                        }}
+                      />
+                    ) : (
+                      <Image
+                        src={`https://api.dicebear.com/9.x/identicon/svg?seed=${group.id}`}
+                        alt={group.name}
+                        width={56}
+                        height={56}
+                        className="h-full w-full"
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=group`;
+                        }}
+                      />
+                    )}
                   </div>
                   <div className="min-w-0">
                     <p className="text-mobile-base sm:text-xl font-medium text-white">

--- a/components/groups-list.tsx
+++ b/components/groups-list.tsx
@@ -1,20 +1,10 @@
 "use client";
 
-import {
-  Trash2,
-  Loader2,
-  AlertTriangle,
-  X,
-  CheckCircle,
-  Plus,
-} from "lucide-react";
-import { useState, useEffect } from "react";
-import Link from "next/link";
-import Image from "next/image";
-import { motion } from "framer-motion";
-import { staggerContainer, slideUp } from "@/utils/animations";
+import React from "react";
+import { Plus } from "lucide-react";
+import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { getAllGroupsWithBalances } from "@/features/groups/api/client";
+import { getAllGroups } from "@/features/groups/api/client";
 import { useQuery } from "@tanstack/react-query";
 import { QueryKeys } from "@/lib/constants";
 import Cookies from "js-cookie";
@@ -23,69 +13,54 @@ import { ApiError } from "@/types/api-error";
 import { useDeleteGroup } from "@/features/groups/hooks/use-create-group";
 import { useGetAllCurrencies, useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
 import { useAuthStore } from "@/stores/authStore";
+import { G, T } from "@/lib/splito-design";
+import { GroupsListContent } from "@/components/groups-list-content";
 
-/** Shows aggregated (converted to default currency) balance for one group */
-function GroupBalanceAggregated({
-  oweItems,
-  owedItems,
-  defaultCurrency,
-  formatCurrency,
-}: {
-  oweItems: { amount: number; currency: string }[];
-  owedItems: { amount: number; currency: string }[];
-  defaultCurrency: string;
-  formatCurrency: (amount: number, currency: string) => string;
-}) {
-  const { total: totalOwe, isLoading: loadingOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
-  const { total: totalOwed, isLoading: loadingOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
-  const hasOwe = oweItems.length > 0;
-  const hasOwed = owedItems.length > 0;
-  if (!hasOwe && !hasOwed) return <span className="text-white/60">Settled</span>;
-  if (loadingOwe || loadingOwed) return <span className="text-white/60">…</span>;
-  if (hasOwe && hasOwed) {
-    return (
-      <div className="text-mobile-xs sm:text-sm">
-        <div>
-          You owe{" "}
-          <span className="text-[#FF4444]">{formatCurrency(totalOwe, defaultCurrency)}</span>
-        </div>
-        <div>
-          Owes you{" "}
-          <span className="text-[#53e45d]">{formatCurrency(totalOwed, defaultCurrency)}</span>
-        </div>
-      </div>
-    );
-  }
-  if (hasOwe) {
-    return (
-      <span>
-        You owe{" "}
-        <span className="text-[#FF4444]">{formatCurrency(totalOwe, defaultCurrency)}</span>
-      </span>
-    );
-  }
-  return (
-    <span>
-      Owes you{" "}
-      <span className="text-[#53e45d]">{formatCurrency(totalOwed, defaultCurrency)}</span>
-    </span>
-  );
-}
-
-export function GroupsList() {
+export function GroupsList({ searchQuery = "" }: { searchQuery?: string }) {
   const {
     data: groupsData,
     isLoading: isGroupsLoading,
     error,
   } = useQuery({
     queryKey: [QueryKeys.GROUPS, "PERSONAL"],
-    queryFn: () => getAllGroupsWithBalances({ type: "PERSONAL" }),
+    queryFn: () => getAllGroups({ type: "PERSONAL" }),
   });
   const deleteGroupMutation = useDeleteGroup();
   const router = useRouter();
   const { user } = useAuthStore();
   const { data: allCurrencies } = useGetAllCurrencies();
   const defaultCurrency = user?.currency || "USD";
+
+  const filteredGroups = useMemo(() => {
+    if (!groupsData) return [];
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return groupsData;
+    return groupsData.filter((g) => g.name.toLowerCase().includes(q));
+  }, [groupsData, searchQuery]);
+
+  // Aggregate owe/owed across all groups for net balance
+  const { totalOweItems, totalOwedItems } = useMemo(() => {
+    if (!user || !groupsData) return { totalOweItems: [] as { amount: number; currency: string }[], totalOwedItems: [] as { amount: number; currency: string }[] };
+    const oweItems: { amount: number; currency: string }[] = [];
+    const owedItems: { amount: number; currency: string }[] = [];
+    groupsData.forEach((group) => {
+      const balances = group.groupBalances || [];
+      const userBalances = balances.filter((b) => b.userId === user.id);
+      const byCurrency: Record<string, number> = {};
+      userBalances.forEach((b) => {
+        byCurrency[b.currency] = (byCurrency[b.currency] ?? 0) + b.amount;
+      });
+      Object.entries(byCurrency).forEach(([curr, amount]) => {
+        if (amount > 0) oweItems.push({ amount, currency: curr });
+        else if (amount < 0) owedItems.push({ amount: Math.abs(amount), currency: curr });
+      });
+    });
+    return { totalOweItems: oweItems, totalOwedItems: owedItems };
+  }, [groupsData, user]);
+
+  const { total: totalOwe } = useConvertedBalanceTotal(totalOweItems, defaultCurrency);
+  const { total: totalOwed } = useConvertedBalanceTotal(totalOwedItems, defaultCurrency);
+  const netBalance = totalOwed - totalOwe;
 
   // Helper function to get currency symbol from the currencies data
   const getCurrencySymbol = (currencyId: string): string => {
@@ -100,6 +75,19 @@ export function GroupsList() {
     const decimals = currencyId === 'JPY' ? 0 : 2;
     return `${symbol}${amount.toFixed(decimals)}`;
   };
+
+  // Total spent across all groups (sum of all expense amounts, converted to default currency)
+  const totalSpentItems = useMemo(() => {
+    if (!groupsData) return [];
+    return groupsData.flatMap((g) =>
+      (Array.isArray((g as { expenses?: { amount: number; currency: string }[] }).expenses)
+        ? (g as { expenses: { amount: number; currency: string }[] }).expenses
+        : []
+      ).map((e) => ({ amount: e.amount, currency: e.currency }))
+    );
+  }, [groupsData]);
+  const { total: totalSpent } = useConvertedBalanceTotal(totalSpentItems, defaultCurrency);
+  const totalSpentFormatted = formatCurrency(totalSpent, defaultCurrency);
 
   useEffect(() => {
     if (error) {
@@ -142,7 +130,7 @@ export function GroupsList() {
     };
   }, []);
 
-  const handleDeleteGroup = (
+  const _handleDeleteGroup = (
     e: React.MouseEvent,
     groupId: string,
     groupName: string
@@ -235,191 +223,30 @@ export function GroupsList() {
     );
   }
 
-  return (
-    <div className="bg-[#0f0f10] rounded-2xl sm:rounded-[20px] min-h-[calc(100vh-120px)] mt-2">
-      <motion.div
-        variants={staggerContainer}
-        initial="initial"
-        animate="animate"
-      >
-        {groupsData.map((group) => {
-          const groupUrl = `/groups/${group.id}`;
-          // Calculate the balances by currency for the current user in this group
-          let balanceDisplay = null;
-          if (user && group.groupBalances && Array.isArray(group.groupBalances)) {
-            // Group balances by currency for the user in this group
-            const userBalances = group.groupBalances.filter(
-              (b) => b.userId === user.id
-            );
-            
-            // Group balances by currency
-            const balancesByCurrency = userBalances.reduce((acc, balance) => {
-              if (!acc[balance.currency]) {
-                acc[balance.currency] = 0;
-              }
-              acc[balance.currency] += balance.amount;
-              return acc;
-            }, {} as Record<string, number>);
+  // Summary stats: net balance formatted (use default currency symbol)
+  const netBalanceFormatted = (() => {
+    if (netBalance > 0) return formatCurrency(netBalance, defaultCurrency);
+    if (netBalance < 0) return `-${formatCurrency(Math.abs(netBalance), defaultCurrency)}`;
+    return formatCurrency(0, defaultCurrency);
+  })();
+  const netBalanceColor = netBalance > 0 ? G : netBalance < 0 ? "#FF4444" : T.muted;
 
-            // Separate positive and negative balances by currency
-            const oweBalances: Record<string, number> = {}; // What you owe others (positive amounts)
-            const owedBalances: Record<string, number> = {}; // What others owe you (negative amounts)
-            
-            Object.entries(balancesByCurrency).forEach(([curr, amount]) => {
-              if (amount > 0) {
-                oweBalances[curr] = amount; // You owe others
-              } else if (amount < 0) {
-                owedBalances[curr] = Math.abs(amount); // Others owe you
-              }
-            });
-
-            const oweItems = Object.entries(oweBalances).map(([currency, amount]) => ({ amount, currency }));
-            const owedItems = Object.entries(owedBalances).map(([currency, amount]) => ({ amount, currency }));
-
-            balanceDisplay = (
-              <GroupBalanceAggregated
-                oweItems={oweItems}
-                owedItems={owedItems}
-                defaultCurrency={defaultCurrency}
-                formatCurrency={formatCurrency}
-              />
-            );
-          } else {
-            balanceDisplay = <span className="text-white/60">No balance</span>;
-          }
-          return (
-            <motion.div
-              key={group.id}
-              variants={slideUp}
-              className="relative px-3 sm:px-5 py-4 sm:py-6 border-b border-white/5 last:border-b-0 hover:bg-white/[0.02] transition-colors"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <Link
-                  href={groupUrl}
-                  className="flex flex-1 min-w-0 items-center gap-3 cursor-pointer"
-                >
-                  <div className="flex-shrink-0 h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-xl bg-white/[0.03]">
-                    {group.image ? (
-                      <Image
-                        src={group.image}
-                        alt={group.name}
-                        width={56}
-                        height={56}
-                        className="h-full w-full object-cover"
-                        onError={(e) => {
-                          const target = e.target as HTMLImageElement;
-                          target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${group.id}`;
-                        }}
-                      />
-                    ) : (
-                      <Image
-                        src={`https://api.dicebear.com/9.x/identicon/svg?seed=${group.id}`}
-                        alt={group.name}
-                        width={56}
-                        height={56}
-                        className="h-full w-full"
-                        onError={(e) => {
-                          const target = e.target as HTMLImageElement;
-                          target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=group`;
-                        }}
-                      />
-                    )}
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-mobile-base sm:text-xl font-medium text-white">
-                      {group.name}
-                    </p>
-                    <p className="text-mobile-sm sm:text-sm text-white/60">
-                      {balanceDisplay}
-                    </p>
-                  </div>
-                </Link>
-                <button
-                  type="button"
-                  onClick={(e) => handleDeleteGroup(e, group.id, group.name)}
-                  className="shrink-0 p-2 rounded-lg text-white/50 hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                  aria-label={`Delete group ${group.name}`}
-                >
-                  <Trash2 className="h-4 w-4 sm:h-5 sm:w-5" />
-                </button>
-              </div>
-            </motion.div>
-          );
-        })}
-      </motion.div>
-
-      {/* Delete Confirmation Modal */}
-      {showDeleteModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 brightness-50 p-4">
-          <div className="relative z-10 w-full max-w-[360px] sm:max-w-[400px] rounded-xl bg-[#101012] p-4 sm:p-6">
-            <div className="mb-4 flex items-center justify-between">
-              <h3 className="text-lg sm:text-xl font-medium text-white">
-                Delete Group
-              </h3>
-              <button
-                onClick={() => {
-                  setShowDeleteModal(false);
-                  setGroupToDelete(null);
-                }}
-                className="rounded-full p-1 hover:bg-white/10"
-              >
-                <X className="h-5 w-5 text-white/70" />
-              </button>
-            </div>
-
-            {deleteSuccess ? (
-              <div className="flex flex-col items-center justify-center py-4">
-                <CheckCircle className="mb-3 sm:mb-4 h-8 sm:h-10 w-8 sm:w-10 text-green-500" />
-                <p className="text-center text-mobile-base sm:text-base text-white">
-                  Group "{groupToDelete?.name}" has been deleted.
-                </p>
-              </div>
-            ) : (
-              <>
-                {deleteError ? (
-                  <div className="mb-4 rounded-lg bg-red-500/10 p-3 text-red-400">
-                    <div className="flex items-start gap-2">
-                      <AlertTriangle className="mt-0.5 h-4 sm:h-5 w-4 sm:w-5 flex-shrink-0" />
-                      <p className="text-mobile-sm sm:text-sm">{deleteError}</p>
-                    </div>
-                  </div>
-                ) : (
-                  <p className="mb-4 text-mobile-base sm:text-base text-white/70">
-                    Are you sure you want to delete "{groupToDelete?.name}"?
-                    This action cannot be undone.
-                  </p>
-                )}
-
-                <div className="flex justify-end gap-2">
-                  <button
-                    onClick={() => {
-                      setShowDeleteModal(false);
-                      setGroupToDelete(null);
-                    }}
-                    className="rounded-lg px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-white/70 hover:bg-white/5"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={confirmDelete}
-                    disabled={isDeleting}
-                    className="flex items-center gap-1.5 sm:gap-2 rounded-lg bg-red-500/10 px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
-                  >
-                    {isDeleting ? (
-                      <>
-                        <Loader2 className="h-3.5 sm:h-4 w-3.5 sm:w-4 animate-spin" />
-                        <span>Deleting...</span>
-                      </>
-                    ) : (
-                      <span>Delete</span>
-                    )}
-                  </button>
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
-  );
+  return React.createElement(GroupsListContent, {
+    filteredGroups,
+    user,
+    defaultCurrency,
+    formatCurrency,
+    getCurrencySymbol,
+    netBalanceFormatted,
+    netBalanceColor,
+    totalSpentFormatted,
+    showDeleteModal,
+    setShowDeleteModal,
+    groupToDelete,
+    setGroupToDelete,
+    deleteSuccess,
+    deleteError,
+    isDeleting,
+    confirmDelete,
+  });
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,12 +2,13 @@
 
 import { Menu } from "lucide-react";
 import { useMobileMenu } from "@/contexts/mobile-menu";
-import Image from "next/image";
 import { useAuthStore } from "@/stores/authStore";
+import { ProfileDropdown } from "@/components/profile-dropdown";
 
 export function Header() {
   const { toggle } = useMobileMenu();
   const { user, isAuthenticated } = useAuthStore();
+  const profileHref = "/settings";
 
   return (
     <div className="fixed left-0 right-0 top-0 z-20 min-[1025px]:pl-[240px]">
@@ -23,33 +24,7 @@ export function Header() {
 
           <div className="flex flex-1 items-center justify-end gap-2 lg:gap-4">
             {isAuthenticated && user && (
-              <div className="h-9 w-9 sm:h-12 sm:w-12 overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5">
-                <div className="h-full w-full rounded-full overflow-hidden bg-[#101012]">
-                  {user.image ? (
-                    <Image
-                      src={user.image}
-                      alt="Profile"
-                      width={48}
-                      height={48}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <Image
-                      src={`https://api.dicebear.com/9.x/identicon/svg?seed=${
-                        user.id || user.email
-                      }`}
-                      alt="Profile"
-                      width={48}
-                      height={48}
-                      className="h-full w-full"
-                      onError={(e) => {
-                        // @ts-expect-error - fallback to a simpler seed
-                        e.target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=user`;
-                      }}
-                    />
-                  )}
-                </div>
-              </div>
+              <ProfileDropdown user={user} profileHref={profileHref} />
             )}
           </div>
         </div>

--- a/components/mobile-menu-toggle.tsx
+++ b/components/mobile-menu-toggle.tsx
@@ -11,7 +11,7 @@ export function MobileMenuToggle() {
     <button
       onClick={toggle}
       className={cn(
-        "fixed top-4 left-4 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-[#1F1F23]/80 brightness-95 transition-all hover:bg-[#2a2a2e] shadow-md min-[1025px]:hidden",
+        "fixed top-4 left-4 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-[#1F1F23]/80 brightness-95 transition-all hover:bg-[#2a2a2e] shadow-md hidden",
         isOpen ? "opacity-0 pointer-events-none translate-x-2" : "opacity-100"
       )}
       aria-label="Toggle menu"

--- a/components/onboarding-gate.tsx
+++ b/components/onboarding-gate.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { useGetUser } from "@/features/user/hooks/use-update-profile";
 import { useGetAllOrganizations } from "@/features/business/hooks/use-organizations";
 import { OnboardingModal } from "./onboarding-modal";
-import { OnboardingTutorial, type OnboardingMode } from "./onboarding-tutorial";
+import { OnboardingTutorial, type OnboardingMode, type OrganizationOnboardingPhase } from "./onboarding-tutorial";
 import { APP_MODE } from "@/lib/app-mode";
 
 function isOrgAdmin(
@@ -37,6 +37,12 @@ export function OnboardingGate() {
     return org ? isOrgAdmin(org, userData.id) : false;
   }, [mode, userData?.id, organizations, pathname]);
 
+  const organizationPhase: OrganizationOnboardingPhase | null = useMemo(() => {
+    if (mode !== "organization") return null;
+    const inOrgRoute = pathname?.match(/^\/organization\/([^/]+)(?:\/|$)/);
+    return inOrgRoute ? "in-org" : "no-org";
+  }, [mode, pathname]);
+
   const isAuthPage = pathname?.match(/^\/login|^\/signup/);
   const hasNoDisplayName =
     !userData?.name || (typeof userData.name === "string" && userData.name.trim() === "");
@@ -44,50 +50,56 @@ export function OnboardingGate() {
     userData?.email &&
     userData?.name &&
     String(userData.name).trim().toLowerCase() === String(userData.email).trim().toLowerCase();
-  
+
   const isNewProfile = userData && (hasNoDisplayName || nameIsEmail);
 
   useEffect(() => {
     if (!userData?.id || isAuthPage || isLoading) return;
     if (mode === "organization" && !orgsFetched) return;
 
-    const tutorialKey = `hasSeenTutorial_${mode}_${userData.id}`;
-    const hasSeenTutorial = localStorage.getItem(tutorialKey);
-
-    if (!hasSeenTutorial && !isNewProfile) {
-      setShowTutorial(true);
+    if (mode === "personal") {
+      const key = `hasSeenTutorial_personal_${userData.id}`;
+      if (!localStorage.getItem(key) && !isNewProfile) {
+        setShowTutorial(true);
+      }
+      return;
     }
-  }, [userData, isNewProfile, isLoading, isAuthPage, mode, orgsFetched]);
 
-
+    if (mode === "organization" && organizationPhase) {
+      const key = `hasSeenTutorial_organization_${organizationPhase}_${userData.id}`;
+      if (!localStorage.getItem(key) && !isNewProfile) {
+        setShowTutorial(true);
+      } else {
+        setShowTutorial(false);
+      }
+    }
+  }, [userData, isNewProfile, isLoading, isAuthPage, mode, orgsFetched, organizationPhase]);
 
   if (isAuthPage || isLoading || !userData) {
     return null;
   }
 
-  // Phase 1: New Profile Setup
   if (isNewProfile) {
     return (
-      <OnboardingModal 
+      <OnboardingModal
         onComplete={() => {
           setShowTutorial(true);
-        }} 
+        }}
       />
     );
   }
 
-  // Phase 2: Highlight Tour (Tutorial)
   if (showTutorial) {
     return (
       <OnboardingTutorial
         userId={userData.id}
         mode={mode}
         isOrgAdmin={mode === "organization" ? isOrgAdminUser : undefined}
+        organizationPhase={mode === "organization" ? organizationPhase ?? undefined : undefined}
         onComplete={() => setShowTutorial(false)}
       />
     );
   }
-
 
   return null;
 }

--- a/components/onboarding-tutorial.tsx
+++ b/components/onboarding-tutorial.tsx
@@ -17,7 +17,7 @@ interface Step {
 const PERSONAL_STEPS: Step[] = [
   {
     id: "welcome",
-    title: "Welcome to Splito! 🚀",
+    title: "Welcome to Splito!",
     content: "Let's take a quick tour of Personal mode — where you manage splits with friends and flatmates.",
     targetId: "",
     position: "center",
@@ -45,19 +45,51 @@ const PERSONAL_STEPS: Step[] = [
   },
   {
     id: "finish",
-    title: "You're all set! 🎉",
+    title: "You're all set! ",
     content: "Start by creating a group or adding friends.",
     targetId: "",
     position: "center",
   },
 ];
 
-/** Organization onboarding for admins/owners — all tabs (Streams, Activity, Members) are visible. */
+/** First half: shown on sign up / business dashboard when user has no org or isn't inside an org yet. Only Settings and org switcher are visible. */
+const ORG_STEPS_BEFORE_FIRST: Step[] = [
+  {
+    id: "welcome",
+    title: "Welcome to Splito for businesses",
+    content: "On the business dashboard you can manage organizations, settings, and switch between orgs. Create or select an organization to get started.",
+    targetId: "",
+    position: "center",
+  },
+  {
+    id: "settings",
+    title: "Settings",
+    content: "Update your profile, display name, default currency, and manage your wallets.",
+    targetId: "sidebar-org-settings-link-no-org",
+    position: "right",
+  },
+  {
+    id: "org-switcher",
+    title: "Switch organization",
+    content: "Use the switcher at the bottom to select or switch between organizations. Create an organization if you don't have one yet.",
+    targetId: "sidebar-org-switcher-button",
+    position: "right",
+  },
+  {
+    id: "finish",
+    title: "You're set",
+    content: "Create an organization or select one from the switcher to access invoices, contracts, and more.",
+    targetId: "",
+    position: "center",
+  },
+];
+
+/** Second half: when user is inside their first org — admins see full tabs. */
 const ORG_STEPS_ADMIN: Step[] = [
   {
     id: "welcome",
-    title: "Welcome to Splito Organization! 🏢",
-    content: "As an admin, you manage invoices, income streams, contracts, activity, and team members.",
+    title: "You're in your organization",
+    content: "Here you can manage invoices, income streams, contracts, activity, and team members.",
     targetId: "",
     position: "center",
   },
@@ -119,19 +151,19 @@ const ORG_STEPS_ADMIN: Step[] = [
   },
   {
     id: "finish",
-    title: "You're ready! 🎊",
+    title: "You're ready!",
     content: "Start by creating contracts, adding members, or setting up income streams.",
     targetId: "",
     position: "center",
   },
 ];
 
-/** Organization onboarding for members — only Dashboard, Invoices, Contracts, Settings (no Streams, Activity, Members). */
+/** Second half: when user is inside their first org — members see Dashboard, Invoices, Contracts, Settings. */
 const ORG_STEPS_MEMBER: Step[] = [
   {
     id: "welcome",
-    title: "Welcome to Splito Organization! 🏢",
-    content: "You're a member of an organization. Raise invoices and view your contracts here.",
+    title: "You're in your organization",
+    content: "Raise invoices and view your contracts here. Admins can approve invoices and manage the team.",
     targetId: "",
     position: "center",
   },
@@ -172,7 +204,7 @@ const ORG_STEPS_MEMBER: Step[] = [
   },
   {
     id: "finish",
-    title: "You're ready! 🎊",
+    title: "You're ready!",
     content: "Raise an invoice or open a contract to get started.",
     targetId: "",
     position: "center",
@@ -181,26 +213,36 @@ const ORG_STEPS_MEMBER: Step[] = [
 
 export type OnboardingMode = "personal" | "organization";
 
+/** When mode is "organization", which half of the flow to show: no-org (settings + switcher) or in-org (invoices, contracts, etc.). */
+export type OrganizationOnboardingPhase = "no-org" | "in-org";
+
 export function OnboardingTutorial({
   onComplete,
   userId,
   mode,
   isOrgAdmin,
+  organizationPhase,
 }: {
   onComplete: () => void;
   userId?: string;
   mode: OnboardingMode;
   /** When mode is "organization", true = admin/owner (sees Streams, Activity, Members), false = member. */
   isOrgAdmin?: boolean;
+  /** When mode is "organization", "no-org" = first half (settings + switch org), "in-org" = second half (invoices, contracts, etc.). */
+  organizationPhase?: OrganizationOnboardingPhase;
 }) {
   const steps =
     mode === "organization"
-      ? isOrgAdmin
-        ? ORG_STEPS_ADMIN
-        : ORG_STEPS_MEMBER
+      ? organizationPhase === "no-org"
+        ? ORG_STEPS_BEFORE_FIRST
+        : isOrgAdmin
+          ? ORG_STEPS_ADMIN
+          : ORG_STEPS_MEMBER
       : PERSONAL_STEPS;
   const storageKey = userId
-    ? `hasSeenTutorial_${mode}_${userId}`
+    ? mode === "organization" && organizationPhase
+      ? `hasSeenTutorial_${mode}_${organizationPhase}_${userId}`
+      : `hasSeenTutorial_${mode}_${userId}`
     : null;
 
   const [currentStepIndex, setCurrentStepIndex] = useState(0);

--- a/components/organization-mobile-nav.tsx
+++ b/components/organization-mobile-nav.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { FileText, TrendingUp, Activity, FileSignature, Users, LayoutDashboard } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { A } from "@/lib/splito-design";
+import { useGetAllOrganizations } from "@/features/business/hooks/use-organizations";
+
+// 6 tabs: Dashboard first, then Invoices, Streams, Activity, Contracts, Members
+const DASHBOARD_TAB = { key: "dashboard", label: "Dashboard", path: "dashboard", icon: LayoutDashboard };
+const ORG_NAV_ITEMS = [
+  { key: "invoices", label: "Invoices", path: "invoices", icon: FileText },
+  { key: "streams", label: "Streams", path: "streams", icon: TrendingUp },
+  { key: "activity", label: "Activity", path: "activity", icon: Activity },
+  { key: "contracts", label: "Contracts", path: "contracts", icon: FileSignature },
+  { key: "members", label: "Members", path: "members", icon: Users },
+] as const;
+const ALL_TABS = [DASHBOARD_TAB, ...ORG_NAV_ITEMS];
+
+// Match /organization/:id or /app/organization/:id (first segment after organization)
+const ORG_ID_FROM_PATH = /\/organization\/([^/]+)(?:\/|$)/;
+const RESERVED_SEGMENTS = new Set(["roles", "create", "organizations", "settings", "members"]);
+
+export function OrganizationMobileNav() {
+  const pathname = usePathname();
+  const { data: organizations = [] } = useGetAllOrganizations({
+    enabled: pathname?.includes("/organization") ?? false,
+  });
+
+  if (!pathname?.includes("/organization")) {
+    return null;
+  }
+
+  const match = pathname.match(ORG_ID_FROM_PATH);
+  const firstSegment = match?.[1];
+  const organizationId = firstSegment && !RESERVED_SEGMENTS.has(firstSegment) ? firstSegment : null;
+  const basePath = pathname.startsWith("/app") ? "/app/organization" : "/organization";
+  const firstOrgId = organizations[0]?.id ?? null;
+  const effectiveOrgId = organizationId ?? firstOrgId;
+
+  const isActive = (path: string) => {
+    if (path === "dashboard") return pathname === basePath;
+    if (!effectiveOrgId) return false;
+    const segment = `${basePath}/${effectiveOrgId}/${path}`;
+    return pathname === segment || pathname.startsWith(segment + "/");
+  };
+
+  const getHref = (path: string) => {
+    if (path === "dashboard") return basePath;
+    if (!effectiveOrgId) return basePath;
+    return `${basePath}/${effectiveOrgId}/${path}`;
+  };
+
+  const navStyle = {
+    background: "rgba(10,10,10,0.97)",
+    backdropFilter: "blur(20px)",
+    borderTop: "1px solid rgba(255,255,255,0.08)",
+    padding: "8px 4px 20px",
+  };
+
+  return (
+    <nav
+      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px] z-40 min-[1025px]:hidden"
+      style={navStyle}
+    >
+      <div className="flex justify-around gap-0">
+        {ALL_TABS.map((item) => {
+          const active = isActive(item.path);
+          const Icon = item.icon;
+          const href = getHref(item.path);
+          return (
+            <Link
+              key={item.key}
+              href={href}
+              className={cn(
+                "flex flex-col items-center gap-0.5 min-w-0 flex-1 py-1 transition-all duration-200 font-[inherit] no-underline",
+                active ? "text-[#22D3EE]" : "text-white/40"
+              )}
+            >
+              <div
+                className={cn(
+                  "flex items-center justify-center w-8 h-8 rounded-[10px] transition-all duration-200",
+                  active && "bg-[#22D3EE]/20"
+                )}
+              >
+                <Icon
+                  className="w-[16px] h-[16px] sm:w-[18px] sm:h-[18px] shrink-0"
+                  strokeWidth={active ? 2.2 : 1.8}
+                  style={{ color: active ? A : "inherit" }}
+                />
+              </div>
+              <span
+                className={cn(
+                  "text-[8px] sm:text-[10px] font-medium truncate max-w-full px-0.5",
+                  active && "font-bold"
+                )}
+              >
+                {item.label}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/components/personal-mobile-nav.tsx
+++ b/components/personal-mobile-nav.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { LayoutDashboard, Users2, UserCircle, Settings } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { A } from "@/lib/splito-design";
+
+const NAV_ITEMS = [
+  { key: "home", label: "Home", href: "/", icon: LayoutDashboard },
+  { key: "groups", label: "Groups", href: "/groups", icon: Users2 },
+  { key: "friends", label: "Friends", href: "/friends", icon: UserCircle },
+  { key: "profile", label: "Profile", href: "/settings", icon: Settings },
+];
+
+export function PersonalMobileNav() {
+  const pathname = usePathname();
+
+  const isActive = (href: string) => {
+    if (href === "/") return pathname === "/";
+    return pathname === href || pathname.startsWith(href + "/");
+  };
+
+  return (
+    <nav
+      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px] z-40 min-[1025px]:hidden"
+      style={{
+        background: "rgba(10,10,10,0.97)",
+        backdropFilter: "blur(20px)",
+        borderTop: "1px solid rgba(255,255,255,0.08)",
+        padding: "12px 8px 28px",
+      }}
+    >
+      <div className="flex justify-around">
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.href);
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.key}
+              href={item.href}
+              className={cn(
+                "flex flex-col items-center gap-1 min-w-0 flex-1 py-0.5 transition-all duration-200 font-[inherit] no-underline",
+                active ? "text-[#22D3EE]" : "text-white/40"
+              )}
+            >
+              <div
+                className={cn(
+                  "flex items-center justify-center w-8 h-8 rounded-[10px] transition-all duration-200",
+                  active && "bg-[#22D3EE]/20"
+                )}
+              >
+                <Icon
+                  className="w-5 h-5 shrink-0"
+                  strokeWidth={active ? 2.2 : 1.8}
+                  style={{ color: active ? A : "inherit" }}
+                />
+              </div>
+              <span
+                className={cn(
+                  "text-[10px] font-medium truncate max-w-full",
+                  active && "font-bold"
+                )}
+              >
+                {item.label}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/components/profile-dropdown.tsx
+++ b/components/profile-dropdown.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { LogOut, UserCircle } from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { signOut } from "@/lib/auth";
+
+type User = { id: string; name: string | null; email: string | null; image: string | null };
+
+const defaultDropdownClassName =
+  "absolute right-0 top-full mt-2 w-56 rounded-xl bg-[#101012] border border-white/10 shadow-xl py-2 z-[100]";
+
+export function ProfileDropdown({
+  user,
+  profileHref,
+  avatarSizeClass = "h-9 w-9 sm:h-12 sm:w-12",
+  dropdownClassName = defaultDropdownClassName,
+}: {
+  user: User;
+  profileHref: string;
+  avatarSizeClass?: string;
+  dropdownClassName?: string;
+}) {
+  const router = useRouter();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleLogout = async () => {
+    setDropdownOpen(false);
+    await signOut();
+    router.push("/login");
+  };
+
+  const itemClass =
+    "flex items-center gap-3 px-4 py-2.5 text-sm text-white/90 hover:bg-white/[0.06] transition-colors";
+
+  return (
+    <div
+      className="relative"
+      ref={dropdownRef}
+      onMouseEnter={() => setDropdownOpen(true)}
+      onMouseLeave={() => setDropdownOpen(false)}
+    >
+      <button
+        type="button"
+        onClick={() => setDropdownOpen((o) => !o)}
+        className="rounded-full focus:outline-none focus:ring-2 focus:ring-white/20"
+        aria-label="Account menu"
+        aria-expanded={dropdownOpen}
+      >
+        <div className={`overflow-hidden rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-0.5 ${avatarSizeClass}`}>
+          <div className="h-full w-full rounded-full overflow-hidden bg-[#101012]">
+            {user.image ? (
+              <Image
+                src={user.image}
+                alt="Profile"
+                width={56}
+                height={56}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <Image
+                src={`https://api.dicebear.com/9.x/identicon/svg?seed=${user.id || user.email}`}
+                alt="Profile"
+                width={56}
+                height={56}
+                className="h-full w-full"
+                onError={(e) => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=user`;
+                }}
+              />
+            )}
+          </div>
+        </div>
+      </button>
+
+      {dropdownOpen && (
+        <div className={dropdownClassName}>
+          <div className="px-4 py-3 border-b border-white/10">
+            <p className="text-sm text-white/60 truncate" title={user.email ?? undefined}>
+              {user.email ?? ""}
+            </p>
+          </div>
+          <Link
+            href={profileHref}
+            onClick={() => setDropdownOpen(false)}
+            className={itemClass}
+          >
+            <UserCircle className="h-4 w-4 text-white/50" strokeWidth={1.5} />
+            Profile
+          </Link>
+          <button
+            type="button"
+            onClick={handleLogout}
+            className={`w-full text-left ${itemClass}`}
+          >
+            <LogOut className="h-4 w-4 text-white/50" strokeWidth={1.5} />
+            Logout
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   UserCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Icons, A, Avatar, T } from "@/lib/splito-design";
 import { useMobileMenu } from "@/contexts/mobile-menu";
 import { useAuthStore } from "@/stores/authStore";
 import { useGetAllOrganizations } from "@/features/business/hooks/use-organizations";
@@ -83,7 +84,7 @@ export function Sidebar() {
   };
 
   return (
-    <>
+    <div className="hidden min-[1025px]:block">
       {isOpen && (
         <div
           className="fixed inset-0 bg-black/70 brightness-50 min-[1025px]:hidden z-50"
@@ -93,15 +94,17 @@ export function Sidebar() {
 
       <div
         className={cn(
-          "fixed left-0 top-0 z-50 h-screen w-[260px] bg-[#101012] transition-all duration-300 ease-in-out shadow-xl min-[1025px]:translate-x-0",
-          isOpen ? "translate-x-0" : "-translate-x-full"
+          "fixed left-0 top-0 z-50 h-screen transition-all duration-300 ease-in-out shadow-xl min-[1025px]:translate-x-0",
+          isOpen ? "translate-x-0" : "-translate-x-full",
+          "w-[226px] border-r border-white/[0.07]"
         )}
+        style={{ background: "linear-gradient(180deg, #0e0e0e 0%, #0b0b0b 100%)" }}
       >
         <div className="flex h-full flex-col">
-          {/* Logo/Brand Section */}
-          <div className="flex h-[70px] sm:h-[80px] items-center px-6 mt-2 sm:mt-4 relative">
-            <Link href="https://splito.io" onClick={close} className="z-10">
-              <Image src={logo} alt="Splito Logo" width={120} height={120} />
+          {/* Logo/Brand – same in both modes */}
+          <div className="flex items-center relative px-[22px] py-5 gap-2.5 mb-8">
+            <Link href={isOrganizationMode ? "https://splito.io" : "/"} onClick={close} className="z-10 flex items-center">
+              <Image src={logo} alt="Splito Logo" width={120} height={32} className="h-8 w-auto" />
             </Link>
             <button
               onClick={close}
@@ -114,21 +117,38 @@ export function Sidebar() {
 
           {/* Main Navigation */}
           <div className="flex-1 space-y-1 px-4 py-4 sm:py-6 overflow-y-auto">
-            {/* Dashboard */}
-            <Link
-              id="sidebar-dashboard-link"
-              href={isOrganizationMode ? "/organization" : "/"}
-              onClick={close}
-              className={cn(
-                "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
-                (isOrganizationMode ? pathname === "/organization" : pathname === "/")
-                  ? "bg-white/[0.07] text-white shadow-sm"
-                  : "text-white/60 hover:bg-white/[0.04] hover:text-white"
-              )}
-            >
-              <LayoutDashboard className="h-5 w-5" strokeWidth={1.5} />
-              Dashboard
-            </Link>
+            {/* Dashboard - shared; in personal mode use design styling */}
+            {(!isOrganizationMode ? (
+              <Link
+                id="sidebar-dashboard-link"
+                href="/"
+                onClick={close}
+                className={cn(
+                  "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                  pathname === "/" && !pathname.startsWith("/groups/")
+                    ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                    : "text-white/60"
+                )}
+              >
+                <span className={pathname === "/" ? "text-[#22D3EE]" : "inherit"}>{Icons.home({})}</span>
+                Dashboard
+              </Link>
+            ) : (
+              <Link
+                id="sidebar-dashboard-link"
+                href="/organization"
+                onClick={close}
+                className={cn(
+                  "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                  pathname === "/organization"
+                    ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                    : "text-white/60"
+                )}
+              >
+                <span className={pathname === "/organization" ? "text-[#22D3EE]" : "inherit"}><LayoutDashboard className="h-4 w-4" strokeWidth={1.5} /></span>
+                Dashboard
+              </Link>
+            ))}
 
             {/* ── Organization mode: connection error hint when APIs fail ── */}
             {isOrganizationMode && !linkOrgId && isOrgsError && (
@@ -152,13 +172,13 @@ export function Sidebar() {
                   href={`/organization/${linkOrgId}/invoices`}
                   onClick={close}
                   className={cn(
-                    "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
                     pathname === `/organization/${linkOrgId}/invoices`
-                      ? "bg-white/[0.07] text-white shadow-sm"
-                      : "text-white/60 hover:bg-white/[0.04] hover:text-white"
+                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                      : "text-white/60"
                   )}
                 >
-                  <FileText className="h-5 w-5" strokeWidth={1.5} />
+                  <span className={pathname === `/organization/${linkOrgId}/invoices` ? "text-[#22D3EE]" : "inherit"}><FileText className="h-4 w-4" strokeWidth={1.5} /></span>
                   Invoices
                 </Link>
 
@@ -168,13 +188,13 @@ export function Sidebar() {
                     href={`/organization/${linkOrgId}/streams`}
                     onClick={close}
                     className={cn(
-                      "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
+                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
                       pathname === `/organization/${linkOrgId}/streams`
-                        ? "bg-white/[0.07] text-white shadow-sm"
-                        : "text-white/60 hover:bg-white/[0.04] hover:text-white"
+                        ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                        : "text-white/60"
                     )}
                   >
-                    <TrendingUp className="h-5 w-5" strokeWidth={1.5} />
+                    <span className={pathname === `/organization/${linkOrgId}/streams` ? "text-[#22D3EE]" : "inherit"}><TrendingUp className="h-4 w-4" strokeWidth={1.5} /></span>
                     Streams
                   </Link>
                 )}
@@ -185,13 +205,13 @@ export function Sidebar() {
                     href={`/organization/${linkOrgId}/activity`}
                     onClick={close}
                     className={cn(
-                      "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
+                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
                       pathname === `/organization/${linkOrgId}/activity`
-                        ? "bg-white/[0.07] text-white shadow-sm"
-                        : "text-white/60 hover:bg-white/[0.04] hover:text-white"
+                        ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                        : "text-white/60"
                     )}
                   >
-                    <Activity className="h-5 w-5" strokeWidth={1.5} />
+                    <span className={pathname === `/organization/${linkOrgId}/activity` ? "text-[#22D3EE]" : "inherit"}><Activity className="h-4 w-4" strokeWidth={1.5} /></span>
                     Activity
                   </Link>
                 )}
@@ -201,13 +221,13 @@ export function Sidebar() {
                   href={`/organization/${linkOrgId}/contracts`}
                   onClick={close}
                   className={cn(
-                    "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
                     pathname === `/organization/${linkOrgId}/contracts`
-                      ? "bg-white/[0.07] text-white shadow-sm"
-                      : "text-white/60 hover:bg-white/[0.04] hover:text-white"
+                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                      : "text-white/60"
                   )}
                 >
-                  <FileSignature className="h-5 w-5" strokeWidth={1.5} />
+                  <span className={pathname === `/organization/${linkOrgId}/contracts` ? "text-[#22D3EE]" : "inherit"}><FileSignature className="h-4 w-4" strokeWidth={1.5} /></span>
                   Contracts
                 </Link>
 
@@ -217,20 +237,20 @@ export function Sidebar() {
                     href={`/organization/${linkOrgId}/members`}
                     onClick={close}
                     className={cn(
-                      "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
+                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
                       pathname === `/organization/${linkOrgId}/members`
-                        ? "bg-white/[0.07] text-white shadow-sm"
-                        : "text-white/60 hover:bg-white/[0.04] hover:text-white"
+                        ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                        : "text-white/60"
                     )}
                   >
-                    <UserPlus className="h-5 w-5" strokeWidth={1.5} />
+                    <span className={pathname === `/organization/${linkOrgId}/members` ? "text-[#22D3EE]" : "inherit"}><UserPlus className="h-4 w-4" strokeWidth={1.5} /></span>
                     Members
                   </Link>
                 )}
               </>
             )}
 
-            {/* ── Personal mode links ── */}
+            {/* ── Personal mode links (My Groups, Friends, Settings) ── */}
             {!isOrganizationMode && (
               <>
                 <Link
@@ -238,13 +258,13 @@ export function Sidebar() {
                   href="/groups"
                   onClick={close}
                   className={cn(
-                    "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
                     pathname === "/groups" || pathname.startsWith("/groups/")
-                      ? "bg-white/[0.07] text-white shadow-sm"
-                      : "text-white/60 hover:bg-white/[0.04] hover:text-white"
+                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                      : "text-white/60"
                   )}
                 >
-                  <Users2 className="h-5 w-5" strokeWidth={1.5} />
+                  <span className={pathname === "/groups" || pathname.startsWith("/groups/") ? "text-[#22D3EE]" : "inherit"}>{Icons.groups({})}</span>
                   My Groups
                 </Link>
                 <Link
@@ -252,63 +272,116 @@ export function Sidebar() {
                   href="/friends"
                   onClick={close}
                   className={cn(
-                    "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
                     pathname === "/friends"
-                      ? "bg-white/[0.07] text-white shadow-sm"
-                      : "text-white/60 hover:bg-white/[0.04] hover:text-white"
+                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                      : "text-white/60"
                   )}
                 >
-                  <UserPlus className="h-5 w-5" strokeWidth={1.5} />
+                  <span className={pathname === "/friends" ? "text-[#22D3EE]" : "inherit"}>{Icons.friends({})}</span>
                   Friends
+                </Link>
+                <Link
+                  id="sidebar-settings-link"
+                  href="/settings"
+                  onClick={close}
+                  className={cn(
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                    pathname === "/settings"
+                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+                      : "text-white/60"
+                  )}
+                >
+                  <span className={pathname === "/settings" ? "text-[#22D3EE]" : "inherit"}>{Icons.settings({})}</span>
+                  Settings
                 </Link>
               </>
             )}
           </div>
 
-          {/* Bottom Section */}
-          <div className="p-4 mt-auto space-y-1">
-            {/* Follow us */}
-            <a
-              id="sidebar-follow-us-link"
-              href="https://x.com/splitodotio"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={close}
-              className="flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all text-white/60 hover:bg-white/[0.04] hover:text-white"
-            >
-              <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-              </svg>
-              Follow us
-            </a>
-
-            {/* Organization mode: org switcher at bottom */}
-            {isOrganizationMode && (
-              <div className="relative" ref={orgSwitcherRef}>
-                <button
-                  id="sidebar-org-switcher-button"
-                  type="button"
-                  onClick={() => setOrgSwitcherOpen((v) => !v)}
-                  className={cn(
-                    "flex w-full items-center gap-3 px-4 py-3 rounded-xl transition-colors text-left",
-                    "text-white/90 hover:bg-[#17171A] hover:text-white",
-                    orgSwitcherOpen && "bg-[#17171A] text-white"
-                  )}
-                >
-                  {/* Org avatar */}
-                  <div className="h-9 w-9 shrink-0 overflow-hidden rounded-full bg-white/10 flex items-center justify-center text-sm font-bold text-white">
-                    {currentOrg
-                      ? currentOrg.name.charAt(0).toUpperCase()
-                      : "?"}
-                  </div>
+          {/* Personal mode: GROUPS section + New group + user card */}
+          {!isOrganizationMode && (
+            <>
+              <div className="mt-7 flex-1 overflow-y-auto min-h-0 px-3.5">
+                <p className="text-[10px] font-extrabold tracking-[0.12em] uppercase text-white/50 px-3.5 mb-2">GROUPS</p>
+                <div className="flex flex-col gap-0.5">
+                  {groups.map((g) => {
+                    const isActive = pathname.startsWith(`/groups/${g.id}`);
+                    return (
+                      <Link
+                        key={g.id}
+                        href={`/groups/${g.id}`}
+                        onClick={close}
+                        className={cn(
+                          "splito-nav-item flex items-center py-2 px-3.5 rounded-[13px] transition-all",
+                          isActive ? "bg-white/[0.09] text-white" : "text-white/60"
+                        )}
+                      >
+                        <span className={cn(
+                          "text-[13px] font-medium truncate flex-1",
+                          isActive ? "text-white font-semibold" : "inherit"
+                        )}>
+                          {g.name}
+                        </span>
+                      </Link>
+                    );
+                  })}
+                  <button
+                    type="button"
+                    onClick={() => { close(); document.dispatchEvent(new CustomEvent("open-create-group-modal")); }}
+                    className="w-full flex items-center gap-[9px] rounded-xl py-[9px] px-[13px] bg-transparent my-1.5 transition-all hover:bg-white/[0.04] cursor-pointer"
+                    style={{ border: "1.5px dashed rgba(255,255,255,0.1)" }}
+                  >
+                    <span className="text-[15px] leading-none" style={{ color: T.muted }}>+</span>
+                    <span className="text-[13px] font-medium" style={{ color: T.muted }}>New group</span>
+                  </button>
+                </div>
+              </div>
+              <div className="px-3 pb-4 pt-5 mt-2">
+                <div className="flex items-center gap-2.5 py-3 px-3.5 rounded-2xl bg-white/[0.05] border border-white/[0.07]">
+                  <Avatar
+                    init={user?.name?.charAt(0)?.toUpperCase() || "Y"}
+                    color={A}
+                    size={34}
+                  />
                   <div className="min-w-0 flex-1">
-                    <p className="text-mobile-sm sm:text-sm font-medium truncate">
-                      {currentOrg?.name ?? "Select organization"}
-                    </p>
-                    <p className="text-xs text-white/50 truncate">Organization</p>
+                    <p className="text-[13px] font-bold truncate text-white">{user?.name || "You"}</p>
+                    <p className="text-[11px] text-white/60 truncate">{user?.email || "you@email.com"}</p>
                   </div>
-                  <ChevronsUpDown className="h-4 w-4 shrink-0 text-white/50" strokeWidth={1.5} />
-                </button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* Bottom Section (organization mode only; styled like personal user card) */}
+          {isOrganizationMode && (
+              <div className="px-3 pb-4 pt-5 mt-2">
+                <div className="relative" ref={orgSwitcherRef}>
+                  <button
+                    id="sidebar-org-switcher-button"
+                    type="button"
+                    onClick={() => setOrgSwitcherOpen((v) => !v)}
+                    className={cn(
+                      "flex w-full items-center gap-2.5 py-3 px-3.5 rounded-2xl text-left transition-colors",
+                      "bg-white/[0.05] border border-white/[0.07]",
+                      "hover:bg-white/[0.07] hover:border-white/[0.1]",
+                      orgSwitcherOpen && "bg-white/[0.07] border-white/[0.1]"
+                    )}
+                    style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)" }}
+                  >
+                    <Avatar
+                      init={currentOrg ? currentOrg.name.charAt(0).toUpperCase() : "?"}
+                      color={A}
+                      size={34}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[13px] font-bold truncate text-white">
+                        {currentOrg?.name ?? "Select organization"}
+                      </p>
+                      <p className="text-[11px] truncate" style={{ color: T.muted }}>Organization</p>
+                    </div>
+                    <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-60" style={{ color: T.muted }} strokeWidth={1.5} />
+                  </button>
 
                 <AnimatePresence>
                   {orgSwitcherOpen && (
@@ -375,10 +448,10 @@ export function Sidebar() {
                   )}
                 </AnimatePresence>
               </div>
-            )}
           </div>
+          )}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -17,7 +17,6 @@ import {
   FileSignature,
   FileText,
   UserCircle,
-  Settings,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useMobileMenu } from "@/contexts/mobile-menu";
@@ -145,7 +144,7 @@ export function Sidebar() {
               </div>
             )}
 
-            {/* ── Organization mode links ── */}
+            {/* ── Organization mode links (when an org is selected) ── */}
             {isOrganizationMode && linkOrgId && (
               <>
                 <Link
@@ -228,21 +227,6 @@ export function Sidebar() {
                     Members
                   </Link>
                 )}
-
-                <Link
-                  id="sidebar-org-settings-link"
-                  href={`/organization/${linkOrgId}/settings`}
-                  onClick={close}
-                  className={cn(
-                    "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
-                    pathname === `/organization/${linkOrgId}/settings`
-                      ? "bg-white/[0.07] text-white shadow-sm"
-                      : "text-white/60 hover:bg-white/[0.04] hover:text-white"
-                  )}
-                >
-                  <Settings className="h-5 w-5" strokeWidth={1.5} />
-                  Settings
-                </Link>
               </>
             )}
 
@@ -276,20 +260,6 @@ export function Sidebar() {
                 >
                   <UserPlus className="h-5 w-5" strokeWidth={1.5} />
                   Friends
-                </Link>
-                <Link
-                  id="sidebar-settings-link"
-                  href="/settings"
-                  onClick={close}
-                  className={cn(
-                    "flex h-[45px] sm:h-[50px] items-center gap-3 rounded-xl px-4 text-mobile-base sm:text-[15px] font-medium transition-all",
-                    pathname === "/settings"
-                      ? "bg-white/[0.07] text-white shadow-sm"
-                      : "text-white/60 hover:bg-white/[0.04] hover:text-white"
-                  )}
-                >
-                  <Settings className="h-5 w-5" strokeWidth={1.5} />
-                  Settings
                 </Link>
               </>
             )}

--- a/features/business/api/client.ts
+++ b/features/business/api/client.ts
@@ -90,6 +90,8 @@ export const OrganizationActivitySchema = z.object({
     .object({
       id: z.string(),
       title: z.string().nullable(),
+      jobTitle: z.string().nullable().optional(),
+      assignedToEmail: z.string().optional(),
       assignedTo: z.object({ id: z.string(), name: z.string().nullable(), email: z.string().nullable() }).nullable().optional(),
     })
     .nullable()
@@ -224,7 +226,7 @@ export const deleteStream = async (organizationId: string, streamId: string) => 
 };
 
 // Contracts
-export const ContractStatusSchema = z.enum(["DRAFT", "SENT", "REJECTED"]);
+export const ContractStatusSchema = z.enum(["DRAFT", "SENT", "REJECTED", "REVOKED"]);
 export const ContractSchema = z.object({
   id: z.string(),
   organizationId: z.string(),
@@ -320,6 +322,10 @@ export const signContract = async (contractId: string) => {
 
 export const rejectContract = async (contractId: string) => {
   await apiClient.patch(`/contracts/${contractId}/reject`, {});
+};
+
+export const revokeContract = async (contractId: string) => {
+  await apiClient.patch(`/contracts/${contractId}/revoke`, {});
 };
 
 export const deleteContract = async (contractId: string) => {

--- a/features/business/hooks/use-contracts.ts
+++ b/features/business/hooks/use-contracts.ts
@@ -7,6 +7,7 @@ import {
   createContract,
   updateContract,
   deleteContract,
+  revokeContract,
   claimContractByToken,
   signContract,
   rejectContract,
@@ -70,6 +71,16 @@ export const useDeleteContract = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: deleteContract,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.CONTRACTS] });
+    },
+  });
+};
+
+export const useRevokeContract = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: revokeContract,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKeys.CONTRACTS] });
     },

--- a/features/currencies/hooks/use-currencies.ts
+++ b/features/currencies/hooks/use-currencies.ts
@@ -118,22 +118,67 @@ export interface OrganizedCurrencies {
   chainGroups: Record<string, Currency[]>;
 }
 
-// Hook to get currencies organized by type and chain
+// Map FiatCurrency to Currency for merging
+function toCurrency(f: FiatCurrency): Currency {
+  return {
+    id: f.id,
+    name: f.name,
+    symbol: f.symbol,
+    type: "FIAT",
+    chainId: null,
+    logoUrl: f.logoUrl ?? null,
+  };
+}
+
+// Fallback fiat list so the dropdown always shows multiple options even when API returns few/none
+const FALLBACK_FIAT: Currency[] = [
+  { id: "USD", name: "US Dollar", symbol: "$", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "EUR", name: "Euro", symbol: "€", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "GBP", name: "British Pound", symbol: "£", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "JPY", name: "Japanese Yen", symbol: "¥", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "THB", name: "Thai Baht", symbol: "฿", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "INR", name: "Indian Rupee", symbol: "₹", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "AUD", name: "Australian Dollar", symbol: "A$", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "CAD", name: "Canadian Dollar", symbol: "C$", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "SGD", name: "Singapore Dollar", symbol: "S$", type: "FIAT", chainId: null, logoUrl: null },
+  { id: "CHF", name: "Swiss Franc", symbol: "Fr", type: "FIAT", chainId: null, logoUrl: null },
+];
+
+// Hook to get currencies organized by type and chain.
+// Merges in fiat from /api/currency/fiat when /api/currency/all returns few or no fiat,
+// so the dropdown always shows a full list (USD, EUR, GBP, JPY, etc.).
 export const useOrganizedCurrencies = () => {
-  const { data, isLoading, error } = useGetAllCurrencies();
+  const { data: allData, isLoading: allLoading } = useGetAllCurrencies();
+  const { data: fiatList, isLoading: fiatLoading } = useGetFiatCurrencies();
 
   return useQuery({
-    queryKey: [CURRENCY_QUERY_KEYS.ORGANIZED_CURRENCIES],
+    queryKey: [
+      CURRENCY_QUERY_KEYS.ORGANIZED_CURRENCIES,
+      allData?.currencies?.length ?? 0,
+      fiatList?.length ?? 0,
+    ],
     queryFn: () => {
-      if (!data) return { fiatCurrencies: [], chainGroups: {} };
+      const fromAll = allData?.currencies ?? [];
+      const fiatFromAll = fromAll.filter((c) => c.type === "FIAT");
+      const chainCurrencies = fromAll.filter((c) => c.type !== "FIAT");
 
-      // Group currencies by type (fiat vs chains)
-      const fiatCurrencies = data.currencies.filter((c) => c.type === "FIAT");
-      const chainCurrencies = data.currencies.filter((c) => c.type !== "FIAT");
+      // Merge fiat: prefer all, then fiat endpoint, then fallback so we always show multiple
+      const byId = new Map<string, Currency>();
+      fiatFromAll.forEach((c) => byId.set(c.id, c));
+      (fiatList ?? []).forEach((f) => {
+        if (!byId.has(f.id)) byId.set(f.id, toCurrency(f));
+      });
+      if (byId.size < 3) {
+        FALLBACK_FIAT.forEach((c) => {
+          if (!byId.has(c.id)) byId.set(c.id, c);
+        });
+      }
+      const fiatCurrencies = Array.from(byId.values()).sort((a, b) =>
+        a.id.localeCompare(b.id)
+      );
 
       // Group chain currencies by their chainId
       const chainGroups: Record<string, Currency[]> = {};
-
       chainCurrencies.forEach((currency) => {
         const chainId = currency.chainId || "Unknown";
         if (!chainGroups[chainId]) {
@@ -144,7 +189,7 @@ export const useOrganizedCurrencies = () => {
 
       return { fiatCurrencies, chainGroups };
     },
-    enabled: !!data,
+    enabled: !!allData || !!fiatList,
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
 };

--- a/features/groups/api/client.ts
+++ b/features/groups/api/client.ts
@@ -40,6 +40,7 @@ export const DetailGroupSchema = z.object({
   groupUsers: z.array(
     z.object({
       ...GroupUserSchema.shape,
+      createdAt: z.coerce.date().optional(),
       user: UserSchema,
     })
   ),
@@ -136,6 +137,11 @@ export const updateMemberRole = async (
   role: "ADMIN" | "MEMBER"
 ) => {
   const response = await apiClient.put(`/groups/${groupId}/members/${userId}/role`, { role });
+  return response;
+};
+
+export const removeMemberFromGroup = async (groupId: string, userId: string) => {
+  const response = await apiClient.delete(`/groups/${groupId}/members/${userId}`);
   return response;
 };
 

--- a/features/groups/hooks/use-create-group.ts
+++ b/features/groups/hooks/use-create-group.ts
@@ -11,6 +11,7 @@ import {
   joinGroup,
   updateGroup,
   updateMemberRole,
+  removeMemberFromGroup as removeMemberFromGroupApi,
   markAsPaid,
 } from "../api/client";
 import { QueryKeys } from "@/lib/constants";
@@ -172,6 +173,19 @@ export const useUpdateMemberRole = () => {
       userId: string;
       role: "ADMIN" | "MEMBER";
     }) => updateMemberRole(groupId, userId, role),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.GROUPS] });
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.GROUPS, variables.groupId] });
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.BUSINESS_ORGANIZATIONS] });
+    },
+  });
+};
+
+export const useRemoveMemberFromGroup = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, userId }: { groupId: string; userId: string }) =>
+      removeMemberFromGroupApi(groupId, userId),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: [QueryKeys.GROUPS] });
       queryClient.invalidateQueries({ queryKey: [QueryKeys.GROUPS, variables.groupId] });

--- a/lib/splito-design.tsx
+++ b/lib/splito-design.tsx
@@ -214,12 +214,14 @@ export const Btn = ({
   variant = "ghost",
   style = {},
   className = "",
+  disabled = false,
 }: {
   children: React.ReactNode;
   onClick?: () => void;
   variant?: "primary" | "ghost" | "danger";
   style?: React.CSSProperties;
   className?: string;
+  disabled?: boolean;
 }) => {
   const styles: Record<string, React.CSSProperties> = {
     primary: { background: A, color: "#0a0a0a", border: "none" },
@@ -238,6 +240,7 @@ export const Btn = ({
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={`splito-btn ${className}`}
       style={{
         display: "flex",
@@ -247,7 +250,8 @@ export const Btn = ({
         padding: "9px 16px",
         fontSize: 13,
         fontWeight: 700,
-        cursor: "pointer",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.6 : 1,
         fontFamily: "inherit",
         transition: "all 0.2s",
         ...styles[variant],
@@ -295,12 +299,15 @@ export const Card = ({
   children,
   style = {},
   className = "",
+  id,
 }: {
   children: React.ReactNode;
   style?: React.CSSProperties;
   className?: string;
+  id?: string;
 }) => (
   <div
+    id={id}
     className={className}
     style={{
       background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)",

--- a/lib/splito-design.tsx
+++ b/lib/splito-design.tsx
@@ -1,0 +1,506 @@
+"use client";
+
+import React from "react";
+
+// ─── Design tokens (match provided design) ────────────────────────────────────
+export const A = "#22D3EE";
+export const G = "#34D399";
+export const T = {
+  dim: "#777",
+  sub: "#888",
+  muted: "#999",
+  mid: "#aaa",
+  soft: "#bbb",
+  label: "#ccc",
+  body: "#d4d4d4",
+  main: "#e8e8e8",
+  bright: "#f5f5f5",
+};
+
+export const fmt = (n: number): string =>
+  `$${+n % 1 === 0 ? Math.abs(+n) : Math.abs(+n).toFixed(2)}`;
+
+// ─── Icons (inline SVG, size 16 default) ───────────────────────────────────────
+const Ic = ({
+  d,
+  size = 18,
+  sw = 1.8,
+  className,
+}: {
+  d: string | string[];
+  size?: number;
+  sw?: number;
+  className?: string;
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={sw}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {Array.isArray(d) ? (
+      d.map((p, i) => <path key={i} d={p} />)
+    ) : (
+      <path d={d} />
+    )}
+  </svg>
+);
+
+export const Icons = {
+  home: (props?: { size?: number; className?: string }) => (
+    <Ic d="M3 9.5L12 3l9 6.5V20a1 1 0 01-1 1H4a1 1 0 01-1-1V9.5z" size={props?.size ?? 16} className={props?.className} />
+  ),
+  groups: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2",
+        "M9 11a4 4 0 100-8 4 4 0 000 8z",
+        "M23 21v-2a4 4 0 00-3-3.87",
+        "M16 3.13a4 4 0 010 7.75",
+      ]}
+      size={props?.size ?? 16}
+      className={props?.className}
+    />
+  ),
+  friends: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M12 22a10 10 0 100-20 10 10 0 000 20z",
+        "M12 16a4 4 0 100-8 4 4 0 000 8z",
+      ]}
+      size={props?.size ?? 16}
+      className={props?.className}
+    />
+  ),
+  settings: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M12 15a3 3 0 100-6 3 3 0 000 6z",
+        "M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z",
+      ]}
+      size={props?.size ?? 16}
+      className={props?.className}
+    />
+  ),
+  plus: (props?: { size?: number; className?: string }) => (
+    <Ic d="M12 5v14M5 12h14" size={props?.size ?? 18} className={props?.className} />
+  ),
+  bell: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9",
+        "M13.73 21a2 2 0 01-3.46 0",
+      ]}
+      className={props?.className}
+    />
+  ),
+  chevD: (props?: { size?: number; className?: string }) => (
+    <Ic d="M6 9l6 6 6-6" size={props?.size ?? 15} className={props?.className} />
+  ),
+  chevR: (props?: { size?: number; className?: string }) => (
+    <Ic d="M9 18l6-6-6-6" size={props?.size ?? 15} className={props?.className} />
+  ),
+  trash: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={["M3 6h18", "M8 6V4h8v2", "M19 6l-1 14H6L5 6"]}
+      size={props?.size ?? 15}
+      className={props?.className}
+    />
+  ),
+  check: (props?: { size?: number; className?: string }) => (
+    <Ic d="M20 6L9 17l-5-5" size={props?.size ?? 15} className={props?.className} />
+  ),
+  wallet: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M20 7H4a2 2 0 00-2 2v10a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2z",
+        "M16 13h.01",
+      ]}
+      className={props?.className}
+    />
+  ),
+  userPlus: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2",
+        "M8.5 11a4 4 0 100-8 4 4 0 000 8z",
+        "M20 8v6",
+        "M23 11h-6",
+      ]}
+      className={props?.className}
+    />
+  ),
+  x: (props?: { size?: number; className?: string }) => (
+    <Ic d="M18 6L6 18M6 6l12 12" size={props?.size ?? 16} className={props?.className} />
+  ),
+  search: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M11 19a8 8 0 100-16 8 8 0 000 16z",
+        "M21 21l-4.35-4.35",
+      ]}
+      className={props?.className}
+    />
+  ),
+  shield: (props?: { size?: number; className?: string }) => (
+    <Ic d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" className={props?.className} />
+  ),
+  logout: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4",
+        "M16 17l5-5-5-5",
+        "M21 12H9",
+      ]}
+      className={props?.className}
+    />
+  ),
+  camera: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z",
+        "M12 17a4 4 0 100-8 4 4 0 000 8z",
+      ]}
+      className={props?.className}
+    />
+  ),
+  link: (props?: { size?: number; className?: string }) => (
+    <Ic
+      d={[
+        "M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71",
+        "M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71",
+      ]}
+      size={props?.size ?? 15}
+      className={props?.className}
+    />
+  ),
+};
+
+// ─── Shared UI primitives ──────────────────────────────────────────────────────
+export const Tag = ({
+  children,
+  color = A,
+  className = "",
+}: {
+  children: React.ReactNode;
+  color?: string;
+  className?: string;
+}) => (
+  <span
+    className={className}
+    style={{
+      fontSize: 10,
+      padding: "3px 10px",
+      borderRadius: 99,
+      fontWeight: 700,
+      background: `${color}1a`,
+      color,
+      border: `1px solid ${color}2a`,
+      letterSpacing: "0.02em",
+    }}
+  >
+    {children}
+  </span>
+);
+
+export const Btn = ({
+  children,
+  onClick,
+  variant = "ghost",
+  style = {},
+  className = "",
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  variant?: "primary" | "ghost" | "danger";
+  style?: React.CSSProperties;
+  className?: string;
+}) => {
+  const styles: Record<string, React.CSSProperties> = {
+    primary: { background: A, color: "#0a0a0a", border: "none" },
+    ghost: {
+      background: "rgba(255,255,255,0.06)",
+      color: T.body,
+      border: "1px solid rgba(255,255,255,0.11)",
+    },
+    danger: {
+      background: "rgba(248,113,113,0.08)",
+      color: "#F87171",
+      border: "1px solid rgba(248,113,113,0.2)",
+    },
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`splito-btn ${className}`}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        borderRadius: 12,
+        padding: "9px 16px",
+        fontSize: 13,
+        fontWeight: 700,
+        cursor: "pointer",
+        fontFamily: "inherit",
+        transition: "all 0.2s",
+        ...styles[variant],
+        ...style,
+      }}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const Avatar = ({
+  init,
+  color,
+  size = 38,
+  className = "",
+}: {
+  init: string;
+  color: string;
+  size?: number;
+  className?: string;
+}) => (
+  <div
+    className={className}
+    style={{
+      width: size,
+      height: size,
+      borderRadius: "50%",
+      background: `${color}1a`,
+      border: `2px solid ${color}33`,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      fontSize: size > 34 ? 11 : 9,
+      fontWeight: 800,
+      color,
+      flexShrink: 0,
+    }}
+  >
+    {init}
+  </div>
+);
+
+export const Card = ({
+  children,
+  style = {},
+  className = "",
+}: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+  className?: string;
+}) => (
+  <div
+    className={className}
+    style={{
+      background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)",
+      border: "1px solid rgba(255,255,255,0.08)",
+      borderRadius: 20,
+      overflow: "hidden",
+      boxShadow:
+        "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)",
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const StatBox = ({
+  label,
+  value,
+  color = "#fff",
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) => (
+  <div>
+    <p
+      style={{
+        color: T.muted,
+        fontSize: 11,
+        marginBottom: 6,
+        fontWeight: 600,
+        letterSpacing: "0.05em",
+      }}
+    >
+      {label}
+    </p>
+    <p
+      style={{
+        color,
+        fontSize: 24,
+        fontWeight: 800,
+        fontFamily: "'DM Mono',monospace",
+        letterSpacing: "-0.03em",
+      }}
+    >
+      {value}
+    </p>
+  </div>
+);
+
+export const SectionLabel = ({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <p
+    className={className}
+    style={{
+      color: T.soft,
+      fontSize: 11,
+      fontWeight: 700,
+      letterSpacing: "0.1em",
+      textTransform: "uppercase",
+      marginBottom: 14,
+    }}
+  >
+    {children}
+  </p>
+);
+
+export const BackBtn = ({
+  onClick,
+  className = "",
+}: {
+  onClick: () => void;
+  className?: string;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`splito-back-btn ${className}`}
+    style={{
+      background: "rgba(255,255,255,0.06)",
+      border: "1px solid rgba(255,255,255,0.1)",
+      borderRadius: 12,
+      padding: "8px 14px",
+      color: T.body,
+      fontSize: 13,
+      cursor: "pointer",
+      display: "flex",
+      alignItems: "center",
+      gap: 5,
+      fontFamily: "inherit",
+      flexShrink: 0,
+      fontWeight: 600,
+      transition: "all 0.2s",
+    }}
+  >
+    ← Back
+  </button>
+);
+
+/** Group avatar: 1–4 cells with initials. items: { init, color }[] */
+export function GroupAvatar({
+  items,
+  size = 46,
+  radius = 14,
+  className = "",
+}: {
+  items: { init: string; color: string }[];
+  size?: number;
+  radius?: number;
+  className?: string;
+}) {
+  const members = items.slice(0, 4);
+  const count = members.length;
+  const cellStyle = (m: { init: string; color: string }) => ({
+    flex: 1,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: `${m.color}28`,
+    color: m.color,
+    fontWeight: 800,
+    fontSize: Math.round(size * (count === 1 ? 0.38 : count === 2 ? 0.32 : 0.26)),
+  });
+  return (
+    <div
+      className={className}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: radius,
+        overflow: "hidden",
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      {count === 0 && <div style={{ flex: 1, background: "#1e1e1e" }} />}
+      {count === 1 && (
+        <div style={{ ...cellStyle(members[0]), flex: 1 }}>{members[0].init}</div>
+      )}
+      {count === 2 && (
+        <div style={{ display: "flex", flex: 1 }}>
+          {members.map((m, i) => (
+            <div
+              key={i}
+              style={{
+                ...cellStyle(m),
+                borderRight: i === 0 ? "1px solid rgba(0,0,0,0.3)" : undefined,
+              }}
+            >
+              {m.init}
+            </div>
+          ))}
+        </div>
+      )}
+      {count >= 3 && (
+        <>
+          <div
+            style={{
+              display: "flex",
+              flex: 1,
+              borderBottom: "1px solid rgba(0,0,0,0.3)",
+            }}
+          >
+            {members.slice(0, 2).map((m, i) => (
+              <div
+                key={i}
+                style={{
+                  ...cellStyle(m),
+                  borderRight: i === 0 ? "1px solid rgba(0,0,0,0.3)" : undefined,
+                }}
+              >
+                {m.init}
+              </div>
+            ))}
+          </div>
+          <div style={{ display: "flex", flex: 1 }}>
+            {members.slice(2, 4).map((m, i) => (
+              <div
+                key={i}
+                style={{
+                  ...cellStyle(m),
+                  borderRight:
+                    i === 0 && members.length > 3
+                      ? "1px solid rgba(0,0,0,0.3)"
+                      : undefined,
+                }}
+              >
+                {m.init}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,26 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Returns relative time like "2h ago", "2 days ago" */
+export function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const d = date instanceof Date ? date : new Date(date);
+  const sec = Math.floor((now.getTime() - d.getTime()) / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day === 1) return "1 day ago";
+  if (day < 7) return `${day} days ago`;
+  const week = Math.floor(day / 7);
+  if (week === 1) return "1 week ago";
+  if (week < 4) return `${week} weeks ago`;
+  const month = Math.floor(day / 30);
+  if (month === 1) return "1 month ago";
+  if (month < 12) return `${month} months ago`;
+  const year = Math.floor(day / 365);
+  return year === 1 ? "1 year ago" : `${year} years ago`;
+}


### PR DESCRIPTION
mobile responsive org & personal mode, group header, auth UI
- Organization mode mobile: bottom nav (6 tabs: Dashboard, Invoices, Streams, Activity, Contracts, Members), responsive org layout and dashboard; org switcher in header on mobile; first org selected by default; header spacing improvements
- Personal mode mobile: bottom nav (Home, Groups, Friends, Profile), centered narrow column and padding for dashboard/groups/friends/settings
- Group page: mobile header (icon back only, name + members, balance right); desktop header (← Back, title + balance text, Settle all + Add Expense); responsive content padding; members list cards stack on mobile with action buttons
- Login/signup: Welcome Back + Google as full-width strip first, then OR, then email/password and primary Login/Sign up button; dark theme and accent blue CTA
- New: OrganizationMobileNav, PersonalMobileNav, splito-design (Card, Btn, T, A, etc.)