### PR TITLE
new ui desktop personal mode

### DIFF
--- a/app/groups/[id]/layout.tsx
+++ b/app/groups/[id]/layout.tsx
@@ -202,7 +202,7 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
         />
 
         <div
-          className="rounded-xl sm:rounded-3xl min-h-[calc(100vh-200px)] overflow-y-auto p-4 sm:p-7"
+          className="p-4 pt-0 sm:pt-0 sm:p-7"
         >
           {children}
         </div>
@@ -217,12 +217,8 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
           groupId={groupId}
           members={group.groupUsers.map((u) => u.user)}
           defaultCurrency={user?.currency || group.defaultCurrency}
-          showIndividualView={settleFriendId !== null}
-          selectedFriendId={settleFriendId}
-          specificAmount={settleFriendId ? getSpecificDebtAmount(settleFriendId) : undefined}
-          specificDebtByCurrency={
-            settleFriendId ? getSpecificDebtByCurrency(settleFriendId) : undefined
-          }
+          showIndividualView={false}
+          defaultExpandedMemberId={settleFriendId}
         />
 
         <AddMemberModal

--- a/app/groups/[id]/members/page.tsx
+++ b/app/groups/[id]/members/page.tsx
@@ -11,28 +11,11 @@ import {
   Btn,
   Avatar,
   T,
-  A,
   G,
   Icons,
+  getUserColor,
 } from "@/lib/splito-design";
 
-const MEMBER_COLORS = [
-  A,
-  "#A78BFA",
-  G,
-  "#FB923C",
-  "#F472B6",
-  "#FBBF24",
-  "#F87171",
-  "#818CF8",
-];
-
-function memberColor(userId: string): string {
-  let h = 0;
-  for (let i = 0; i < userId.length; i++)
-    h = (h << 5) - h + userId.charCodeAt(i);
-  return MEMBER_COLORS[Math.abs(h) % MEMBER_COLORS.length];
-}
 
 function getInit(name: string | null): string {
   if (!name || !name.trim()) return "?";
@@ -47,9 +30,8 @@ export default function GroupMembersPage() {
   const {
     group,
     isAdmin,
-    openAddMember,
     handleRemoveMember,
-    handleSettleFriendClick,
+    openSettle,
     handleSendReminder,
     formatCurrency,
     defaultCurrency,
@@ -80,24 +62,10 @@ export default function GroupMembersPage() {
 
   return (
     <div className="pb-6">
-      <div className="flex items-center justify-between gap-3 mb-5 sm:mb-6">
-        <SectionLabel>Your Members</SectionLabel>
-        {isAdmin && (
-          <Btn
-            onClick={openAddMember}
-            variant="ghost"
-            className="shrink-0"
-            style={{ padding: "8px 14px", fontSize: 12 }}
-          >
-            <Icons.userPlus /> Add Member
-          </Btn>
-        )}
-      </div>
-
       <Card className="mb-5 sm:mb-[22px] overflow-hidden">
         {group.groupUsers.map((member, idx) => {
           const isCurrentUser = member.user.id === user.id;
-          const color = memberColor(member.user.id);
+          const color = getUserColor(member.user.name);
           const paid = (group.expenses ?? [])
             .filter(
               (e: { paidBy: string; splitType?: string }) =>
@@ -116,46 +84,51 @@ export default function GroupMembersPage() {
               className={idx < group.groupUsers.length - 1 ? "border-b border-white/[0.06]" : ""}
               style={{ transition: "background 0.15s" }}
             >
-              <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-[14px] p-4 sm:p-5">
-                <div className="flex items-center min-w-0 flex-1">
-                  <Avatar
-                    init={getInit(member.user.name)}
-                    color={color}
-                    size={42}
-                  />
-                  <div className="ml-3 sm:flex-1 min-w-0">
-                    <p
-                      className="font-bold text-sm sm:text-[14px] text-white leading-tight"
-                      style={{ color: T.bright }}
-                    >
-                      {isCurrentUser
-                        ? `${member.user.name ?? "You"} (you)`
-                        : member.user.name ?? "Member"}
-                    </p>
-                    <p
-                      className="text-xs sm:text-[12px] mt-1 font-medium"
-                      style={{ color: T.muted }}
-                    >
-                      Paid {formatAmount(paid)} ·{" "}
-                      <span style={{ color: owesDisplay.color, fontWeight: 600 }}>
-                        {owesDisplay.text}
-                      </span>
-                    </p>
-                  </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  padding: "15px 22px",
+                }}
+              >
+                <Avatar
+                  init={getInit(member.user.name)}
+                  color={color}
+                  size={42}
+                />
+                <div style={{ flex: 1 }}>
+                  <p style={{ fontWeight: 700, fontSize: 14, color: T.bright }}>
+                    {isCurrentUser
+                      ? `${member.user.name ?? "You"} (you)`
+                      : member.user.name ?? "Member"}
+                  </p>
+                  <p
+                    style={{
+                      fontSize: 12,
+                      color: T.muted,
+                      marginTop: 3,
+                      fontWeight: 500,
+                    }}
+                  >
+                    Paid {formatAmount(paid)} ·{" "}
+                    <span style={{ color: owesDisplay.color, fontWeight: 600 }}>
+                      {owesDisplay.text}
+                    </span>
+                  </p>
                 </div>
                 {!isCurrentUser && (
-                  <div className="flex items-center gap-2 sm:gap-2 flex-wrap sm:flex-nowrap sm:shrink-0 pl-[54px] sm:pl-0">
+                  <div style={{ display: "flex", gap: 7 }}>
                     <Btn
-                      onClick={() => handleSettleFriendClick(member.user.id)}
+                      onClick={() => openSettle(member.user.id)}
                       variant="ghost"
-                      className="flex-1 sm:flex-initial min-w-0"
                       style={{
-                        padding: "8px 12px",
+                        padding: "8px 14px",
                         fontSize: 12,
                         display: "flex",
                         alignItems: "center",
-                        justifyContent: "center",
                         gap: 5,
+                        fontWeight: 700,
                       }}
                     >
                       <Icons.wallet /> Settle
@@ -168,14 +141,13 @@ export default function GroupMembersPage() {
                         )
                       }
                       variant="ghost"
-                      className="flex-1 sm:flex-initial min-w-0"
                       style={{
-                        padding: "8px 12px",
+                        padding: "8px 14px",
                         fontSize: 12,
                         display: "flex",
                         alignItems: "center",
-                        justifyContent: "center",
                         gap: 5,
+                        fontWeight: 600,
                       }}
                     >
                       <Icons.bell /> Notify
@@ -204,9 +176,9 @@ export default function GroupMembersPage() {
         })}
       </Card>
 
-      <Card className="p-4 sm:p-[22px]">
+      <Card style={{ padding: "22px" }}>
         <SectionLabel>Group spend breakdown</SectionLabel>
-        <div className="flex gap-4 sm:gap-8 flex-wrap mb-4 sm:mb-[18px]">
+        <div style={{ display: "flex", gap: 32, flexWrap: "wrap", marginBottom: 18 }}>
           <StatBox
             label="Total spent"
             value={formatAmount(totalSpent)}
@@ -238,7 +210,7 @@ export default function GroupMembersPage() {
               key={m.user.id}
               style={{
                 width: `${100 / group.groupUsers.length}%`,
-                background: memberColor(m.user.id),
+                background: getUserColor(m.user.name),
                 opacity: 0.75,
                 borderRadius: 99,
               }}

--- a/app/groups/[id]/splits/page.tsx
+++ b/app/groups/[id]/splits/page.tsx
@@ -14,6 +14,7 @@ import {
   Icons,
   G,
   T,
+  getUserColor,
 } from "@/lib/splito-design";
 
 type ExpenseWithParticipants = {
@@ -38,10 +39,12 @@ const CATEGORY_STYLES: Record<string, { bg: string; icon: string }> = {
 
 function getCategoryStyle(category: string) {
   const key = (category || "").toUpperCase();
-  return (
-    CATEGORY_STYLES[key] ||
-    CATEGORY_STYLES[key.split(/[\s-_]/)[0]] || { bg: "rgba(255,255,255,0.06)", icon: "🧾" }
-  );
+  const known = CATEGORY_STYLES[key] || CATEGORY_STYLES[key.split(/[\s-_]/)[0]];
+  if (known) return known;
+  // If not a known keyword, treat it as a raw emoji
+  const trimmed = (category || "").trim();
+  if (trimmed && trimmed !== "OTHER") return { bg: "rgba(255,255,255,0.06)", icon: trimmed };
+  return { bg: "rgba(255,255,255,0.06)", icon: "🧾" };
 }
 
 function formatDateKey(d: Date | string): string {
@@ -192,7 +195,7 @@ function ExpenseRow({
                       <Avatar
                         init={u ? (u.name ?? "?")[0].toUpperCase() : "?"}
                         size={28}
-                        color="#22D3EE"
+                        color={getUserColor(u?.name || "?")}
                       />
                       <span style={{ color: T.body, fontSize: 13, fontWeight: 500 }}>{name}</span>
                     </div>
@@ -216,32 +219,15 @@ function ExpenseRow({
               })}
             </div>
           <div style={{ display: "flex", gap: 8, paddingTop: 16 }}>
-            <Btn variant="ghost" onClick={onSettle} style={{ padding: "8px 16px", fontSize: 12 }}>
+            <Btn variant="ghost" onClick={onSettle} className="splito-sbtn" style={{ padding: "8px 16px", fontSize: 12 }}>
               <Icons.check /> Settle
             </Btn>
-            <Btn variant="ghost" onClick={onNotify} style={{ padding: "8px 16px", fontSize: 12 }}>
+            <Btn variant="ghost" onClick={onNotify} className="splito-abtn" style={{ padding: "8px 16px", fontSize: 12 }}>
               <Icons.bell /> Notify
             </Btn>
-            <button
-              type="button"
-              onClick={onDelete}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 5,
-                background: "rgba(248,113,113,0.06)",
-                border: "1px solid rgba(248,113,113,0.15)",
-                borderRadius: 12,
-                padding: "8px 14px",
-                color: "#F87171",
-                fontSize: 12,
-                cursor: "pointer",
-                fontFamily: "inherit",
-                fontWeight: 600,
-              }}
-            >
+            <Btn variant="danger" onClick={onDelete} style={{ padding: "8px 14px", fontSize: 12 }}>
               <Icons.trash size={14} /> Delete
-            </button>
+            </Btn>
           </div>
         </div>
       )}
@@ -255,7 +241,7 @@ export default function GroupSplitsPage() {
   const {
     group,
     formatCurrency,
-    handleSettleFriendClick,
+    openSettle,
     handleSendReminder,
     openAddExpense,
   } = useGroupLayout();
@@ -321,8 +307,7 @@ export default function GroupSplitsPage() {
                     if (firstOwer) handleSendReminder(firstOwer.userId, expense.id);
                   }}
                   onSettle={() => {
-                    const firstOwer = expense.expenseParticipants?.find((p) => p.amount > 0);
-                    if (firstOwer) handleSettleFriendClick(firstOwer.userId);
+                    openSettle();
                   }}
                   onDelete={() => {
                     if (!group?.id) {
@@ -341,7 +326,7 @@ export default function GroupSplitsPage() {
 
       {expenseToDelete && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 !mt-0"
           onClick={() => {
             if (!deleteExpenseMutation.isPending) setExpenseToDelete(null);
           }}

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -4,7 +4,7 @@ import { GroupsList } from "@/components/groups-list";
 import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { CreateGroupForm } from "@/components/create-group-form";
-import { Icons } from "@/lib/splito-design";
+import { Icons, T } from "@/lib/splito-design";
 
 export default function GroupsPage() {
   const searchParams = useSearchParams();
@@ -42,15 +42,32 @@ export default function GroupsPage() {
       </div>
       <div className="flex-1 overflow-y-auto p-4 sm:p-7">
         <div
-          className="flex items-center rounded-[14px] mb-5 sm:mb-6 py-2.5 px-4 gap-2 bg-white/[0.04] border border-white/[0.08]"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.08)",
+            borderRadius: 14,
+            padding: "11px 16px",
+            marginBottom: 24,
+            gap: 8
+          }}
         >
-          <span className="text-[#999] shrink-0">{Icons.search({ size: 18 })}</span>
+          <span style={{ color: T.muted, display: "flex" }}>{Icons.search()}</span>
           <input
-            type="text"
             placeholder="Search groups…"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="flex-1 min-w-0 bg-transparent text-[14px] text-white placeholder:text-white/50 focus:outline-none font-medium"
+            style={{
+              background: "none",
+              border: "none",
+              color: "#fff",
+              fontSize: 14,
+              outline: "none",
+              width: "100%",
+              fontFamily: "inherit",
+              fontWeight: 500
+            }}
           />
         </div>
         <GroupsList searchQuery={searchQuery} />

--- a/app/organization/[organizationId]/layout.tsx
+++ b/app/organization/[organizationId]/layout.tsx
@@ -364,7 +364,7 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
           <div className="fixed inset-0 z-50 h-screen w-screen">
             <div className="fixed inset-0 bg-black/80 backdrop-blur-sm" onClick={() => setIsSettingsModalOpen(false)} />
             <div
-              className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[450px] rounded-2xl p-6 z-10"
+              className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[450px] rounded-2xl p-6 z-[999]"
               style={{ background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)", border: "1px solid rgba(255,255,255,0.08)", boxShadow: "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)" }}
             >
               <h2 className="text-xl font-extrabold tracking-[-0.02em] mb-6" style={{ color: T.bright }}>Organization settings</h2>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,6 +42,7 @@ import {
   G,
   T,
   Icons,
+  getUserColor,
 } from "@/lib/splito-design";
 
 /** Derive overall youOwe/youGet from groups' groupBalances (same source as group pages) */
@@ -201,11 +202,11 @@ function GroupBalanceShort({
   const { total: owedTotal, isLoading: loadOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
   if (loadOwe || loadOwed) return <span className="text-white/60">…</span>;
   const net = (owedTotal ?? 0) - (oweTotal ?? 0);
-  if (net === 0) return <span style={{ color: G, fontSize: 13, fontWeight: 800 }}>+$0</span>;
+  if (net === 0) return <span style={{ color: G, fontSize: 13, fontWeight: 800, fontFamily: "monospace" }}>+$0</span>;
   if (net > 0)
     return (
       <span
-        className="font-dm-mono font-extrabold text-[13px]"
+        className="font-mono font-extrabold text-[13px]"
         style={{ color: G }}
       >
         +{formatCurrency(net, defaultCurrency)}
@@ -213,7 +214,7 @@ function GroupBalanceShort({
     );
   return (
     <span
-      className="font-dm-mono font-extrabold text-[13px]"
+      className="font-mono font-extrabold text-[13px]"
       style={{ color: "#F87171" }}
     >
       -{formatCurrency(Math.abs(net), defaultCurrency)}
@@ -423,7 +424,7 @@ export default function Page() {
   /** Recent activity from all groups (expenses + settlements) for Dashboard card */
   const recentActivityFromGroups = useMemo(() => {
     if (!user || !groups?.length) return [];
-    const items: { id: string; text: string; date: Date; dotColor: string }[] = [];
+    const items: { id: string; text: string; subtext: string; date: Date; dotColor: string }[] = [];
     for (const group of groups) {
       const expenses = (group as { expenses?: { id: string; name: string; amount: number; currency: string; paidBy: string; createdAt: Date; splitType: string }[] }).expenses ?? [];
       const groupUsers = (group as { groupUsers?: { user: { id: string; name?: string | null } }[] }).groupUsers ?? [];
@@ -431,18 +432,22 @@ export default function Page() {
         userId === user.id ? "You" : (groupUsers.find((gu) => gu.user.id === userId)?.user?.name ?? "Someone");
       for (const exp of expenses) {
         const date = exp.createdAt instanceof Date ? exp.createdAt : new Date(exp.createdAt);
-        const amountStr = formatCurrency(exp.amount, exp.currency || defaultCurrency);
+        const amountStr = formatCurrency(Math.abs(exp.amount), exp.currency || defaultCurrency);
+        const timeAgo = formatRelativeTime(date);
+        const subtext = `${timeAgo} · ${group.name}`;
         if (exp.splitType === "SETTLEMENT") {
           items.push({
             id: exp.id,
-            text: `${paidByName(exp.paidBy)} marked a payment as settled (${amountStr})`,
+            text: `${paidByName(exp.paidBy)} settled ${amountStr}`,
+            subtext,
             date,
-            dotColor: G,
+            dotColor: "#A78BFA",
           });
         } else {
           items.push({
             id: exp.id,
             text: `${paidByName(exp.paidBy)} added ${exp.name} (${amountStr})`,
+            subtext,
             date,
             dotColor: A,
           });
@@ -458,16 +463,16 @@ export default function Page() {
       .slice(0, 4)
       .map((gu) => ({
         init: gu.user.name?.charAt(0)?.toUpperCase() || "?",
-        color: "#22D3EE",
+        color: getUserColor(gu.user.name),
       }));
 
   return (
     <div className="flex-1 flex flex-col min-w-0">
       {/* Sticky header – design, responsive padding */}
       <div
-        className="border-b border-white/[0.07] px-4 sm:px-7 flex items-center h-14 sm:h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
+        className="border-b border-white/[0.07] px-7 flex items-center h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
       >
-        <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
+        <h1 className="text-[20px] font-extrabold tracking-[-0.02em] text-white">
           Dashboard
         </h1>
       </div>
@@ -519,7 +524,7 @@ export default function Page() {
             )}
           </p>
           <div
-            className="h-px my-5"
+            className="h-px my-[22px]"
             style={{ background: "rgba(255,255,255,0.07)" }}
           />
           <div className="grid grid-cols-3 gap-0">
@@ -540,15 +545,15 @@ export default function Page() {
                 "You settled this month",
                 isAnalyticsLoading || settledConvLoading
                   ? "…"
-                  : formatCurrency(settledConverted, defaultCurrency),
+                  : settledThisMonth === 0 ? "$0.00" : formatCurrency(settledConverted, defaultCurrency),
               ],
-            ].map(([label, value], i) => (
+            ].map(([label, value], i, arr) => (
               <div
                 key={String(label)}
-                className={`min-w-0 ${i === 0 ? "pr-2 sm:pr-7" : i === 1 ? "px-2 sm:px-7 border-r border-white/[0.07]" : "pl-2 sm:pl-7"} text-center sm:text-left`}
+                className={`min-w-0 ${i < arr.length - 1 ? "pr-2 sm:pr-[28px] border-r border-white/[0.07]" : ""} ${i > 0 ? "pl-2 sm:pl-[28px]" : ""} text-left`}
               >
                 <p
-                  className="text-[10px] sm:text-[11px] mb-1 sm:mb-2.5 font-semibold tracking-[0.04em] truncate"
+                  className="text-[10px] sm:text-[11px] mb-2 sm:mb-2.5 font-semibold tracking-[0.04em] truncate"
                   style={{ color: T.muted }}
                 >
                   {label}
@@ -561,7 +566,7 @@ export default function Page() {
                 </p>
               </div>
             ))}
-        </div>
+          </div>
       </div>
 
         {/* Your Groups + Recent Activity – design grid, responsive */}
@@ -606,8 +611,8 @@ export default function Page() {
                 return (
                   <Link href={`/groups/${g.id}`} key={g.id}>
                     <div
-                      className="splito-row-hover flex items-center gap-3 py-2.5 border-b border-white/[0.06] cursor-pointer last:border-b-0"
-                      style={i < 2 ? { borderBottom: "1px solid rgba(255,255,255,0.06)" } : {}}
+                      className="splito-row-hover flex items-center gap-3 py-[11px] border-b border-white/[0.06] cursor-pointer last:border-b-0"
+                      style={i < (groups.slice(0,3).length - 1) ? { borderBottom: "1px solid rgba(255,255,255,0.06)" } : {}}
                     >
                       <GroupAvatar
                         items={groupAvatarItems(g)}
@@ -623,8 +628,8 @@ export default function Page() {
                             ? (g as { expenses: unknown[] }).expenses.length
                             : 0)}{" "}
                           expenses
-          </p>
-        </div>
+                        </p>
+                      </div>
                       <GroupBalanceShort
                         group={g}
                         userId={user?.id ?? null}
@@ -651,20 +656,20 @@ export default function Page() {
                 {recentActivityFromGroups.map((a) => (
                   <div
                     key={a.id}
-                    className="flex gap-3 py-2.5 border-b border-white/[0.06] last:border-b-0"
+                    className="flex gap-3 py-[9px] border-b border-white/[0.06] last:border-b-0"
                   >
                     <div
-                      className="w-2 h-2 rounded-full flex-shrink-0 mt-1.5"
+                      className="w-2 h-2 rounded-full flex-shrink-0 mt-[5px]"
                       style={{ background: a.dotColor }}
                     />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-[13px] font-medium leading-snug" style={{ color: T.body }}>
+                    <div className="min-w-0">
+                      <p className="text-[13px] font-[500] text-[#d4d4d4] leading-snug">
                         {a.text}
                       </p>
-                      <p className="text-[11px] mt-0.5 font-semibold" style={{ color: T.sub }}>
-                        {formatRelativeTime(a.date)}
-          </p>
-        </div>
+                      <p className="text-[11px] mt-0.5 font-[600]" style={{ color: T.sub }}>
+                        {a.subtext}
+                      </p>
+                    </div>
                   </div>
                 ))}
           </div>
@@ -740,18 +745,17 @@ export default function Page() {
                     }));
                   const friendInit =
                     friend.name?.split(" ").map((n) => n[0]).join("").slice(0, 2).toUpperCase() || "?";
-                  const FRIEND_COLORS = [A, "#A78BFA", G, "#FB923C", "#F472B6", "#FBBF24", "#818CF8"];
-                  const color = FRIEND_COLORS[index % FRIEND_COLORS.length];
+                  const color = getUserColor(friend.name);
                   return (
                     <FriendBalanceCard
                       key={friend.id}
                       friendName={friend.name ?? "Friend"}
                       friendInit={friendInit}
                       color={color}
-                              oweItems={oweItems}
-                              owedItems={owedItems}
-                              defaultCurrency={defaultCurrency}
-                            />
+                      oweItems={oweItems}
+                      owedItems={owedItems}
+                      defaultCurrency={defaultCurrency}
+                    />
                   );
                 })
             )}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -59,6 +59,9 @@ export default function SettingsPage() {
   const { mutate: removeWallet, isPending: isRemovingWallet } =
     useRemoveWallet();
 
+  // Guard against infinite loop if API fails
+  const autoSetPrimaryAttempted = React.useRef<string | null>(null);
+
   // Process wallet data for UI
   const wallets = walletData?.accounts || [];
 
@@ -187,6 +190,18 @@ export default function SettingsPage() {
       address: walletToUpdate.address,
     });
   };
+
+  // Auto-set single wallet as primary
+  useEffect(() => {
+    if (wallets.length === 1 && !wallets[0].isDefault) {
+      if (autoSetPrimaryAttempted.current !== wallets[0].id) {
+        autoSetPrimaryAttempted.current = wallets[0].id;
+        handleSetAsPrimary(wallets[0].id);
+      }
+    } else if (wallets.length > 1 || wallets.length === 0) {
+      autoSetPrimaryAttempted.current = null;
+    }
+  }, [wallets, handleSetAsPrimary]);
 
   // Remove a wallet using the mutation hook
   const handleRemoveWallet = (walletId: string) => {

--- a/app/settings/settings-page-content.tsx
+++ b/app/settings/settings-page-content.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
-import { Loader2, Trash2, Save, Info } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import type { Currency } from "@/features/currencies/api/client";
 import type { Wallet } from "@/features/wallets/api/client";
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/tooltip";
 import { AddWalletModal } from "@/components/add-wallet-modal";
 import type { User } from "@/api-helpers/modelSchema/UserSchema";
-import { Card, Btn, T, Icons, A } from "@/lib/splito-design";
+import { Card, Btn, T, Icons, A, getUserColor } from "@/lib/splito-design";
 
 export interface SettingsPageContentProps {
   user: User;
@@ -81,6 +81,15 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
   } = props;
 
   const [notificationsOn, setNotificationsOn] = React.useState(true);
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  React.useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    const set = () => setIsMobile(mq.matches);
+    set();
+    mq.addEventListener("change", set);
+    return () => mq.removeEventListener("change", set);
+  }, []);
 
   const SLabel = ({ children, style = {} }: { children: React.ReactNode; style?: React.CSSProperties }) => (
     <div
@@ -167,20 +176,28 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
   const userEmail = user?.email ?? "";
   const userInitial = (displayName || user?.name || "Y").charAt(0).toUpperCase();
 
+  // Chain metadata (matching design artifact)
+  const CHAIN_META: Record<string, { color: string; icon: string }> = {
+    Aptos: { color: "#22D3EE", icon: "⬡" },
+    Ethereum: { color: "#818CF8", icon: "◆" },
+    Base: { color: "#3B82F6", icon: "🔵" },
+    Solana: { color: "#A78BFA", icon: "◎" },
+    Stellar: { color: "#34D399", icon: "✦" },
+    Polygon: { color: "#A855F7", icon: "⬟" },
+  };
+
+  const getChainMeta = (chainName: string) => {
+    return CHAIN_META[chainName] || { color: "#666", icon: "◆" };
+  };
+
   return (
-    <div className="flex w-full min-h-screen bg-black rounded-xl">
-      <div className="flex-1 flex flex-col min-w-0">
-        {/* Sticky header – design (matches Dashboard), responsive */}
-        <div
-          className="border-b border-white/[0.07] px-4 sm:px-7 flex items-center h-14 sm:h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
-        >
-          <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
-            Settings
-          </h1>
-        </div>
-        <div className="flex-1 p-4 sm:p-7 overflow-y-auto max-w-[660px] pb-24">
-          <SLabel style={{ marginTop: 0 }}>Profile</SLabel>
-          <Card className="p-4 sm:p-[22px] mb-1">
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+      <div style={{ borderBottom: "1px solid rgba(255,255,255,0.07)", padding: "0 28px", display: "flex", alignItems: "center", height: 70, position: "sticky", top: 0, background: "rgba(11,11,11,0.95)", backdropFilter: "blur(20px)", zIndex: 40 }}>
+        <h1 style={{ fontSize: 20, fontWeight: 800, letterSpacing: "-0.02em", color: "#fff" }}>Settings</h1>
+      </div>
+      <div style={{ flex: 1, padding: "26px 28px", overflowY: "auto", maxWidth: 660 }}>
+          <SLabel>Profile</SLabel>
+          <Card style={{ padding: "22px", marginBottom: 4 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 22, paddingBottom: 22, borderBottom: "1px solid rgba(255,255,255,0.07)" }}>
               <div style={{ position: "relative" }}>
                 <label htmlFor="profile-upload" style={{ cursor: isUploadingImage ? "not-allowed" : "pointer", display: "block" }}>
@@ -189,14 +206,14 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
                       width: 64,
                       height: 64,
                       borderRadius: "50%",
-                      background: `${A}1a`,
-                      border: `2px solid ${A}44`,
+                      background: `${getUserColor(user?.name || "You")}1a`,
+                      border: `2px solid ${getUserColor(user?.name || "You")}44`,
                       display: "flex",
                       alignItems: "center",
                       justifyContent: "center",
                       fontSize: 22,
                       fontWeight: 800,
-                      color: A,
+                      color: getUserColor(user?.name || "You"),
                       overflow: "hidden",
                     }}
                   >
@@ -254,69 +271,30 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
               <input
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
-                style={{
-                  background: "rgba(255,255,255,0.05)",
-                  border: "1.5px solid rgba(255,255,255,0.09)",
-                  borderRadius: 12,
-                  padding: "10px 14px",
-                  color: "#fff",
-                  fontSize: 14,
-                  outline: "none",
-                  fontFamily: "inherit",
-                  width: 220,
-                  fontWeight: 500,
-                }}
+                style={{ background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", borderRadius: 12, padding: "10px 14px", color: "#fff", fontSize: 14, outline: "none", fontFamily: "inherit", width: 220, fontWeight: 500 }}
               />
             </Row>
             <Row style={{ borderBottom: "none" }}>
               <span style={{ color: T.body, fontSize: 14, fontWeight: 600 }}>Email</span>
               <input
                 value={userEmail}
-                readOnly
-                style={{
-                  background: "rgba(255,255,255,0.05)",
-                  border: "1.5px solid rgba(255,255,255,0.09)",
-                  borderRadius: 12,
-                  padding: "10px 14px",
-                  color: T.muted,
-                  fontSize: 14,
-                  outline: "none",
-                  fontFamily: "inherit",
-                  width: 220,
-                  fontWeight: 500,
-                }}
+                onChange={(e) => {}}
+                style={{ background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", borderRadius: 12, padding: "10px 14px", color: "#fff", fontSize: 14, outline: "none", fontFamily: "inherit", width: 220, fontWeight: 500 }}
               />
             </Row>
             <div style={{ paddingTop: 18, display: "flex", justifyContent: "flex-end" }}>
-              {hasChanges && (
-                <button
-                  onClick={handleSaveChanges}
-                  disabled={isUpdatatingUser}
-                  style={{
-                    background: A,
-                    border: "none",
-                    borderRadius: 12,
-                    padding: "10px 22px",
-                    color: "#0a0a0a",
-                    fontWeight: 800,
-                    fontSize: 13,
-                    cursor: isUpdatatingUser ? "not-allowed" : "pointer",
-                    fontFamily: "inherit",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 6,
-                    opacity: isUpdatatingUser ? 0.7 : 1,
-                  }}
-                >
-                  {isUpdatatingUser ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                  {isUpdatatingUser ? "Saving..." : "Save Changes"}
-                </button>
-              )}
+              <button
+                onClick={handleSaveChanges}
+                disabled={isUpdatatingUser}
+                style={{ background: A, border: "none", borderRadius: 12, padding: "10px 22px", color: "#0a0a0a", fontWeight: 800, fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}
+              >
+                Save Changes
+              </button>
             </div>
           </Card>
 
           <SLabel>Preferences</SLabel>
-          <Card className="px-4 sm:px-[22px] py-0">
+          <Card style={{ padding: "0 22px" }}>
             <Row>
               <div>
                 <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Notifications</p>
@@ -339,7 +317,7 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
             </Row>
           </Card>
 
-          {wallets.length > 0 && (
+          {wallets.length > 0 && !isMobile && (
             <>
               <SLabel>Accept Payments in</SLabel>
               <Card className="p-[22px] mb-4" id="settings-accept-payments-tokens">
@@ -366,7 +344,7 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
           )}
 
           <SLabel>Security</SLabel>
-          <Card className="px-4 sm:px-[22px] py-0">
+          <Card style={{ padding: "0 22px" }}>
             <Row
               style={{ borderBottom: "none", cursor: "pointer" }}
               onClick={() => { if (typeof window !== "undefined") window.location.href = "/settings/change-password"; }}
@@ -386,36 +364,50 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
                 <Loader2 className="h-8 w-8 animate-spin" style={{ color: T.muted }} />
               </div>
             ) : wallets.length > 0 ? (
-              wallets.map((wallet, idx) => (
-                <div
-                  key={wallet.id}
-                  className="flex flex-col sm:flex-row sm:items-center gap-3 py-4 px-4 sm:py-[17px] sm:px-[22px] border-b border-white/[0.06] last:border-b-0"
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2 mb-1">
-                      <p className="text-sm font-bold text-[#e8e8e8]">{getChainName(wallet.chainId)}</p>
-                      {wallet.isDefault && (
-                        <span style={{ fontSize: 10, padding: "3px 10px", borderRadius: 99, fontWeight: 700, background: `${A}1a`, color: A, border: `1px solid ${A}2a` }}>Primary</span>
-                      )}
+              wallets.map((wallet, idx) => {
+                const chainName = getChainName(wallet.chainId);
+                const meta = getChainMeta(chainName);
+                const addr = wallet.address || "";
+                const truncatedAddress = addr.length > 14 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+                return (
+                  <div
+                    key={wallet.id}
+                    style={{ display: "flex", alignItems: "center", gap: 14, padding: "17px 22px", borderBottom: idx < wallets.length - 1 ? "1px solid rgba(255,255,255,0.06)" : "none", minWidth: 0 }}
+                  >
+                    <div style={{ width: 44, height: 44, borderRadius: 14, background: `${meta.color}18`, border: `1.5px solid ${meta.color}33`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 22, flexShrink: 0, color: "#fff" }}>
+                      {meta.icon}
                     </div>
-                    <p className="text-xs text-[#999] font-mono truncate" title={wallet.address}>
-                      {wallet.address.length > 20 ? wallet.address.slice(0, 10) + "..." + wallet.address.slice(-8) : wallet.address}
-                    </p>
+                    <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
+                        <p style={{ fontSize: 14, fontWeight: 700, color: T.bright }}>{chainName}</p>
+                        {(wallet.isDefault || wallets.length === 1) && (
+                          <span style={{ fontSize: 10, padding: "3px 10px", borderRadius: 99, fontWeight: 700, background: `${A}1a`, color: A, border: `1px solid ${A}2a` }}>Primary</span>
+                        )}
+                      </div>
+                      <p style={{ fontSize: 12, color: T.muted, fontFamily: "monospace", fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={addr}>
+                        {truncatedAddress}
+                      </p>
+                    </div>
+                    <div style={{ display: "flex", gap: 7, flexShrink: 0 }}>
+                      {!wallet.isDefault && wallets.length > 1 && handleSetAsPrimary && (
+                        <button
+                          onClick={() => handleSetAsPrimary(wallet.id)}
+                          className="abtn"
+                          style={{ background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.11)", borderRadius: 10, padding: "7px 14px", color: T.body, fontSize: 11, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", transition: "all 0.2s" }}
+                        >
+                          Set Primary
+                        </button>
+                      )}
+                      <button
+                        onClick={() => handleRemoveWallet(wallet.id)}
+                        style={{ background: "rgba(248,113,113,0.07)", border: "1px solid rgba(248,113,113,0.15)", borderRadius: 10, padding: "7px 12px", color: "#F87171", fontSize: 11, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center", gap: 4, fontWeight: 600 }}
+                      >
+                        {Icons.trash({})} Remove
+                      </button>
+                    </div>
                   </div>
-                  <div className="flex gap-2 flex-shrink-0">
-                    {!wallet.isDefault && handleSetAsPrimary && (
-                      <Btn variant="ghost" className="py-1.5 px-3 text-[11px]" onClick={() => handleSetAsPrimary(wallet.id)}>Set Primary</Btn>
-                    )}
-                    <button
-                      onClick={() => handleRemoveWallet(wallet.id)}
-                      className="flex items-center gap-1 py-1.5 px-3 rounded-lg text-[11px] font-semibold border border-[rgba(248,113,113,0.15)] bg-[rgba(248,113,113,0.07)] text-[#F87171]"
-                    >
-                      {Icons.trash({ size: 12 })}
-                      Remove
-                    </button>
-                  </div>
-                </div>
-              ))
+                );
+              })
             ) : (
               <div style={{ padding: "24px 22px", color: T.body, fontSize: 13 }}>You don&apos;t have any wallets yet.</div>
             )}
@@ -424,32 +416,14 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
             id="settings-add-wallet-button"
             onClick={() => setIsWalletModalOpen(true)}
             disabled={isAddingWallet}
-            style={{
-              width: "100%",
-              padding: 14,
-              background: "rgba(255,255,255,0.03)",
-              border: "1.5px dashed rgba(255,255,255,0.12)",
-              borderRadius: 18,
-              color: T.muted,
-              fontSize: 14,
-              fontWeight: 700,
-              cursor: isAddingWallet ? "not-allowed" : "pointer",
-              fontFamily: "inherit",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 8,
-              transition: "all 0.2s",
-              marginTop: 10,
-              opacity: isAddingWallet ? 0.7 : 1,
-            }}
+            className="abtn"
+            style={{ width: "100%", padding: "14px", background: "rgba(255,255,255,0.03)", border: "1.5px dashed rgba(255,255,255,0.12)", borderRadius: 18, color: T.muted, fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center", justifyContent: "center", gap: 8, transition: "all 0.2s", marginTop: 10 }}
           >
-            {Icons.plus({ size: 16 })}
-            Add Wallet
+            {Icons.plus({})} Add Wallet
           </button>
 
           <SLabel>Account</SLabel>
-          <Card className="px-4 sm:px-[22px] py-0">
+          <Card style={{ padding: "0 22px" }}>
             <Row
               style={{
                 borderBottom: "none",
@@ -538,7 +512,6 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
             </div>
           )}
         </AnimatePresence>
-      </div>
     </div>
   );
 }

--- a/components/add-expense-modal.tsx
+++ b/components/add-expense-modal.tsx
@@ -21,7 +21,7 @@ import CurrencyDropdown from "./currency-dropdown";
 import TimeLockToggle from "./ui/TimeLockToggle";
 import { motion, AnimatePresence } from "framer-motion";
 import { fadeIn, scaleIn } from "@/utils/animations";
-import { Card, A, T } from "@/lib/splito-design";
+import { Card, A, T, getUserColor } from "@/lib/splito-design";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 
 const CATEGORY_OPTIONS: { emoji: string; api: string }[] = [
@@ -296,7 +296,7 @@ export function AddExpenseModal({
     }
 
     const payload: ExpensePayload = {
-      category: formData.category || "OTHER",
+      category: formData.categoryEmoji || formData.category || "OTHER",
       name: formData.name || "Expense",
       description: formData.description || "",
       amount: parseFloat(formData.amount),
@@ -806,7 +806,7 @@ export function AddExpenseModal({
                     gap: 8,
                   }}
                 >
-                  {members.map((member, index) => {
+                  {members.map((member) => {
                     const init =
                       member.id === user?.id
                         ? "Y"
@@ -817,8 +817,7 @@ export function AddExpenseModal({
                             .slice(0, 2)
                             .toUpperCase();
                     const isSelected = formData.paidBy === member.id;
-                    const memberColors = ["#A78BFA", "#34D399", "#FB923C", "#F472B6", "#FBBF24", "#22D3EE"];
-                    const memberColor = memberColors[index % memberColors.length];
+                    const memberColor = getUserColor(member.id === user?.id ? (user?.name || member.name) : member.name);
                     return (
                       <button
                         key={member.id}
@@ -828,9 +827,9 @@ export function AddExpenseModal({
                         }
                         style={{
                           padding: "10px 4px",
-                          background: "rgba(255,255,255,0.04)",
+                          background: isSelected ? `${memberColor}12` : "rgba(255,255,255,0.04)",
                           border: isSelected
-                            ? `2px solid ${A}`
+                            ? `2px solid ${memberColor}`
                             : "1px solid rgba(255,255,255,0.08)",
                           borderRadius: 14,
                           cursor: "pointer",
@@ -839,7 +838,7 @@ export function AddExpenseModal({
                           alignItems: "center",
                           gap: 6,
                           transition: "all 0.2s",
-                          boxShadow: isSelected ? `0 0 14px ${A}44` : "none",
+                          boxShadow: isSelected ? `0 0 14px ${memberColor}44` : "none",
                         }}
                       >
                         <div
@@ -847,21 +846,21 @@ export function AddExpenseModal({
                             width: 38,
                             height: 38,
                             borderRadius: "50%",
-                            background: isSelected ? A : `${memberColor}1a`,
+                            background: isSelected ? memberColor : `${memberColor}1a`,
                             border: isSelected ? "none" : `2px solid ${memberColor}40`,
                             display: "flex",
                             alignItems: "center",
                             justifyContent: "center",
                             fontSize: 11,
                             fontWeight: 800,
-                            color: isSelected ? "#fff" : memberColor,
+                            color: isSelected ? "#0a0a0a" : memberColor,
                           }}
                         >
                           {init}
                         </div>
                         <span
                           style={{
-                            color: isSelected ? A : T.sub,
+                            color: isSelected ? memberColor : T.sub,
                             fontSize: 10,
                             fontWeight: 700,
                           }}

--- a/components/add-member-modal.tsx
+++ b/components/add-member-modal.tsx
@@ -2,16 +2,15 @@
 
 import {
   useAddMembersToGroup,
-  useGetGroupById,
 } from "@/features/groups/hooks/use-create-group";
 import { useAddFriend } from "@/features/friends/hooks/use-add-friend";
-import { X, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
 import { isValidEmail } from "@/utils/validation";
+import { A, T } from "@/lib/splito-design";
 
 interface AddMemberModalProps {
   isOpen: boolean;
@@ -116,65 +115,129 @@ export function AddMemberModal({
 
   if (!isOpen) return null;
 
+  const isDisabled = isPending || isAddingFriend;
+  const canSubmit = !isDisabled && !!email.trim() && isValidEmail(email.trim());
+
   return (
-    <div className="fixed inset-0 z-50 h-screen w-screen">
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/70 brightness-100"
+        className="fixed inset-0"
+        style={{ background: "rgba(0,0,0,0.88)", backdropFilter: "blur(16px)" }}
         onClick={onClose}
       />
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[450px]">
-        <div className="animate-border-light relative z-10">
-          <div className="relative rounded-[14.77px] bg-black p-4 lg:p-8">
-            <div className="flex items-center justify-between mb-6 lg:mb-8">
-              <h3 className="text-2xl lg:text-[29.28px] font-base text-white tracking-[-0.03em]">
-                Add Admin
-              </h3>
-              <button
-                onClick={onClose}
-                className="rounded-full p-1.5 lg:p-2 hover:bg-white/10 transition-colors"
-              >
-                <X className="h-5 w-5 lg:h-6 lg:w-6 text-white" />
-              </button>
-            </div>
 
-            <div className="space-y-4 lg:space-y-6">
-              <p className="text-white/60 text-sm -mt-2">Add a new org admin by email. Regular members join via contract.</p>
-              <label className="block text-lg font-medium text-white mb-2 mt-2">Admin email</label>
-              <div className="relative">
-                <input
-                  type="text"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  placeholder="me@email.com"
-                  className="w-full h-12 lg:h-14 bg-[#1F1F23] rounded-2xl pl-4 pr-4 
-                  text-base lg:text-lg font-normal text-white 
-                  border border-white/10 
-                  transition-all duration-300
-                  placeholder:text-white/30
-                  focus:outline-none focus:border-white/20 focus:shadow-[0_0_15px_rgba(255,255,255,0.05)]"
-                  disabled={isPending || isAddingFriend}
-                />
-              </div>
-
-              <Button
-                onClick={handleAddMember}
-                disabled={(isPending || isAddingFriend) || !email.trim() || !isValidEmail(email.trim())}
-                className="w-full h-14 rounded-full bg-[#fff] text-black text-base font-bold mt-8 shadow-none border-none"
-                style={{ backgroundColor: '#fff', color: '#000' }}
-              >
-                {(isPending || isAddingFriend) ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Adding...
-                  </>
-                ) : (
-                  "Add Admin"
-                )}
-              </Button>
-            </div>
+      {/* Modal */}
+      <div
+        className="relative z-10 w-full max-w-[460px] rounded-[28px] p-7"
+        style={{
+          background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
+          border: "1px solid rgba(255,255,255,0.09)",
+          boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
+          animation: "mIn 0.3s cubic-bezier(.34,1.56,.64,1)",
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <p style={{ color: "#fff", fontSize: 20, fontWeight: 800, letterSpacing: "-0.02em" }}>
+              Add Member
+            </p>
+            <p style={{ color: T.mid, fontSize: 12, marginTop: 4 }}>
+              Invite someone to join this group by their email address.
+            </p>
           </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: "rgba(255,255,255,0.07)",
+              border: "1px solid rgba(255,255,255,0.10)",
+              color: "rgba(255,255,255,0.60)",
+              width: 34,
+              height: 34,
+              borderRadius: "50%",
+              cursor: "pointer",
+              fontSize: 18,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+          >
+            ×
+          </button>
         </div>
+
+        {/* Email field */}
+        <div className="mb-5">
+          <label
+            style={{
+              color: "rgba(204,204,204,0.9)",
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              marginBottom: 8,
+              display: "block",
+            }}
+          >
+            Member Email
+          </label>
+          <input
+            type="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="friend@email.com"
+            disabled={isDisabled}
+            style={{
+              width: "100%",
+              background: "rgba(255,255,255,0.05)",
+              border: "1.5px solid rgba(255,255,255,0.09)",
+              borderRadius: 14,
+              padding: "12px 16px",
+              color: "#fff",
+              fontSize: 14,
+              outline: "none",
+              boxSizing: "border-box",
+              fontFamily: "inherit",
+              fontWeight: 500,
+            }}
+          />
+        </div>
+
+        {/* Submit button */}
+        <button
+          onClick={handleAddMember}
+          disabled={!canSubmit}
+          style={{
+            width: "100%",
+            padding: "13px",
+            background: canSubmit ? A : "rgba(255,255,255,0.05)",
+            color: canSubmit ? "#0a0a0a" : "#555",
+            border: "none",
+            borderRadius: 14,
+            fontSize: 14,
+            fontWeight: 800,
+            cursor: canSubmit ? "pointer" : "default",
+            fontFamily: "inherit",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+            transition: "all 0.2s",
+          }}
+        >
+          {isDisabled ? (
+            <>
+              <Loader2 style={{ width: 16, height: 16, animation: "spin 0.8s linear infinite" }} />
+              Adding…
+            </>
+          ) : (
+            "Add Member"
+          )}
+        </button>
       </div>
     </div>
   );

--- a/components/add-wallet-modal.tsx
+++ b/components/add-wallet-modal.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import { X, ChevronDown, Check, Loader2 } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { fadeIn, scaleIn } from "@/utils/animations";
 import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
-// import {
-//   getAvailableChains,
-//   addMultichainAccount,
-// } from "@/services/walletService";
 import {
   StellarWalletsKit,
   WalletNetwork,
@@ -21,20 +17,8 @@ import {
   useUserWallets,
   useSetWalletAsPrimary,
 } from "@/features/wallets/hooks/use-wallets";
-// import {
-//   Wallet as WalletType,
-//   ChainResponse as ChainResponseType,
-// } from "@/features/wallets/api/client";
-import { AptosWalletAdapterProvider, useWallet } from "@aptos-labs/wallet-adapter-react";
-import { WalletSelector as ShadcnWalletSelector } from "@/components/WalletSelector";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-// Define wallet interface
-interface Wallet {
-  id: string;
-  address: string;
-  chain: string;
-  isPrimary: boolean;
-}
 
 interface Chain {
   id: string;
@@ -42,35 +26,38 @@ interface Chain {
   enabled: boolean;
 }
 
-interface ChainResponse {
-  chains: Chain[];
-}
-
 interface AddWalletModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-// Fallback chains in case API fails
+// Fallback chains in case API fails (matching design artifact)
 const FALLBACK_CHAINS = [
-  { id: "ethereum", name: "Ethereum", enabled: true },
-  { id: "stellar", name: "Stellar", enabled: true },
   { id: "aptos", name: "Aptos", enabled: true },
+  { id: "ethereum", name: "Ethereum", enabled: true },
+  { id: "base", name: "Base", enabled: true },
   { id: "solana", name: "Solana", enabled: true },
+  { id: "stellar", name: "Stellar", enabled: true },
   { id: "polygon", name: "Polygon", enabled: true },
-  { id: "binance", name: "Binance", enabled: true },
 ];
 
-// API URL for access to backend
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+// Chain metadata for styling (matching design artifact)
+const getChainMeta = (chainId: string) => {
+  const metaMap: Record<string, { color: string; icon: string }> = {
+    aptos: { color: "#22D3EE", icon: "⬡" },
+    ethereum: { color: "#818CF8", icon: "◆" },
+    base: { color: "#3B82F6", icon: "🔵" },
+    solana: { color: "#A78BFA", icon: "◎" },
+    stellar: { color: "#34D399", icon: "✦" },
+    polygon: { color: "#A855F7", icon: "⬟" },
+  };
+  return metaMap[chainId] || { color: "#666", icon: "◆" };
+};
 
 export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
   const [walletAddress, setWalletAddress] = useState<string>("");
   const [selectedChain, setSelectedChain] = useState<Chain | null>(null);
-  const [step, setStep] = useState<"address" | "connecting">("address");
-  const [primaryWalletExists, setPrimaryWalletExists] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [tab, setTab] = useState<"manual" | "connect">("manual");
   const [isConnectingWallet, setIsConnectingWallet] = useState(false);
   const walletKitRef = useRef<StellarWalletsKit | null>(null);
   const [aptosAddress, setAptosAddress] = useState<string>("");
@@ -84,7 +71,7 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
   // Add wallet mutation
   const { mutate: addWalletMutation, isPending: isAddingWallet } =
     useAddWallet();
-  const { mutate: setPrimaryWallet, isPending: isSettingPrimary } =
+  const { mutate: _setPrimaryWallet, isPending: isSettingPrimary } =
     useSetWalletAsPrimary();
 
   // Process chains data
@@ -163,7 +150,7 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
       if (!/^0x[a-fA-F0-9]{64}$/.test(parsed.toString())) {
         throw new Error("Not 64 hex chars");
       }
-    } catch (err) {
+    } catch {
       toast.error("Invalid Aptos address. Must be a valid 0x-prefixed 64-character hex string.");
       return;
     }
@@ -178,7 +165,7 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
       {
         chainId,
         address: walletAddress,
-        isPrimary: false,
+        isPrimary: userWallets.length === 0,
       },
       {
         onSuccess: () => {
@@ -195,7 +182,6 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
   // Function to handle chain selection
   const handleChainSelect = (chain: Chain) => {
     setSelectedChain(chain);
-    setIsDropdownOpen(false);
   };
 
   // Get placeholder with the selected chain name
@@ -204,9 +190,6 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
       chains.find((c) => c.id === selectedChain?.id)?.name || "blockchain";
     return `Enter ${chainName} wallet address`;
   };
-
-  // Find the currently selected chain
-  const selectedChainObject = chains.find((c) => c.id === selectedChain?.id);
 
   // Handle connect wallet with Stellar Wallets Kit
   const handleConnectWallet = async () => {
@@ -260,7 +243,7 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
                 {
                   chainId: "stellar", // Use 'stellar' for Stellar chain ID
                   address: publicKey,
-                  isPrimary: false,
+                  isPrimary: userWallets.length === 0,
                 },
                 {
                   onSuccess: () => {
@@ -317,7 +300,7 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
         {
           chainId: "aptos",
           address: address,
-          isPrimary: false,
+          isPrimary: userWallets.length === 0,
         },
         {
           onSuccess: () => {
@@ -333,54 +316,9 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
     }
 
     
-    
-
   }
 
-  // Handler for Aptos wallet connect using Wallet Adapter SDK
-  // const handleAptosWalletConnect = async () => {
-  //   console.log("Aptos handleAptosWalletConnect called 111111111111111111111111");
-  //   try {
-  //     console.log("Aptos handleAptosWalletConnect called 222222222222222222222222");
-  //     if (isConnectingWallet) return;
-  //     setIsConnectingWallet(true);
-  //     if (!connect) return;
-  //     if (!wallets || wallets.length === 0) {
-  //       toast.error("No Aptos wallets available to connect.");
-  //       return;
-  //     }
-  //     const walletName = wallets[0].name;
-  //     if (!walletName) {
-  //       toast.error("Could not determine Aptos wallet name.");
-  //       return;
-  //     }
-  //     await connect(walletName);
-  //     if (!account?.address) {
-  //       toast.error("No Aptos wallet connected.");
-  //       return;
-  //     }
-  //     setAptosAddress(account.address.toString());
-  //     addWalletMutation(
-  //       {
-  //         chainId: "aptos",
-  //         address: account.address.toString(),
-  //         isPrimary: true,
-  //       },
-  //       {
-  //         onSuccess: () => {
-  //           toast.success("Aptos wallet connected successfully!");
-  //           setAptosAddress("");
-  //           onClose();
-  //         },
-  //       }
-  //     );
-  //   } catch (error) {
-  //     console.error("Aptos Wallet Connect Error:", error);
-  //     toast.error("Failed to connect Aptos wallet.");
-  //   }
-  // };
-
-  const { account, connected, connect, wallets } = useWallet();
+  const { account, connected, wallets, connect } = useWallet();
 
   useEffect(() => {
     console.log("Aptos useEffect triggered", { connected, account });
@@ -407,34 +345,94 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
           />
-          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[500px]">
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-[460px]">
             <motion.div
-              className="relative z-10 rounded-3xl overflow-hidden"
+              className="relative z-10"
+              style={{
+                background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
+                border: "1px solid rgba(255,255,255,0.09)",
+                borderRadius: 28,
+                padding: 28,
+                boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
+              }}
               {...scaleIn}
             >
-              <div className="flex flex-col bg-black rounded-3xl p-6 border border-white/80">
-                {/* Modal Header */}
-                <div className="w-full mb-4">
-                  <div className="flex items-center justify-between">
-                    <h2 className="text-2xl font-semibold text-white">
-                      Wallet
-                    </h2>
-                    <button
-                      onClick={onClose}
-                      className="rounded-full p-1.5 hover:bg-white/10 transition-colors"
-                    >
-                      <X className="h-5 w-5 text-white/70" />
-                    </button>
-                  </div>
-                </div>
+              {/* Modal Header */}
+              <div className="flex items-center justify-between mb-6">
+                <p style={{ fontSize: 20, fontWeight: 800, color: "#fff", letterSpacing: "-0.02em" }}>
+                  Wallet
+                </p>
+                <button
+                  onClick={onClose}
+                  style={{
+                    background: "rgba(255,255,255,0.07)",
+                    border: "1px solid rgba(255,255,255,0.1)",
+                    color: "#bbb",
+                    width: 34,
+                    height: 34,
+                    borderRadius: "50%",
+                    cursor: "pointer",
+                    fontSize: 18,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  ×
+                </button>
+              </div>
 
-                {/* Modal Content */}
-                <div className="space-y-6 mb-8">
-                  {/* Wallet Address Input */}
-                  <div className="space-y-2">
+              {/* Tab Switcher */}
+              <div
+                className="flex gap-1 mb-6"
+                style={{
+                  background: "rgba(255,255,255,0.04)",
+                  borderRadius: 14,
+                  padding: 4,
+                  border: "1px solid rgba(255,255,255,0.08)",
+                }}
+              >
+                {[
+                  ["manual", "Manual Address"],
+                  ["connect", "Connect Wallet"],
+                ].map(([k, l]) => (
+                  <button
+                    key={k}
+                    onClick={() => setTab(k as "manual" | "connect")}
+                    style={{
+                      flex: 1,
+                      padding: "10px",
+                      background: tab === k ? "rgba(255,255,255,0.1)" : "none",
+                      color: tab === k ? "#fff" : "#999",
+                      border: "none",
+                      borderRadius: 10,
+                      fontSize: 13,
+                      fontWeight: tab === k ? 700 : 500,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                      transition: "all 0.2s",
+                    }}
+                  >
+                    {l}
+                  </button>
+                ))}
+              </div>
+
+              {/* Manual Tab */}
+              {tab === "manual" && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+                  <div>
                     <label
                       htmlFor="wallet-address"
-                      className="block text-white text-base"
+                      style={{
+                        color: "#ccc",
+                        fontSize: 11,
+                        fontWeight: 700,
+                        letterSpacing: "0.06em",
+                        textTransform: "uppercase",
+                        marginBottom: 10,
+                        display: "block",
+                      }}
                     >
                       Wallet Address
                     </label>
@@ -443,164 +441,446 @@ export const AddWalletModal = ({ isOpen, onClose }: AddWalletModalProps) => {
                       type="text"
                       value={walletAddress}
                       onChange={(e) => setWalletAddress(e.target.value)}
-                      className="w-full bg-black border border-white/20 text-white p-3 rounded-xl focus:outline-none focus:ring-1 focus:ring-white/30"
+                      style={{
+                        width: "100%",
+                        background: "rgba(255,255,255,0.05)",
+                        border: "1.5px solid rgba(255,255,255,0.09)",
+                        borderRadius: 14,
+                        padding: "14px 16px",
+                        color: "#fff",
+                        fontSize: 14,
+                        outline: "none",
+                        fontFamily: "inherit",
+                      }}
                       placeholder={getPlaceholder()}
                       disabled={isAddingWallet || isSettingPrimary}
+                      autoFocus
                     />
-
                   </div>
 
-                  {/* Wallet Chain Dropdown */}
-                  <div className="space-y-2">
-                    <label className="block text-white text-base">
-                      Wallet Chain
+                  <div>
+                    <label
+                      style={{
+                        color: "#ccc",
+                        fontSize: 11,
+                        fontWeight: 700,
+                        letterSpacing: "0.06em",
+                        textTransform: "uppercase",
+                        marginBottom: 10,
+                        display: "block",
+                      }}
+                    >
+                      Blockchain
                     </label>
 
                     {chainsLoading ? (
                       <div className="flex items-center p-3 text-white/70">
                         <Loader2 className="h-5 w-5 animate-spin mr-2" />
-                        <span>Loading blockchains...</span>
+                        <span>Loading...</span>
                       </div>
                     ) : (
                       <div className="relative">
-                        <button
+                        <select
                           id="wallet-chain-dropdown"
-                          type="button"
-                          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                          className="w-full bg-black border border-[#2e2e31] text-white p-3 rounded-lg focus:outline-none focus:ring-1 focus:ring-white/30 flex items-center justify-between"
+                          value={selectedChain?.id || ""}
+                          onChange={(e) =>
+                            handleChainSelect(
+                              chains.find((c) => c.id === e.target.value)!
+                            )
+                          }
                           disabled={isAddingWallet || isSettingPrimary}
+                          style={{
+                            width: "100%",
+                            background: "rgba(255,255,255,0.05)",
+                            border: "1.5px solid rgba(255,255,255,0.09)",
+                            borderRadius: 14,
+                            padding: "14px 44px 14px 16px",
+                            color: "#fff",
+                            fontSize: 14,
+                            outline: "none",
+                            fontFamily: "inherit",
+                            cursor: "pointer",
+                            appearance: "none",
+                          }}
                         >
-                          <span>
-                            {selectedChain?.name || "Select blockchain"}
-                          </span>
-                          <ChevronDown
-                            className={`h-5 w-5 text-white/70 transition-transform duration-200 ${
-                              isDropdownOpen ? "rotate-180" : ""
-                            }`}
-                          />
-                        </button>
-
-
-                        {/* Dropdown */}
-                        <AnimatePresence>
-                          {isDropdownOpen && (
-                            <motion.div
-                              initial={{ opacity: 0, y: -10 }}
-                              animate={{ opacity: 1, y: 0 }}
-                              exit={{ opacity: 0, y: -10 }}
-                              transition={{ duration: 0.15 }}
-                              className="absolute left-0 right-0 mt-1 bg-black border border-[#2e2e31] rounded-lg overflow-hidden z-10 max-h-[250px] overflow-y-auto"
+                          {chains.map((chain) => (
+                            <option
+                              key={chain.id}
+                              value={chain.id}
+                              style={{ background: "#1a1a1a" }}
                             >
-                              {chains.map((chain) => (
-                                <button
-                                  key={chain.id}
-                                  type="button"
-                                  onClick={() => handleChainSelect(chain)}
-                                  className="w-full text-left px-4 py-3 text-white hover:bg-white/5 transition-colors flex items-center"
-                                >
-                                  <div className="w-5 h-5 flex items-center justify-center border border-white/30 rounded mr-3">
-                                    {selectedChain?.id === chain.id && (
-                                      <Check className="h-3.5 w-3.5 text-white" />
-                                    )}
-                                  </div>
-                                  {chain.name}
-                                </button>
-                              ))}
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
+                              {chain.name}
+                            </option>
+                          ))}
+                        </select>
+                        <div
+                          style={{
+                            position: "absolute",
+                            right: 14,
+                            top: "50%",
+                            transform: "translateY(-50%)",
+                            color: "#999",
+                            pointerEvents: "none",
+                          }}
+                        >
+                          <ChevronDown className="h-4 w-4" />
+                        </div>
                       </div>
                     )}
                   </div>
+
+                  <button
+                    id="wallet-submit-button"
+                    onClick={handleSubmit}
+                    disabled={isAddingWallet || isSettingPrimary || chainsLoading || !walletAddress}
+                    style={{
+                      width: "100%",
+                      padding: "15px",
+                      background: walletAddress && !isAddingWallet && !isSettingPrimary ? "#22D3EE" : "rgba(255,255,255,0.05)",
+                      color: walletAddress && !isAddingWallet && !isSettingPrimary ? "#0a0a0a" : "#555",
+                      border: "none",
+                      borderRadius: 14,
+                      fontSize: 15,
+                      fontWeight: 800,
+                      cursor: walletAddress && !isAddingWallet && !isSettingPrimary ? "pointer" : "default",
+                      fontFamily: "inherit",
+                      transition: "all 0.2s",
+                      marginTop: 4,
+                    }}
+                  >
+                    {isAddingWallet || isSettingPrimary ? "Adding..." : "Add Wallet"}
+                  </button>
                 </div>
+              )}
 
-                {/* Add Wallet Button */}
-                <motion.button
-                  id="wallet-submit-button"
-                  onClick={handleSubmit}
-                  disabled={isAddingWallet || isSettingPrimary || chainsLoading}
-                  whileHover={{
-                    scale: isAddingWallet || isSettingPrimary ? 1 : 1.02,
-                  }}
-                  whileTap={{
-                    scale: isAddingWallet || isSettingPrimary ? 1 : 0.98,
-                  }}
-                  className="w-full h-[58px] flex items-center justify-center
-                  bg-white rounded-full
-                  text-lg font-semibold text-black
-                  transition-all duration-200 hover:bg-white/90 disabled:opacity-70 disabled:cursor-not-allowed"
-                >
-
-                  {isAddingWallet || isSettingPrimary ? (
-                    <div className="flex items-center gap-2">
-                      <div className="h-5 w-5 border-2 border-black/20 border-t-black rounded-full animate-spin"></div>
-                      <span>Adding...</span>
-                    </div>
-                  ) : (
-                    "Add Wallet"
-                  )}
-                </motion.button>
-
-                {/* Connect Wallet Link */}
-                <div className="mt-4 text-center">
-                  <div className="flex items-center gap-2 my-2">
-                    <div className="h-px bg-white/20 flex-grow"></div>
-                    <span className="text-white/50 text-sm">OR</span>
-                    <div className="h-px bg-white/20 flex-grow"></div>
-                  </div>
-                  {selectedChain?.id === "stellar" && (
-                    <button
-                      type="button"
-                      className={`text-white transition-colors text-base flex items-center justify-center gap-2 w-full bg-transparent border py-3 rounded-full mt-2 ${
-                        selectedChain?.id === "stellar"
-                          ? "border-white/40 hover:bg-white/10"
-                          : "border-white/10 cursor-not-allowed opacity-50"
-                      }`}
-                      onClick={handleConnectWallet}
-                      disabled={isConnectingWallet}
-                    >
-                      {isConnectingWallet ? (
-                        <>
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          <span>Connecting...</span>
-                        </>
-                      ) : (
-                        <span>Connect Stellar Wallet</span>
-                      )}
-                    </button>
-                  )}
-                  {selectedChain?.id === "aptos" && (
-                    <div className="w-full flex flex-col items-center mt-2">
-                      <ShadcnWalletSelector />
-                      {connected && account?.address && (
-                        <>
-                          <div className="text-xs text-white/60 mt-1">
-                            Connected Aptos address: {aptosAddress || (account.address.toString ? account.address.toString() : String(account.address))}
-                          </div>
-                          <button
-                            className="text-white transition-colors text-base flex items-center justify-center gap-2 w-full bg-transparent border py-3 rounded-full mt-2 border-white/40 hover:bg-white/10"
-                            onClick={()=>{//handleAptosWalletConnect() //added mutate functin as this one was giving error of connected address saying already connected might be right can change on further debugging
-                              console.log("Aptos handleAptosWalletConnectMutate called");
-                              handleAptosWalletConnectMutate(aptosAddress || (account.address.toString ? account.address.toString() : String(account.address)))
-
+              {/* Connect Tab */}
+              {tab === "connect" && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                  <p
+                    style={{
+                      color: "#999",
+                      fontSize: 13,
+                      marginBottom: 6,
+                      fontWeight: 500,
+                      lineHeight: 1.5,
+                    }}
+                  >
+                    Choose a chain and connect your wallet extension.
+                  </p>
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "repeat(3, 1fr)",
+                      gap: 8,
+                      marginBottom: 8,
+                    }}
+                  >
+                    {chains.map((chain) => {
+                      const meta = getChainMeta(chain.id);
+                      const isSelected = selectedChain?.id === chain.id;
+                      return (
+                        <button
+                          key={chain.id}
+                          onClick={() => handleChainSelect(chain)}
+                          style={{
+                            padding: "12px 6px",
+                            background: isSelected
+                              ? `${meta.color}18`
+                              : "rgba(255,255,255,0.04)",
+                            border: `1.5px solid ${
+                              isSelected
+                                ? `${meta.color}55`
+                                : "rgba(255,255,255,0.08)"
+                            }`,
+                            borderRadius: 16,
+                            cursor: "pointer",
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            gap: 6,
+                            transition: "all 0.2s",
+                            fontFamily: "inherit",
+                            boxShadow: isSelected
+                              ? `0 0 16px ${meta.color}22`
+                              : "none",
+                          }}
+                        >
+                          <span
+                            style={{
+                              fontSize: 20,
+                              color: "#fff",
                             }}
                           >
-                            {userWallets.some(w => w.chainId === "aptos" && w.address === (account.address.toString ? account.address.toString() : String(account.address))) ? 'Update Wallet' : 'Save Wallet'}
+                            {meta.icon}
+                          </span>
+                          <span
+                            style={{
+                              fontSize: 11,
+                              fontWeight: 700,
+                              color: isSelected ? meta.color : "#999",
+                            }}
+                          >
+                            {chain.name}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {/* Connect Button for Stellar */}
+                  {selectedChain?.id === "stellar" && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={handleConnectWallet}
+                        disabled={isConnectingWallet}
+                        style={{
+                          width: "100%",
+                          padding: "15px",
+                          background: "#22D3EE",
+                          color: "#0a0a0a",
+                          border: "none",
+                          borderRadius: 14,
+                          fontSize: 15,
+                          fontWeight: 800,
+                          cursor: isConnectingWallet ? "default" : "pointer",
+                          fontFamily: "inherit",
+                          marginTop: 4,
+                        }}
+                      >
+                        {isConnectingWallet ? (
+                          <div
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              gap: 8,
+                            }}
+                          >
+                            <Loader2 className="h-5 w-5 animate-spin" />
+                            <span>Connecting...</span>
+                          </div>
+                        ) : (
+                          `Connect ${selectedChain.name} Wallet`
+                        )}
+                      </button>
+                      <p
+                        style={{
+                          color: "#999",
+                          fontSize: 11,
+                          textAlign: "center",
+                          marginTop: 2,
+                          fontWeight: 600,
+                        }}
+                      >
+                        Connect with Petra, Martian, and other {selectedChain.name} wallets
+                      </p>
+                    </>
+                  )}
+
+                  {/* Connect Button for Aptos */}
+                  {selectedChain?.id === "aptos" && (
+                    <>
+                      {connected && account?.address ? (
+                        <>
+                          <div
+                            style={{
+                              padding: "12px 14px",
+                              background: "rgba(34,211,238,0.08)",
+                              border: "1px solid rgba(34,211,238,0.2)",
+                              borderRadius: 12,
+                            }}
+                          >
+                            <p
+                              style={{
+                                fontSize: 11,
+                                color: "#999",
+                                marginBottom: 4,
+                                fontWeight: 600,
+                              }}
+                            >
+                              Connected Address
+                            </p>
+                            <p
+                              style={{
+                                fontSize: 12,
+                                color: "#22D3EE",
+                                fontFamily: "monospace",
+                                wordBreak: "break-all",
+                              }}
+                            >
+                              {aptosAddress ||
+                                (account.address.toString
+                                  ? account.address.toString()
+                                  : String(account.address))}
+                            </p>
+                          </div>
+                          <button
+                            onClick={() => {
+                              handleAptosWalletConnectMutate(
+                                aptosAddress ||
+                                  (account.address.toString
+                                    ? account.address.toString()
+                                    : String(account.address))
+                              );
+                            }}
+                            style={{
+                              width: "100%",
+                              padding: "15px",
+                              background: "#22D3EE",
+                              color: "#0a0a0a",
+                              border: "none",
+                              borderRadius: 14,
+                              fontSize: 15,
+                              fontWeight: 800,
+                              cursor: "pointer",
+                              fontFamily: "inherit",
+                              transition: "all 0.2s",
+                              marginTop: 4,
+                            }}
+                          >
+                            {userWallets.some(
+                              (w) =>
+                                w.chainId === "aptos" &&
+                                w.address ===
+                                  (account.address.toString
+                                    ? account.address.toString()
+                                    : String(account.address))
+                            )
+                              ? "Update Wallet"
+                              : "Save Wallet"}
                           </button>
                         </>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (wallets && wallets.length > 0) {
+                              try {
+                                connect(wallets[0].name);
+                              } catch (error) {
+                                console.error("Failed to connect wallet:", error);
+                                toast.error("Failed to connect wallet");
+                              }
+                            } else {
+                              toast.error("No Aptos wallets found. Please install Petra or Martian wallet.");
+                            }
+                          }}
+                          style={{
+                            width: "100%",
+                            padding: "15px",
+                            background: "#22D3EE",
+                            color: "#0a0a0a",
+                            border: "none",
+                            borderRadius: 14,
+                            fontSize: 15,
+                            fontWeight: 800,
+                            cursor: "pointer",
+                            fontFamily: "inherit",
+                            marginTop: 4,
+                          }}
+                        >
+                          Connect {selectedChain.name} Wallet
+                        </button>
                       )}
-                      <p className="text-white/70 text-xs mt-2">
-                        Connect with Petra, Martian, and other Aptos wallets
+                      <p
+                        style={{
+                          color: "#999",
+                          fontSize: 11,
+                          textAlign: "center",
+                          marginTop: 2,
+                          fontWeight: 600,
+                        }}
+                      >
+                        Connect with Petra, Martian, and other {selectedChain.name} wallets
                       </p>
-                    </div>
+                    </>
                   )}
+
+                  {/* Other chains */}
                   {selectedChain?.id !== "stellar" && selectedChain?.id !== "aptos" && (
-                    <p className="text-white/50 text-xs mt-2">
-                      Web wallet connection only works with Stellar or Aptos blockchain
-                    </p>
+                    <>
+                      <button
+                        type="button"
+                        disabled
+                        style={{
+                          width: "100%",
+                          padding: "15px",
+                          background: "rgba(255,255,255,0.05)",
+                          color: "#555",
+                          border: "none",
+                          borderRadius: 14,
+                          fontSize: 15,
+                          fontWeight: 800,
+                          cursor: "default",
+                          fontFamily: "inherit",
+                          marginTop: 4,
+                        }}
+                      >
+                        Connect {selectedChain?.name} Wallet
+                      </button>
+                      <p
+                        style={{
+                          color: "#999",
+                          fontSize: 11,
+                          textAlign: "center",
+                          marginTop: 2,
+                          fontWeight: 600,
+                        }}
+                      >
+                        Connect with Petra, Martian, and other {selectedChain?.name} wallets
+                      </p>
+                    </>
                   )}
+
+                  {/* Divider */}
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      margin: "4px 0",
+                    }}
+                  >
+                    <div
+                      style={{
+                        flex: 1,
+                        height: 1,
+                        background: "rgba(255,255,255,0.07)",
+                      }}
+                    />
+                    <span style={{ color: "#999", fontSize: 11, fontWeight: 600 }}>
+                      OR
+                    </span>
+                    <div
+                      style={{
+                        flex: 1,
+                        height: 1,
+                        background: "rgba(255,255,255,0.07)",
+                      }}
+                    />
+                  </div>
+
+                  {/* Manual Entry Button */}
+                  <button
+                    onClick={() => setTab("manual")}
+                    style={{
+                      width: "100%",
+                      padding: "13px",
+                      background: "rgba(255,255,255,0.05)",
+                      color: "#e8e8e8",
+                      border: "1.5px solid rgba(255,255,255,0.09)",
+                      borderRadius: 14,
+                      fontSize: 14,
+                      fontWeight: 700,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    Enter address manually
+                  </button>
                 </div>
-              </div>
+              )}
             </motion.div>
           </div>
         </motion.div>

--- a/components/currency-dropdown.tsx
+++ b/components/currency-dropdown.tsx
@@ -2,14 +2,14 @@
 
 import { useState, useRef, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { Loader2, X } from "lucide-react";
+import { Loader2, X, Map } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useOrganizedCurrencies } from "@/features/currencies/hooks/use-currencies";
 import type { Currency } from "@/features/currencies/api/client";
 import { A, T } from "@/lib/splito-design";
 import { Icons } from "@/lib/splito-design";
 
-// Flag emoji for common fiat currencies (id/code -> emoji)
+// Flag emoji for fiat currencies: explicit map for codes that don't match country (e.g. EUR, CHF)
 const FIAT_FLAGS: Record<string, string> = {
   USD: "🇺🇸",
   EUR: "🇪🇺",
@@ -25,11 +25,53 @@ const FIAT_FLAGS: Record<string, string> = {
   KRW: "🇰🇷",
   MXN: "🇲🇽",
   BRL: "🇧🇷",
+  VND: "🇻🇳",
+  HKD: "🇭🇰",
+  NZD: "🇳🇿",
+  ZAR: "🇿🇦",
+  PHP: "🇵🇭",
+  IDR: "🇮🇩",
+  MYR: "🇲🇾",
+  AED: "🇦🇪",
+  SAR: "🇸🇦",
+  EGP: "🇪🇬",
+  NGN: "🇳🇬",
+  PKR: "🇵🇰",
+  BDT: "🇧🇩",
+  TRY: "🇹🇷",
+  RUB: "🇷🇺",
+  PLN: "🇵🇱",
+  CZK: "🇨🇿",
+  HUF: "🇭🇺",
+  RON: "🇷🇴",
+  SEK: "🇸🇪",
+  NOK: "🇳🇴",
+  DKK: "🇩🇰",
+  ILS: "🇮🇱",
+  CLP: "🇨🇱",
+  COP: "🇨🇴",
+  PEN: "🇵🇪",
+  ARS: "🇦🇷",
+  UAH: "🇺🇦",
 };
+
+/** Convert ISO 3166-1 alpha-2 country code to flag emoji (e.g. VN -> 🇻🇳) */
+function countryCodeToFlag(cc: string): string {
+  if (!cc || cc.length !== 2) return "";
+  const a = cc.toUpperCase().charCodeAt(0) - 65;
+  const b = cc.toUpperCase().charCodeAt(1) - 65;
+  if (a < 0 || a > 25 || b < 0 || b > 25) return "";
+  return String.fromCodePoint(0x1f1e6 + a, 0x1f1e6 + b);
+}
 
 const getCurrencyFlag = (c: Currency): string => {
   if (c.type !== "FIAT") return "";
-  return FIAT_FLAGS[c.id] || FIAT_FLAGS[c.symbol] || "💱";
+  const byId = FIAT_FLAGS[c.id] || FIAT_FLAGS[c.symbol];
+  if (byId) return byId;
+  // ISO 4217: many currency codes use first 2 letters as country code (e.g. VND -> VN)
+  const id = (c.id || c.symbol || "").toUpperCase();
+  if (id.length >= 2) return countryCodeToFlag(id.slice(0, 2)) || "💱";
+  return "💱";
 };
 
 // Chain ID → display name and icon for section headers (Fiat, Aptos, Solana, Stellar, Base, etc.)
@@ -111,25 +153,33 @@ export default function CurrencyDropdown({
   } | null>(null);
 
   useLayoutEffect(() => {
-    if (activeDropdown !== "currency" || !triggerRef.current) {
+    if (activeDropdown !== "currency") {
       setDropdownRect(null);
       setSearchQuery("");
       setCurrencyTab("fiat");
       return;
     }
-    const el = triggerRef.current;
-    const rect = el.getBoundingClientRect();
-    const padding = 8;
-    const spaceBelow = window.innerHeight - rect.bottom - padding;
-    const spaceAbove = rect.top - padding;
-    const maxH = 320;
-    const maxHeight = Math.min(maxH, spaceBelow > spaceAbove ? spaceBelow : spaceAbove, window.innerHeight - padding * 2);
-    setDropdownRect({
-      top: spaceBelow >= maxH ? rect.bottom + 4 : rect.top - maxHeight - 4,
-      left: rect.left,
-      width: rect.width,
-      maxHeight: Math.max(120, maxHeight),
-    });
+
+    const updateRect = () => {
+      if (!triggerRef.current) return;
+      const el = triggerRef.current;
+      const rect = el.getBoundingClientRect();
+      const maxHeight = 320;
+      setDropdownRect({
+        top: rect.bottom + 4,
+        left: rect.left,
+        width: rect.width,
+        maxHeight: maxHeight,
+      });
+    };
+
+    updateRect();
+    window.addEventListener("scroll", updateRect, true);
+    window.addEventListener("resize", updateRect);
+    return () => {
+      window.removeEventListener("scroll", updateRect, true);
+      window.removeEventListener("resize", updateRect);
+    };
   }, [activeDropdown]);
 
   // Close on click outside
@@ -241,7 +291,7 @@ export default function CurrencyDropdown({
         if (!isSelected) e.currentTarget.style.background = "transparent";
       }}
     >
-      <span style={{ fontSize: 17 }}>
+      <span style={{ fontSize: 17, color: "#fff" }}>
         {isFiat ? getCurrencyFlag(currency) : "◆"}
       </span>
       <span
@@ -460,7 +510,7 @@ export default function CurrencyDropdown({
                           gap: 6,
                         }}
                       >
-                        <span style={{ color: chainColor }}>{chainIcon}</span>
+                        <span style={{ color: "#fff" }}>{chainIcon}</span>
                         {chainName}
                       </div>
                       {tokens.map((currency) =>
@@ -518,7 +568,7 @@ export default function CurrencyDropdown({
                         gap: 6,
                       }}
                     >
-                      <span style={{ color: chainColor }}>{chainIcon}</span>
+                      <span style={{ color: "#fff" }}>{chainIcon}</span>
                       {chainName}
                     </div>
                     {tokens.map((currency) =>
@@ -568,25 +618,67 @@ export default function CurrencyDropdown({
         }}
       >
         {mode === "single" ? (
-          <span
+          <div
             style={{
-              color: selected ? T.bright : T.muted,
-              fontSize: 14,
-              fontWeight: 600,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              textAlign: "left",
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
               flex: 1,
               minWidth: 0,
             }}
           >
-            {isLoadingCurrencies
-              ? "Loading currencies..."
-              : selected
-                ? `${selected.type === "FIAT" ? selected.id : selected.symbol} · ${selected.name}`
-                : placeholder || defaultPlaceholder}
-          </span>
+            <span
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                fontSize:
+                  selected &&
+                  selected.type === "FIAT" &&
+                  getCurrencyFlag(selected)
+                    ? 18
+                    : undefined,
+              }}
+              aria-hidden
+            >
+              {selected &&
+              selected.type === "FIAT" &&
+              getCurrencyFlag(selected) ? (
+                getCurrencyFlag(selected)
+              ) : (
+                <Map size={18} strokeWidth={1.8} style={{ color: T.muted }} />
+              )}
+            </span>
+            <span
+              style={{
+                fontSize: 14,
+                fontWeight: 600,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                textAlign: "left",
+                flex: 1,
+                minWidth: 0,
+              }}
+            >
+              {isLoadingCurrencies ? (
+                <span style={{ color: T.muted }}>Loading currencies...</span>
+              ) : selected ? (
+                <span style={{ display: "flex", alignItems: "center" }}>
+                  <span style={{ color: T.bright }}>
+                    {selected.type === "FIAT" ? selected.id : selected.symbol}
+                  </span>
+                  <span style={{ color: T.muted, margin: "0 6px" }}>·</span>
+                  <span style={{ color: T.muted }}>{selected.name}</span>
+                </span>
+              ) : (
+                <span style={{ color: T.muted }}>
+                  {placeholder || defaultPlaceholder}
+                </span>
+              )}
+            </span>
+          </div>
         ) : (
           <div
             style={{
@@ -686,7 +778,7 @@ export default function CurrencyDropdown({
                 left: dropdownRect.left,
                 width: dropdownRect.width,
                 maxHeight: dropdownRect.maxHeight,
-                zIndex: 99999,
+                zIndex: 200,
                 background: "#141414",
                 border: "1px solid rgba(255,255,255,0.09)",
                 borderRadius: 18,

--- a/components/friends-list.tsx
+++ b/components/friends-list.tsx
@@ -6,21 +6,14 @@ import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { useRouter } from "next/navigation";
 import Cookies from "js-cookie";
 import { toast } from "sonner";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ApiError } from "@/types/api-error";
 import { UserPlus } from "lucide-react";
-import { Card, Avatar, Icons, T, fmt, G } from "@/lib/splito-design";
+import { Card, Avatar, Icons, T, fmt, G, getUserColor } from "@/lib/splito-design";
+import { SettleDebtsModal } from "@/components/settle-debts-modal";
+import { useAuthStore } from "@/stores/authStore";
+import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
 
-const AVATAR_COLORS = [
-  "#A78BFA",
-  "#34D399",
-  "#FB923C",
-  "#F472B6",
-  "#FBBF24",
-  "#22D3EE",
-  "#F87171",
-  "#818CF8",
-];
 
 function getInitials(name: string): string {
   const parts = name.trim().split(/\s+/);
@@ -40,6 +33,10 @@ function getFriendBalance(
 export function FriendsList({ search = "" }: { search?: string }) {
   const { data: friends, isLoading, error } = useGetFriends();
   const router = useRouter();
+  const { user } = useAuthStore();
+  const { data: groups = [] } = useGetAllGroups({ type: "PERSONAL" });
+  const [isSettleModalOpen, setIsSettleModalOpen] = useState(false);
+  const [selectedFriendId, setSelectedFriendId] = useState<string | null>(null);
 
   useEffect(() => {
     if (error) {
@@ -56,6 +53,30 @@ export function FriendsList({ search = "" }: { search?: string }) {
       }
     }
   }, [error, router]);
+
+  // Find the group that has a balance with this friend
+  const getGroupForFriend = (friendId: string) => {
+    const sharedGroups = groups.filter((g) =>
+      (g.groupUsers ?? []).some(
+        (gu: { userId?: string; user?: { id: string } }) =>
+          gu.userId === friendId || gu.user?.id === friendId
+      )
+    );
+    return (
+      sharedGroups.find((g) =>
+        (g.groupBalances ?? []).some(
+          (b) => b.firendId === friendId && b.amount !== 0
+        )
+      ) ?? sharedGroups[0] ?? null
+    );
+  };
+
+  const handleSettleFriendClick = (friendId: string) => {
+    setSelectedFriendId(friendId);
+    setIsSettleModalOpen(true);
+  };
+
+  const selectedGroup = selectedFriendId ? getGroupForFriend(selectedFriendId) : null;
 
   const searchLower = search.trim().toLowerCase();
   const filtered =
@@ -156,9 +177,28 @@ export function FriendsList({ search = "" }: { search?: string }) {
               friend={friend}
               index={idx}
               isLast={idx === filtered.length - 1}
+              onSettleClick={() => handleSettleFriendClick(friend.id)}
             />
           ))}
         </motion.div>
+      )}
+      {selectedGroup && (
+        <SettleDebtsModal
+          isOpen={isSettleModalOpen}
+          onClose={() => {
+            setIsSettleModalOpen(false);
+            setSelectedFriendId(null);
+          }}
+          showIndividualView={false}
+          groupId={selectedGroup.id}
+          balances={selectedGroup.groupBalances ?? []}
+          members={(selectedGroup.groupUsers ?? []).map(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (gu: any) => gu.user ?? { id: "", name: null }
+          )}
+          defaultCurrency={user?.currency || selectedGroup.defaultCurrency || "USD"}
+          defaultExpandedMemberId={selectedFriendId}
+        />
       )}
     </Card>
   );
@@ -168,6 +208,7 @@ function FriendRow({
   friend,
   index,
   isLast,
+  onSettleClick,
 }: {
   friend: {
     id: string;
@@ -177,9 +218,10 @@ function FriendRow({
   };
   index: number;
   isLast: boolean;
+  onSettleClick: () => void;
 }) {
   const balance = getFriendBalance(friend.balances);
-  const color = AVATAR_COLORS[index % AVATAR_COLORS.length];
+  const color = getUserColor(friend.name);
   const init = getInitials(friend.name);
 
   return (
@@ -214,6 +256,10 @@ function FriendRow({
       {balance < 0 && (
         <button
           type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSettleClick();
+          }}
           className="sbtn shrink-0"
           style={{
             display: "flex",

--- a/components/group-info-header.tsx
+++ b/components/group-info-header.tsx
@@ -33,7 +33,7 @@ export function GroupInfoHeader({
   const [isSettling, setIsSettling] = useState(false);
   const queryClient = useQueryClient();
   const { user } = useAuthStore();
-  const { defaultCurrency } = useGroupLayout();
+  const { defaultCurrency, openAddMember, isAdmin } = useGroupLayout();
 
   // Compute balance arrays (use empty when no group so hooks are unconditional)
   const balancesByCurrency = (() => {
@@ -95,8 +95,8 @@ export function GroupInfoHeader({
 
   const tabs = [
     { label: "Splits", href: `/groups/${groupId}/splits` },
-    { label: "Members", href: `/groups/${groupId}/members` },
     { label: "Activity", href: `/groups/${groupId}/activity` },
+    { label: "Members", href: `/groups/${groupId}/members` },
   ];
 
   const memberCount = group.groupUsers?.length ?? 0;
@@ -112,7 +112,7 @@ export function GroupInfoHeader({
 
   return (
     <div
-      className="flex flex-col sticky top-0 z-10"
+      className="flex flex-col sticky top-0 z-[40]"
       style={{
         background: "rgba(11,11,11,0.95)",
         backdropFilter: "blur(20px)",
@@ -193,8 +193,8 @@ export function GroupInfoHeader({
         style={{ borderTop: "1px solid rgba(255,255,255,0.07)" }}
       />
 
-      {/* Tabs: Splits, Members, Activity */}
-      <div className="flex items-center px-4 sm:px-7 py-4 sm:py-6">
+      {/* Tabs: Splits, Activity, Members + Add Member button */}
+      <div className="flex items-center justify-between px-4 sm:px-7 py-4 sm:py-6">
         <div
           className="flex rounded-[14px] transition-all w-full sm:w-auto"
           style={{
@@ -214,13 +214,22 @@ export function GroupInfoHeader({
                   "flex-1 sm:flex-initial rounded-[10px] text-[13px] transition-all text-center",
                   isActive ? "bg-white/10 text-white font-bold" : "text-white/60 font-medium"
                 )}
-                style={{ padding: "8px 12px" }}
+                style={{ padding: "8px 20px" }}
               >
                 {tab.label}
               </Link>
             );
           })}
         </div>
+        {pathname === `/groups/${groupId}/members` && isAdmin && (
+          <Btn
+            onClick={openAddMember}
+            variant="ghost"
+            style={{ padding: "8px 14px", fontSize: 12, flexShrink: 0 }}
+          >
+            <Icons.userPlus /> Add Member
+          </Btn>
+        )}
       </div>
     </div>
   );

--- a/components/group-info-header.tsx
+++ b/components/group-info-header.tsx
@@ -19,7 +19,7 @@ export function GroupInfoHeader({
   onSettleClick,
   group,
   onAddExpenseClick,
-  onSettingsClick,
+  onSettingsClick: _onSettingsClick,
 }: {
   groupId: string;
   onSettleClick: () => void;
@@ -29,8 +29,8 @@ export function GroupInfoHeader({
 }) {
   const router = useRouter();
   const pathname = usePathname();
-  const [isAddingExpense, setIsAddingExpense] = useState(false);
-  const [isSettling, setIsSettling] = useState(false);
+  const [isAddingExpense, _setIsAddingExpense] = useState(false);
+  const [_isSettling, setIsSettling] = useState(false);
   const queryClient = useQueryClient();
   const { user } = useAuthStore();
   const { defaultCurrency, openAddMember, isAdmin } = useGroupLayout();

--- a/components/groups-list-content.tsx
+++ b/components/groups-list-content.tsx
@@ -6,17 +6,7 @@ import { motion } from "framer-motion";
 import { Loader2, AlertTriangle, X, CheckCircle } from "lucide-react";
 import { staggerContainer, slideUp } from "@/utils/animations";
 import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
-import { Card, GroupAvatar, Icons, Tag, G, T } from "@/lib/splito-design";
-
-const AVATAR_COLORS = ["#22D3EE", "#a78bfa", "#34D399", "#fb923c"];
-
-function getInit(name: string | null | undefined, fallback: string): string {
-  if (!name || !name.trim()) return fallback;
-  const parts = name.trim().split(/\s+/);
-  if (parts.length >= 2)
-    return (parts[0].charAt(0) + parts[1].charAt(0)).toUpperCase();
-  return name.charAt(0).toUpperCase();
-}
+import { Card, GroupAvatar, Icons, Tag, G, T, getUserColor } from "@/lib/splito-design";
 
 function relativeTime(date: Date): string {
   const now = new Date();
@@ -50,26 +40,17 @@ function GroupCard({
   formatCurrency: (amount: number, currency: string) => string;
 }) {
   const balances = group.groupBalances || [];
-  const memberIds = Array.from(new Set(balances.map((b) => b.userId)));
-  // Prefer groupUsers for initials (like Dashboard); fallback to balance-derived list with "?" for others
-  const avatarItems =
-    group.groupUsers && group.groupUsers.length > 0
-      ? group.groupUsers.slice(0, 4).map((gu, i) => ({
-          init: getInit(gu.user.name, gu.user.id === user?.id ? "Y" : "?"),
-          color: AVATAR_COLORS[i % AVATAR_COLORS.length],
-        }))
-      : memberIds.slice(0, 4).map((userId, i) => ({
-          init:
-            userId === user?.id
-              ? getInit(user?.name ?? null, "Y")
-              : "?",
-          color: AVATAR_COLORS[i % AVATAR_COLORS.length],
-        }));
-  if (avatarItems.length === 0)
-    avatarItems.push({
-      init: group.name.charAt(0).toUpperCase() || "G",
-      color: AVATAR_COLORS[0],
-    });
+
+  // Use the same logic as dashboard for consistency
+  const avatarItems = (group.groupUsers ?? [])
+    .slice(0, 4)
+    .map((gu) => ({
+      init: gu.user.name?.charAt(0)?.toUpperCase() || "?",
+      color: getUserColor(gu.user.name),
+    }));
+
+  // Get member count from groupUsers
+  const memberCount = (group.groupUsers ?? []).length;
 
   const userBalances = balances.filter((b) => b.userId === user?.id);
   const byCurrency: Record<string, number> = {};
@@ -88,13 +69,12 @@ function GroupCard({
   const net = totalOwed - totalOwe;
 
   const balanceLabel = (() => {
-    if (net === 0) return { text: "±$0", color: T.muted };
+    if (net === 0) return { text: "±$0", color: T.dim };
     if (net > 0) return { text: `+$${net.toFixed(2)}`, color: G };
-    return { text: `-$${Math.abs(net).toFixed(2)}`, color: "#FF4444" };
+    return { text: `-$${Math.abs(net).toFixed(2)}`, color: "#F87171" };
   })();
   const totalMagnitude = Object.values(byCurrency).reduce((s, a) => s + Math.abs(a), 0);
   const totalLabel = totalMagnitude > 0 ? formatCurrency(totalMagnitude, defaultCurrency) : formatCurrency(0, defaultCurrency);
-  const memberCount = memberIds.length;
   const expenseCount = Array.isArray((group as { expenses?: unknown[] }).expenses)
     ? (group as { expenses: unknown[] }).expenses.length
     : 0;
@@ -107,11 +87,12 @@ function GroupCard({
     <motion.div variants={slideUp}>
       <Link
         href={groupUrl}
-        className="flex items-center w-full text-left transition-colors hover:bg-white/[0.03] gap-3 sm:gap-4 py-4 px-4 sm:py-[18px] sm:px-6"
+        className="flex items-center w-full text-left transition-colors hover:bg-white/[0.03] py-4 px-4 sm:py-[18px] sm:px-6"
+        style={{ gap: 16 }}
       >
         <GroupAvatar items={avatarItems} size={52} radius={17} />
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 mb-0.5">
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 5 }}>
             <p className="text-[15px] font-extrabold text-white truncate tracking-[-0.01em]" style={{ color: T.bright }}>
               {group.name}
             </p>
@@ -121,19 +102,19 @@ function GroupCard({
             {memberCount} members · {expenseCount} expenses · {ago}
           </p>
         </div>
-        <div className="flex items-center shrink-0" style={{ gap: 8 }}>
-          <div className="text-right">
-            <p
-              className="font-[family-name:var(--font-dm-mono)] text-[17px] font-extrabold"
-              style={{ color: balanceLabel.color }}
-            >
-              {balanceLabel.text}
-            </p>
-            <p className="text-[11px] font-semibold mt-[3px]" style={{ color: T.muted }}>
-              total {totalLabel}
-            </p>
-          </div>
-          <span className="text-white/40">{Icons.chevR({ size: 18 })}</span>
+        <div className="text-right shrink-0">
+          <p
+            className="font-[family-name:var(--font-dm-mono)] text-[17px] font-extrabold"
+            style={{ color: balanceLabel.color }}
+          >
+            {balanceLabel.text}
+          </p>
+          <p className="text-[11px] font-semibold mt-[3px]" style={{ color: T.muted }}>
+            total {totalLabel}
+          </p>
+        </div>
+        <div style={{ color: T.dim, display: "flex" }}>
+          {Icons.chevR()}
         </div>
       </Link>
     </motion.div>
@@ -180,20 +161,18 @@ export function GroupsListContent(props: GroupsListContentProps) {
 
   return (
     <div>
-      <div
-        className="grid grid-cols-3 gap-2 sm:gap-3 mb-4 sm:mb-6"
-      >
-        <Card className="p-3 sm:p-5 min-w-0">
-          <p className="uppercase mb-1 sm:mb-2 text-[10px] sm:text-[11px] font-bold tracking-wider truncate" style={{ color: T.muted }}>Groups</p>
-          <p className="font-[family-name:var(--font-dm-mono)] text-base sm:text-[22px] font-extrabold tracking-tight truncate" style={{ color: "#e8e8e8" }}>{filteredGroups.length}</p>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginBottom: 26 }}>
+        <Card style={{ padding: "18px 20px" }}>
+          <p style={{ color: T.muted, fontSize: 11, marginBottom: 8, fontWeight: 700, letterSpacing: "0.05em" }}>Groups</p>
+          <p style={{ color: "#e8e8e8", fontSize: 22, fontWeight: 800, fontFamily: "monospace", letterSpacing: "-0.02em" }}>{filteredGroups.length}</p>
         </Card>
-        <Card className="p-3 sm:p-5 min-w-0">
-          <p className="uppercase mb-1 sm:mb-2 text-[10px] sm:text-[11px] font-bold tracking-wider truncate" style={{ color: T.muted }}>Total spent</p>
-          <p className="font-[family-name:var(--font-dm-mono)] text-base sm:text-[22px] font-extrabold tracking-tight truncate" style={{ color: "#e8e8e8" }}>{totalSpentFormatted}</p>
+        <Card style={{ padding: "18px 20px" }}>
+          <p style={{ color: T.muted, fontSize: 11, marginBottom: 8, fontWeight: 700, letterSpacing: "0.05em" }}>Total spent</p>
+          <p style={{ color: "#e8e8e8", fontSize: 22, fontWeight: 800, fontFamily: "monospace", letterSpacing: "-0.02em" }}>{totalSpentFormatted}</p>
         </Card>
-        <Card className="p-3 sm:p-5 min-w-0">
-          <p className="uppercase mb-1 sm:mb-2 text-[10px] sm:text-[11px] font-bold tracking-wider truncate" style={{ color: T.muted }}>Net balance</p>
-          <p className="font-[family-name:var(--font-dm-mono)] text-base sm:text-[22px] font-extrabold tracking-tight truncate" style={{ color: netBalanceColor }}>{netBalanceFormatted}</p>
+        <Card style={{ padding: "18px 20px" }}>
+          <p style={{ color: T.muted, fontSize: 11, marginBottom: 8, fontWeight: 700, letterSpacing: "0.05em" }}>Net balance</p>
+          <p style={{ color: netBalanceColor, fontSize: 22, fontWeight: 800, fontFamily: "monospace", letterSpacing: "-0.02em" }}>{netBalanceFormatted}</p>
         </Card>
       </div>
 

--- a/components/groups-list-content.tsx
+++ b/components/groups-list-content.tsx
@@ -46,7 +46,7 @@ function GroupCard({
     .slice(0, 4)
     .map((gu) => ({
       init: gu.user.name?.charAt(0)?.toUpperCase() || "?",
-      color: getUserColor(gu.user.name),
+      color: getUserColor(gu.user.name ?? null),
     }));
 
   // Get member count from groupUsers

--- a/components/settle-debts-modal.tsx
+++ b/components/settle-debts-modal.tsx
@@ -622,7 +622,7 @@ export function SettleDebtsModal({
   };
 
   // Helper to check if wallet is connected for the selected chain
-  const isWalletConnectedForChain = () => {
+  const _isWalletConnectedForChain = () => {
     if (selectedChain === 'aptos') {
       return aptosWallet.connected && aptosWallet.account?.address;
     } else if (selectedChain === 'stellar') {

--- a/components/settle-debts-modal.tsx
+++ b/components/settle-debts-modal.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import Image from "next/image";
 import { GroupBalance, User } from "@/api-helpers/modelSchema";
 import { useSettleDebt } from "@/features/settle/hooks/use-splits";
+import { useMarkAsPaid } from "@/features/groups/hooks/use-create-group";
 import { useHandleEscapeToCloseModal } from "@/hooks/useHandleEscape";
 import { useQueryClient } from "@tanstack/react-query";
 import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
@@ -29,9 +30,10 @@ interface SettleDebtsModalProps {
   members?: User[];
   showIndividualView?: boolean;
   selectedFriendId?: string | null;
-  defaultCurrency?: string; // <-- add this
-  specificAmount?: number; // Add specific amount for individual debt settlement
-  specificDebtByCurrency?: Record<string, number>; // Add currency-specific debt info
+  defaultCurrency?: string;
+  specificAmount?: number;
+  specificDebtByCurrency?: Record<string, number>;
+  defaultExpandedMemberId?: string | null;
 }
 
 export function SettleDebtsModal({
@@ -43,8 +45,9 @@ export function SettleDebtsModal({
   showIndividualView = false,
   selectedFriendId = null,
   defaultCurrency,
-  specificAmount, // Add this parameter
-  specificDebtByCurrency, // Add currency-specific debt info
+  specificAmount,
+  specificDebtByCurrency,
+  defaultExpandedMemberId,
 }: SettleDebtsModalProps) {
   const user = useAuthStore((state) => state.user);
   const {
@@ -69,8 +72,15 @@ export function SettleDebtsModal({
   const [multiCurrencyDebts, setMultiCurrencyDebts] = useState<Array<{currency: string, amount: number, tokenAmount: number}>>([]);
   const [totalTokenAmount, setTotalTokenAmount] = useState("0"); // Total token amount for all currencies
   const [expandedRowMemberId, setExpandedRowMemberId] = useState<string | null>(null);
+  const [memberMethods, setMemberMethods] = useState<Record<string, "crypto" | "bank">>({});
+  const [memberMarkedPaid, setMemberMarkedPaid] = useState<Record<string, boolean>>({});
+  const [memberChains, setMemberChains] = useState<Record<string, string>>({});
+  const [memberBankCurrencies, setMemberBankCurrencies] = useState<Record<string, string>>({});
+  const [memberBankDropdownOpen, setMemberBankDropdownOpen] = useState<Record<string, boolean>>({});
+  const [memberBankSearch, setMemberBankSearch] = useState<Record<string, string>>({});
 
   const settleDebtMutation = useSettleDebt(groupId);
+  const markAsPaidMutation = useMarkAsPaid();
   const _queryClient = useQueryClient();
   const { data: friends } = useGetFriends();
   const { data: _groups } = useGetAllGroups();
@@ -241,6 +251,13 @@ export function SettleDebtsModal({
       setExcludedFriendIds([]);
     }
   }, [isOpen, groupId, showIndividualView, selectedFriendId, userStellarAddress]);
+
+  // Auto-expand the specified member row when modal opens
+  useEffect(() => {
+    if (isOpen && defaultExpandedMemberId) {
+      setExpandedRowMemberId(defaultExpandedMemberId);
+    }
+  }, [isOpen, defaultExpandedMemberId]);
 
   // Set the selected user based on selectedFriendId prop
   useEffect(() => {
@@ -805,6 +822,47 @@ export function SettleDebtsModal({
       .sort((a, b) => b.amount - a.amount);
   }, [balances, user?.id, _members]);
 
+  const CURRENCY_FLAG: Record<string, string> = {
+    USD: "🇺🇸", EUR: "🇪🇺", GBP: "🇬🇧", JPY: "🇯🇵", THB: "🇹🇭",
+    INR: "🇮🇳", AUD: "🇦🇺", CAD: "🇨🇦", SGD: "🇸🇬", CHF: "🇨🇭",
+    CNY: "🇨🇳", KRW: "🇰🇷", MXN: "🇲🇽", BRL: "🇧🇷", SEK: "🇸🇪",
+    NOK: "🇳🇴", DKK: "🇩🇰", NZD: "🇳🇿", ZAR: "🇿🇦", HKD: "🇭🇰",
+  };
+
+  const SETTLE_CHAIN_META: Record<string, { icon: string; color: string }> = {
+    stellar: { icon: "✦", color: "#34D399" },
+    solana:  { icon: "◎", color: "#A78BFA" },
+    aptos:   { icon: "⬡", color: "#22D3EE" },
+    base:    { icon: "🔵", color: "#3B82F6" },
+  };
+
+  const availableChains = organizedCurrencies?.chainGroups
+    ? Object.keys(organizedCurrencies.chainGroups)
+    : ["stellar", "solana", "aptos", "base"];
+
+  const handleMarkAsPaid = (memberId: string, amount: number) => {
+    if (!user || !groupId) return;
+    markAsPaidMutation.mutate(
+      {
+        groupId,
+        payload: {
+          payerId: memberId,
+          payeeId: user.id,
+          amount,
+          currency: defaultCurrency || "USD",
+          currencyType: "FIAT",
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success("Marked as paid");
+          setMemberMarkedPaid((p) => ({ ...p, [memberId]: true }));
+        },
+        onError: () => toast.error("Failed to mark as paid"),
+      }
+    );
+  };
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -872,7 +930,7 @@ export function SettleDebtsModal({
                   </div>
 
                   {/* Debtor list — expandable card-like rows */}
-                  <div className="space-y-2.5 max-h-[320px] overflow-y-auto pr-0.5">
+                  <div className="space-y-2.5">
                     {memberDebtRows.length > 0 ? (
                       memberDebtRows.map((row) => {
                         const isExpanded = expandedRowMemberId === row.memberId;
@@ -921,25 +979,238 @@ export function SettleDebtsModal({
                             </button>
                             {isExpanded && (
                               <div
-                                className="border-t border-white/[0.06] bg-black/20 px-4 py-4"
+                                className="border-t border-white/[0.06] bg-black/20 px-4 py-4 space-y-3"
                                 onClick={(e) => e.stopPropagation()}
                               >
+                                {/* Method tabs */}
                                 <div className="grid grid-cols-2 gap-2">
-                                  <button
-                                    type="button"
-                                    className="flex items-center justify-center gap-2 py-3 px-3 rounded-[14px] border border-[#22D3EE]/50 bg-[#22D3EE]/10 text-[#22D3EE] text-xs font-bold transition-colors hover:bg-[#22D3EE]/15"
-                                  >
-                                    <Link2 className="h-3.5 w-3.5 flex-shrink-0" />
-                                    Crypto on-chain
-                                  </button>
-                                  <button
-                                    type="button"
-                                    className="flex items-center justify-center gap-2 py-3 px-3 rounded-[14px] border border-white/10 bg-white/[0.04] text-white/80 text-xs font-bold transition-colors hover:bg-white/[0.06]"
-                                  >
-                                    <Landmark className="h-3.5 w-3.5 flex-shrink-0" />
-                                    Bank / Mark paid
-                                  </button>
+                                  {(["crypto", "bank"] as const).map((method) => {
+                                    const active = (memberMethods[row.memberId] ?? "crypto") === method;
+                                    return (
+                                      <button
+                                        key={method}
+                                        type="button"
+                                        onClick={() => setMemberMethods((p) => ({ ...p, [row.memberId]: method }))}
+                                        className="flex items-center justify-center gap-2 py-3 px-3 rounded-[14px] border text-xs font-bold transition-colors"
+                                        style={{
+                                          background: active ? "rgba(34,211,238,0.10)" : "rgba(255,255,255,0.04)",
+                                          borderColor: active ? "rgba(34,211,238,0.50)" : "rgba(255,255,255,0.10)",
+                                          color: active ? "#22D3EE" : "rgba(255,255,255,0.80)",
+                                        }}
+                                      >
+                                        {method === "crypto" ? (
+                                          <><Link2 className="h-3.5 w-3.5 flex-shrink-0" /> Crypto on-chain</>
+                                        ) : (
+                                          <><Landmark className="h-3.5 w-3.5 flex-shrink-0" /> Bank / Mark paid</>
+                                        )}
+                                      </button>
+                                    );
+                                  })}
                                 </div>
+
+                                {/* Crypto on-chain panel */}
+                                {(memberMethods[row.memberId] ?? "crypto") === "crypto" && (
+                                  <div>
+                                    <p className="text-[10px] font-bold tracking-[0.1em] uppercase mb-2" style={{ color: "#ccc" }}>
+                                      Chain
+                                    </p>
+                                    <div className="grid grid-cols-4 gap-2 mb-3">
+                                      {availableChains.map((chain) => {
+                                        const meta = SETTLE_CHAIN_META[chain] || { icon: "◆", color: "#666" };
+                                        const isChainSel = (memberChains[row.memberId] || selectedChain) === chain;
+                                        return (
+                                          <button
+                                            key={chain}
+                                            type="button"
+                                            onClick={() => {
+                                              setMemberChains((p) => ({ ...p, [row.memberId]: chain }));
+                                              setSelectedChain(chain);
+                                            }}
+                                            className="flex flex-col items-center gap-1.5 py-3 rounded-[14px] border transition-all"
+                                            style={{
+                                              background: isChainSel ? `${meta.color}18` : "rgba(255,255,255,0.04)",
+                                              borderColor: isChainSel ? `${meta.color}55` : "rgba(255,255,255,0.08)",
+                                              boxShadow: isChainSel ? `0 0 14px ${meta.color}22` : "none",
+                                            }}
+                                          >
+                                            <span style={{ color: meta.color, fontSize: 18 }}>{meta.icon}</span>
+                                            <span className="text-[10px] font-bold" style={{ color: isChainSel ? meta.color : "rgba(255,255,255,0.55)" }}>
+                                              {chain.charAt(0).toUpperCase() + chain.slice(1)}
+                                            </span>
+                                          </button>
+                                        );
+                                      })}
+                                    </div>
+
+                                    {(memberChains[row.memberId] || selectedChain) && (() => {
+                                      const member = _members.find((m) => m.id === row.memberId);
+                                      if (!canProceedWithSettlement()) {
+                                        return (
+                                          <div>
+                                            {selectedChain === "aptos" && <ShadcnWalletSelector />}
+                                            {selectedChain === "stellar" && (
+                                              <button
+                                                type="button"
+                                                className="w-full py-3 rounded-[14px] bg-white/[0.06] border border-white/10 text-white text-sm font-semibold hover:bg-white/[0.1] transition-colors"
+                                                onClick={connectWallet}
+                                              >
+                                                Connect {selectedChain.charAt(0).toUpperCase() + selectedChain.slice(1)} Wallet
+                                              </button>
+                                            )}
+                                            {selectedChain && !getUserWalletAddress() && (
+                                              <p className="text-xs text-red-400 mt-2 text-center">
+                                                Please connect your {selectedChain} wallet or add it in settings first.
+                                              </p>
+                                            )}
+                                          </div>
+                                        );
+                                      }
+                                      return (
+                                        <button
+                                          type="button"
+                                          disabled={isPending}
+                                          className="w-full py-3 rounded-[14px] text-sm font-extrabold transition-opacity hover:opacity-90 disabled:opacity-50"
+                                          style={{ background: "#22D3EE", color: "#0a0a0a" }}
+                                          onClick={() => member && handleSettleOne(member)}
+                                        >
+                                          {isPending ? "Sending…" : "Settle Now"}
+                                        </button>
+                                      );
+                                    })()}
+
+                                    <button
+                                      type="button"
+                                      className="w-full mt-2 py-2.5 rounded-[14px] text-xs font-semibold transition-colors hover:text-white/80"
+                                      style={{ border: "1px dashed rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.55)" }}
+                                      onClick={() => setMemberMethods((p) => ({ ...p, [row.memberId]: "bank" }))}
+                                    >
+                                      Don&apos;t trust app? Mark as paid manually instead
+                                    </button>
+                                  </div>
+                                )}
+
+                                {/* Bank / Mark paid panel */}
+                                {memberMethods[row.memberId] === "bank" && (() => {
+                                  const selCurrency = memberBankCurrencies[row.memberId] || defaultCurrency || "USD";
+                                  const isOpen = !!memberBankDropdownOpen[row.memberId];
+                                  const search = memberBankSearch[row.memberId] || "";
+                                  const fiatList = organizedCurrencies?.fiatCurrencies || [];
+                                  const filtered = fiatList.filter((c: { id: string; name: string }) =>
+                                    c.id.toLowerCase().includes(search.toLowerCase()) ||
+                                    c.name.toLowerCase().includes(search.toLowerCase())
+                                  );
+                                  const selEntry = fiatList.find((c: { id: string }) => c.id === selCurrency);
+                                  return (
+                                    <div>
+                                      <p className="text-[12px] mb-3" style={{ color: "rgba(255,255,255,0.60)", lineHeight: 1.6 }}>
+                                        Ask {row.name.split(" ")[0]} to pay via their banking app, then mark as paid here.
+                                      </p>
+                                      <p className="text-[10px] font-bold tracking-[0.1em] uppercase mb-2" style={{ color: "#ccc" }}>
+                                        They&apos;ll Pay In
+                                      </p>
+
+                                      {/* Dropdown trigger */}
+                                      <button
+                                        type="button"
+                                        onClick={() => setMemberBankDropdownOpen((p) => ({ ...p, [row.memberId]: !p[row.memberId] }))}
+                                        className="w-full rounded-[14px] px-4 py-3 text-sm font-semibold mb-1 flex items-center justify-between transition-colors"
+                                        style={{
+                                          background: "rgba(255,255,255,0.05)",
+                                          border: `1px solid ${isOpen ? "rgba(255,255,255,0.18)" : "rgba(255,255,255,0.09)"}`,
+                                          color: "#fff",
+                                        }}
+                                      >
+                                        <span>
+                                          {CURRENCY_FLAG[selCurrency] || "💱"} {selCurrency}
+                                          {selEntry ? ` · ${selEntry.name}` : ""}
+                                        </span>
+                                        <span style={{ color: "rgba(255,255,255,0.45)", fontSize: 11, transition: "transform 0.2s", display: "inline-block", transform: isOpen ? "rotate(180deg)" : "none" }}>▾</span>
+                                      </button>
+
+                                      {/* Dropdown panel */}
+                                      {isOpen && (
+                                        <div
+                                          className="rounded-[18px] overflow-hidden mb-3"
+                                          style={{ border: "1px solid rgba(255,255,255,0.09)", background: "#141414", boxShadow: "0 20px 60px rgba(0,0,0,0.7)" }}
+                                        >
+                                          {/* Search */}
+                                          <div className="flex items-center gap-2 px-3 py-2.5" style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.4)" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+                                            <input
+                                              autoFocus
+                                              placeholder="Search currency…"
+                                              value={search}
+                                              onChange={(e) => setMemberBankSearch((p) => ({ ...p, [row.memberId]: e.target.value }))}
+                                              className="bg-transparent outline-none text-[13px] w-full"
+                                              style={{ color: "#fff", fontFamily: "inherit" }}
+                                            />
+                                          </div>
+                                          {/* Fiat label */}
+                                          <div className="px-4 py-1.5 text-[10px] font-bold tracking-[0.1em] uppercase" style={{ color: "rgba(255,255,255,0.35)" }}>
+                                            Fiat
+                                          </div>
+                                          {/* Currency list */}
+                                          <div style={{ maxHeight: 200, overflowY: "auto" }}>
+                                            {filtered.map((c: { id: string; name: string }, i: number) => {
+                                              const isSel = c.id === selCurrency;
+                                              return (
+                                                <div
+                                                  key={c.id}
+                                                  onClick={() => {
+                                                    setMemberBankCurrencies((p) => ({ ...p, [row.memberId]: c.id }));
+                                                    setMemberBankDropdownOpen((p) => ({ ...p, [row.memberId]: false }));
+                                                    setMemberBankSearch((p) => ({ ...p, [row.memberId]: "" }));
+                                                  }}
+                                                  className="flex items-center gap-3 px-4 cursor-pointer transition-colors"
+                                                  style={{
+                                                    padding: "10px 16px",
+                                                    borderBottom: i < filtered.length - 1 ? "1px solid rgba(255,255,255,0.04)" : "none",
+                                                    background: isSel ? "rgba(34,211,238,0.06)" : "transparent",
+                                                  }}
+                                                >
+                                                  <span style={{ fontSize: 17 }}>{CURRENCY_FLAG[c.id] || "💱"}</span>
+                                                  <span style={{ fontWeight: 700, fontSize: 13, color: isSel ? "#fff" : "rgba(255,255,255,0.85)", minWidth: 36 }}>{c.id}</span>
+                                                  <span style={{ color: "rgba(255,255,255,0.45)", fontSize: 12, flex: 1 }}>{c.name}</span>
+                                                  {isSel && <span style={{ color: "#22D3EE", fontSize: 12 }}>✓</span>}
+                                                </div>
+                                              );
+                                            })}
+                                            {filtered.length === 0 && (
+                                              <p className="text-center py-4 text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>No currencies found</p>
+                                            )}
+                                          </div>
+                                        </div>
+                                      )}
+
+                                      {memberMarkedPaid[row.memberId] ? (
+                                        <div
+                                          className="w-full py-3 rounded-[14px] text-sm font-bold text-center"
+                                          style={{
+                                            background: "rgba(52,211,153,0.06)",
+                                            border: "1px solid rgba(52,211,153,0.20)",
+                                            color: "#34D399",
+                                          }}
+                                        >
+                                          ✓ Marked as paid
+                                        </div>
+                                      ) : (
+                                        <button
+                                          type="button"
+                                          disabled={markAsPaidMutation.isPending}
+                                          className="w-full py-3 rounded-[14px] text-sm font-extrabold transition-colors hover:opacity-90 disabled:opacity-50"
+                                          style={{
+                                            background: "rgba(52,211,153,0.10)",
+                                            border: "1.5px solid rgba(52,211,153,0.25)",
+                                            color: "#34D399",
+                                          }}
+                                          onClick={() => handleMarkAsPaid(row.memberId, row.amount)}
+                                        >
+                                          {markAsPaidMutation.isPending ? "Marking…" : "✓ Mark as Paid"}
+                                        </button>
+                                      )}
+                                    </div>
+                                  );
+                                })()}
                               </div>
                             )}
                           </div>
@@ -975,114 +1246,57 @@ export function SettleDebtsModal({
                     </span>
                   </div>
 
-                  {multiCurrencyDebts.length > 0 && (
-                    <div className="rounded-xl p-3 bg-white/[0.05] border border-white/10">
-                      <div className="text-xs text-white/70 mb-2 font-medium">Conversion breakdown</div>
-                      {multiCurrencyDebts.map((debt, index) => (
-                        <div key={index} className="flex justify-between items-center text-xs py-0.5">
-                          <span className="text-white/80">
-                            {formatCurrency(debt.amount, debt.currency)}
-                          </span>
-                          <span className="text-white/55">
-                            {debt.tokenAmount.toFixed(6)} {selectedToken?.symbol}
-                          </span>
-                        </div>
-                      ))}
-                      <div className="border-t border-white/10 mt-2 pt-2 flex justify-between text-xs font-semibold">
-                        <span className="text-white">Total token</span>
-                        <span className="text-white">{totalTokenAmount} {selectedToken?.symbol}</span>
-                      </div>
-                    </div>
-                  )}
                 </div>
 
-                {/* Wallet connection when not connected */}
-                {!canProceedWithSettlement() && (
-                  <div className="mt-4">
-                    {selectedChain === "aptos" && <ShadcnWalletSelector />}
-                  </div>
-                )}
-
-                {canProceedWithSettlement() ? (
-                  <button
-                    className="w-full mt-5 h-12 rounded-[14px] bg-[#22D3EE] text-[#0a0a0a] font-extrabold text-sm flex items-center justify-center gap-2 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={() => {
-                      handleSettleAll();
-                    }}
-                    disabled={
-                      isPending ||
-                      remainingTotal <= 0 ||
-                      groupDebtBreakdown.length === 0
-                    }
-                  >
-                    {isPending ? (
-                      <>
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span>Sending…</span>
-                      </>
-                    ) : (
-                      <>
-                        <span>Review &amp; Confirm</span>
-                        <ChevronRight className="h-4 w-4" />
-                      </>
-                    )}
-                  </button>
-                ) : (
-                  selectedChain === "stellar" && (
-                    <button
-                      className="w-full mt-5 h-11 rounded-xl bg-white/[0.06] border border-white/10 text-white text-sm font-semibold flex items-center justify-center gap-2 hover:bg-white/[0.1] transition-colors"
-                      onClick={connectWallet}
-                    >
-                      <span>Connect Stellar Wallet</span>
-                    </button>
-                  )
-                )}
-
-                {selectedChain === "aptos" && !isWalletConnectedForChain() && (
-                  <p className="text-xs text-amber-400 mt-2 text-center">
-                    Please connect your Aptos wallet to continue
-                  </p>
-                )}
-                {selectedChain === "stellar" && !getUserWalletAddress() && (
-                  <p className="text-xs text-red-400 mt-2 text-center">
-                    Please connect your Stellar wallet or add your Stellar wallet address in settings first.
-                  </p>
-                )}
+                <button
+                  className="w-full mt-5 h-12 rounded-[14px] bg-[#22D3EE] text-[#0a0a0a] font-extrabold text-sm flex items-center justify-center gap-2 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={handleSettleAll}
+                  disabled={isPending || remainingTotal <= 0}
+                >
+                  {isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <span>Sending…</span>
+                    </>
+                  ) : (
+                    <>
+                      <span>Review &amp; Confirm</span>
+                      <ChevronRight className="h-4 w-4" />
+                    </>
+                  )}
+                </button>
               </motion.div>
             )}
 
             {/* Settle Individual Debt Section - Only shown when a friend's button is clicked */}
             {showIndividualView && (
               <motion.div
-                className="relative z-10 rounded-[24px] bg-black p-5 sm:p-8 border border-white/10 shadow-[0_0_15px_rgba(255,255,255,0.05)]"
+                className="relative z-10 rounded-[28px] p-7 border border-white/[0.09] shadow-[0_40px_100px_rgba(0,0,0,0.8)] max-h-[90vh] overflow-y-auto"
+                style={{ background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)" }}
                 {...scaleIn}
               >
-                <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center justify-between mb-5">
                   <div>
-                    <div className="mb-1 text-xs sm:text-sm text-white/60">
-                      Settle Individual Debt
-                    </div>
-                    <h2 className="text-xl sm:text-3xl font-semibold text-white">
-                      {selectedUser
-                        ? `Settle ${selectedUser.name}'s Debts`
-                        : "Settle Individual Debt"}
+                    <h2 className="text-xl font-extrabold text-white tracking-tight">
+                      Settle {selectedUser ? (selectedUser.name || "Member").split(" ")[0] : "Debt"}
                     </h2>
+                    <p className="mt-1.5 text-xs text-white/55">Individual settlement</p>
                   </div>
                   <button
                     onClick={onClose}
-                    className="p-2 rounded-full hover:bg-white/[0.03] transition-colors"
+                    className="h-9 w-9 rounded-full border border-white/10 bg-white/[0.07] grid place-items-center hover:bg-white/[0.12] transition-colors flex-shrink-0"
                   >
-                    <X className="h-5 w-5 text-white/60" />
+                    <X className="h-4 w-4 text-white/70" />
                   </button>
                 </div>
 
-                <div className="space-y-4 sm:space-y-6">
+                <div className="space-y-4">
                   <div>
-                    <div className="text-base sm:text-lg font-medium text-white mb-3 sm:mb-4">
+                    <label className="text-[#ccc] text-[11px] font-bold tracking-[0.08em] uppercase mb-2 block">
                       Choose Payment Token
-                    </div>
+                    </label>
 
-                    <div className="relative mb-3 sm:mb-4">
+                    <div className="relative mb-4">
                       <ResolverSelector
                         value={selectedToken || undefined}
                         onChange={(option) => setSelectedToken(option || null)}
@@ -1090,15 +1304,17 @@ export function SettleDebtsModal({
                     </div>
 
                     {availableChainsForToken.length > 1 && (
-                      <div className="mb-3 sm:mb-4">
-                        <label className="block text-white mb-1">Select Chain</label>
+                      <div className="mb-4">
+                        <label className="text-[#ccc] text-[11px] font-bold tracking-[0.08em] uppercase mb-2 block">
+                          Select Chain
+                        </label>
                         <select
                           value={selectedChain || ''}
                           onChange={e => setSelectedChain(e.target.value)}
-                          className="w-full rounded px-3 py-2 bg-black border border-white/10 text-white"
+                          className="w-full rounded-[14px] px-4 py-3 bg-white/[0.05] border-[1.5px] border-white/[0.09] text-white text-[14px] outline-none font-inherit"
                         >
                           {availableChainsForToken.map(chain => (
-                            <option key={chain} value={chain}>
+                            <option key={chain} value={chain} className="bg-[#141414]">
                               {chain.charAt(0).toUpperCase() + chain.slice(1)}
                             </option>
                           ))}
@@ -1107,27 +1323,30 @@ export function SettleDebtsModal({
                     )}
 
                     <div className="relative space-y-3">
-                      {/* Token Amount to Send - Merged with debt amount functionality */}
+                      {/* Token Amount to Send */}
                       {selectedToken && (
                         <div>
-                          <label className="block text-white mb-2 text-sm">
-                            Token Amount to Send {(isLoadingTokenPrice || isLoadingRate || isLoadingMultiCurrency) && "(Converting...)"}
+                          <label className="text-[#ccc] text-[11px] font-bold tracking-[0.08em] uppercase mb-2 block">
+                            Amount {(isLoadingTokenPrice || isLoadingRate || isLoadingMultiCurrency) && "(Converting...)"} <span className="text-[#22D3EE]">({selectedToken?.symbol})</span>
                           </label>
-                          <div className="w-full flex items-center justify-between rounded-full h-12 sm:h-14 px-4 sm:px-6 bg-transparent border border-white/10 text-white">
+                          <div className="w-full flex items-center bg-white/[0.05] border-[1.5px] border-white/[0.09] rounded-[14px] px-4 py-3 text-white">
+                            <span className="text-[#22D3EE] text-[20px] font-extrabold mr-2 min-w-[24px]">
+                              {selectedToken?.symbol === 'USD' ? '$' : selectedToken?.symbol[0]}
+                            </span>
                             <input
                               type="text"
                               value={multiCurrencyDebts.length > 0 ? totalTokenAmount : (tokenAmount || fiatAmount)}
                               onChange={(e) => {
                                 if (multiCurrencyDebts.length === 0) {
                                   setFiatAmount(e.target.value);
-                                  setIndividualAmount(e.target.value); // Keep for compatibility
+                                  setIndividualAmount(e.target.value);
                                 }
                               }}
-                              className="bg-transparent outline-none text-base sm:text-lg w-full"
+                              className="bg-transparent outline-none text-[26px] font-[800] w-full font-inherit"
                               placeholder="0.00"
                               readOnly={multiCurrencyDebts.length > 0 || (isLoadingTokenPrice || isLoadingRate || isLoadingMultiCurrency)}
                             />
-                            <span className="text-base sm:text-lg text-white/50">
+                            <span className="text-[14px] font-bold text-white/50 ml-2">
                               {selectedToken?.symbol || "Token"}
                             </span>
                           </div>
@@ -1135,25 +1354,25 @@ export function SettleDebtsModal({
                           {/* Conversion Breakdown Dropdown */}
                           {multiCurrencyDebts.length > 0 && (
                             <details className="mt-3 group">
-                              <summary className="cursor-pointer text-sm text-white/70 hover:text-white transition-colors flex items-center gap-2 list-none [&::-webkit-details-marker]:hidden">
+                              <summary className="cursor-pointer text-[13px] text-white/70 hover:text-white transition-colors flex items-center gap-2 font-medium list-none [&::-webkit-details-marker]:hidden">
                                 <ChevronDown className="h-4 w-4 transition-transform duration-200 group-open:rotate-180" />
                                 Conversion Breakdown
                               </summary>
-                              <div className="mt-2 p-3 bg-white/5 rounded-lg">
+                              <div className="mt-2 p-3 bg-white/[0.03] border border-white/[0.06] rounded-[14px]">
                                 {multiCurrencyDebts.map((debt, index) => (
-                                  <div key={index} className="flex justify-between items-center text-sm py-1">
+                                  <div key={index} className="flex justify-between items-center text-[12px] py-1">
                                     <span className="text-white/80">
                                       {formatCurrency(debt.amount, debt.currency)}
                                     </span>
-                                    <span className="text-white/60">
+                                    <span className="text-[#34D399] font-bold">
                                       {debt.tokenAmount.toFixed(6)} {selectedToken?.symbol}
                                     </span>
                                   </div>
                                 ))}
-                                <div className="border-t border-white/20 mt-2 pt-2">
-                                  <div className="flex justify-between items-center text-sm font-medium">
+                                <div className="border-t border-white/[0.08] mt-2 pt-2">
+                                  <div className="flex justify-between items-center text-[13px] font-bold">
                                     <span className="text-white">Total:</span>
-                                    <span className="text-white">
+                                    <span className="text-[#34D399]">
                                       {totalTokenAmount} {selectedToken?.symbol}
                                     </span>
                                   </div>
@@ -1191,60 +1410,50 @@ export function SettleDebtsModal({
                   </div>
 
                   {!selectedUser && (
-                    <div className="text-center text-white/60 py-4 text-mobile-sm sm:text-base">
+                    <div className="text-center text-white/60 py-4 text-[13px]">
                       Select a user to settle individual debt
                     </div>
                   )}
 
                   {selectedUser && (
-                    <div className="flex items-center gap-3 sm:gap-4 p-3 sm:p-4 bg-white/5 rounded-xl">
-                      <div className="h-10 w-10 sm:h-14 sm:w-14 overflow-hidden rounded-full">
+                    <div className="flex items-center gap-3 sm:gap-4 p-4 mt-2 bg-white/[0.03] border border-white/[0.08] rounded-[18px]">
+                      <div className="h-[46px] w-[46px] overflow-hidden rounded-full border-2 border-white/[0.1]">
                         <Image
                           src={
                             selectedUser.image ||
                             `https://api.dicebear.com/9.x/identicon/svg?seed=${selectedUser.id}`
                           }
                           alt={selectedUser.name || "User"}
-                          width={56}
-                          height={56}
+                          width={46}
+                          height={46}
                           className="h-full w-full object-cover"
                           onError={(e) => {
-                            // Fallback to dicebear
                             const target = e.target as HTMLImageElement;
                             target.src = `https://api.dicebear.com/9.x/identicon/svg?seed=${selectedUser.id}`;
                           }}
                         />
                       </div>
-                      <div>
-                        <p className="text-mobile-base sm:text-xl text-white font-medium">
+                      <div className="flex-[1]">
+                        <p className="text-[14px] text-white font-[700] mb-0.5">
                           {selectedUser.name}
                         </p>
-                        <p className="text-mobile-sm sm:text-base text-white/60">
+                        <p className="text-[12px] text-white/60 font-[500]">
                           You owe{" "}
                           {(() => {
-                            console.log('Display logic check:', {
-                              multiCurrencyDebts: multiCurrencyDebts,
-                              multiCurrencyDebtsLength: multiCurrencyDebts.length,
-                              selectedUserBalance,
-                              defaultCurrency,
-                              groupDebtCurrencies,
-                              showIndividualView
-                            });
-                            
                             return multiCurrencyDebts.length > 0 ? (
-                              <div className="flex flex-wrap gap-1">
+                              <div className="flex flex-wrap gap-1 mt-1">
                                 {multiCurrencyDebts.map((debt, idx) => (
-                                  <span key={idx} className="text-[#FF4444]">
+                                  <span key={idx} className="text-[#34D399] font-[800] font-mono">
                                     {formatCurrency(debt.amount, debt.currency)}
                                     {idx < multiCurrencyDebts.length - 1 && ", "}
                                   </span>
                                 ))}
-                                <span className="text-white/60 ml-1">
+                                <span className="text-white/60 ml-1 font-[400] font-sans">
                                   worth {totalTokenAmount} {selectedToken?.symbol || "tokens"}
                                 </span>
                               </div>
                             ) : (
-                              <span className="text-[#FF4444]">
+                              <span className="text-[#34D399] font-[800] font-mono ml-1">
                                 {formatCurrency(Math.abs(selectedUserBalance), defaultCurrency)}
                               </span>
                             );
@@ -1257,14 +1466,14 @@ export function SettleDebtsModal({
 
                 {/* Show wallet connection component for any chain if not connected */}
                 {!canProceedWithSettlement() && (
-                  <div className="mb-6">
+                  <div className="mt-4">
                     {selectedChain === 'aptos' && <ShadcnWalletSelector />}
                   </div>
                 )}
 
                 {canProceedWithSettlement() ? (
                   <button
-                    className="w-full mt-8 sm:mt-12 flex items-center justify-center gap-2 text-mobile-base sm:text-lg font-medium h-10 sm:h-14 bg-white text-black rounded-full hover:bg-white/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full mt-6 h-12 rounded-[14px] bg-[#22D3EE] text-[#0a0a0a] font-extrabold text-sm flex items-center justify-center gap-2 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={() => selectedUser && handleSettleOne(selectedUser)}
                     disabled={
                       isPending ||
@@ -1276,26 +1485,20 @@ export function SettleDebtsModal({
                   >
                     {isPending ? (
                       <>
-                        <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 animate-spin" />
-                        <span>Settling payment...</span>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        <span>Sending…</span>
                       </>
                     ) : (
                       <>
-                        <Image
-                          src="/coins-dollar.svg"
-                          alt="Settle Payment"
-                          width={24}
-                          height={24}
-                          className="invert h-4 w-4 sm:h-5 sm:w-5"
-                        />
-                        <span>Settle Payment</span>
+                        <span>Review &amp; Confirm</span>
+                        <ChevronRight className="h-4 w-4" />
                       </>
                     )}
                   </button>
                 ) : (
                   selectedChain === 'stellar' && (
                     <button
-                      className="text-white transition-colors text-base flex items-center justify-center gap-2 w-full bg-transparent border py-3 rounded-full mt-2 border-white/40 hover:bg-white/10"
+                      className="w-full mt-5 h-11 rounded-xl bg-white/[0.06] border border-white/10 text-white text-sm font-semibold flex items-center justify-center gap-2 hover:bg-white/[0.1] transition-colors"
                       onClick={connectWallet}
                     >
                       <span>Connect Stellar Wallet</span>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -5,27 +5,23 @@ import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  Users2,
   UserPlus,
   LayoutDashboard,
   ChevronLeft,
   ChevronsUpDown,
   Plus,
-  LogOut,
   TrendingUp,
   Activity,
   FileSignature,
   FileText,
   Receipt,
-  UserCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Icons, A, Avatar, T } from "@/lib/splito-design";
+import { Icons, getUserColor } from "@/lib/splito-design";
 import { useMobileMenu } from "@/contexts/mobile-menu";
 import { useAuthStore } from "@/stores/authStore";
 import { useGetAllOrganizations } from "@/features/business/hooks/use-organizations";
 import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
-import { signOut } from "@/lib/auth";
 import { APP_MODE } from "@/lib/app-mode";
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -77,13 +73,6 @@ export function Sidebar() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const handleLogout = async () => {
-    close();
-    setOrgSwitcherOpen(false);
-    await signOut();
-    router.push("/login");
-  };
-
   return (
     <div className="hidden min-[1025px]:block">
       {isOpen && (
@@ -101,15 +90,15 @@ export function Sidebar() {
         )}
         style={{ background: "linear-gradient(180deg, #0e0e0e 0%, #0b0b0b 100%)" }}
       >
-        <div className="flex h-full flex-col">
+        <div className="flex h-full flex-col px-[14px] py-[22px]">
           {/* Logo/Brand – same in both modes */}
-          <div className="flex items-center relative px-[22px] py-5 gap-2.5 mb-8">
+          <div className="flex items-center relative pl-2 gap-2.5 mb-8">
             <Link href={isOrganizationMode ? "https://splito.io" : "/"} onClick={close} className="z-10 flex items-center">
               <Image src={logo} alt="Splito Logo" width={120} height={32} className="h-8 w-auto" />
             </Link>
             <button
               onClick={close}
-              className="absolute right-4 top-1/2 -translate-y-1/2 h-8 w-8 flex items-center justify-center rounded-full bg-[#17171A] text-white/70 hover:text-white transition-colors min-[1025px]:hidden"
+              className="absolute right-0 top-1/2 -translate-y-1/2 h-8 w-8 flex items-center justify-center rounded-full bg-[#17171A] text-white/70 hover:text-white transition-colors min-[1025px]:hidden"
               aria-label="Close menu"
             >
               <ChevronLeft className="h-5 w-5" strokeWidth={1.5} />
@@ -117,7 +106,7 @@ export function Sidebar() {
           </div>
 
           {/* Main Navigation */}
-          <div className="flex-1 space-y-1 px-4 py-4 sm:py-6 overflow-y-auto">
+          <nav className="flex flex-col gap-0.5">
             {/* Dashboard - shared; in personal mode use design styling */}
             {(!isOrganizationMode ? (
               <Link
@@ -125,10 +114,10 @@ export function Sidebar() {
                 href="/"
                 onClick={close}
                 className={cn(
-                  "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                  "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                   pathname === "/" && !pathname.startsWith("/groups/")
-                    ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                    : "text-white/60"
+                    ? "bg-white/[0.09] text-white font-bold"
+                    : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                 )}
               >
                 <span className={pathname === "/" ? "text-[#22D3EE]" : "inherit"}>{Icons.home({})}</span>
@@ -140,10 +129,10 @@ export function Sidebar() {
                 href="/organization"
                 onClick={close}
                 className={cn(
-                  "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                  "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                   pathname === "/organization"
-                    ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                    : "text-white/60"
+                    ? "bg-white/[0.09] text-white font-bold"
+                    : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                 )}
               >
                 <span className={pathname === "/organization" ? "text-[#22D3EE]" : "inherit"}><LayoutDashboard className="h-4 w-4" strokeWidth={1.5} /></span>
@@ -173,10 +162,10 @@ export function Sidebar() {
                   href={`/organization/${linkOrgId}/invoices`}
                   onClick={close}
                   className={cn(
-                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                     pathname === `/organization/${linkOrgId}/invoices`
-                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                      : "text-white/60"
+                      ? "bg-white/[0.09] text-white font-bold"
+                      : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                   )}
                 >
                   <span className={pathname === `/organization/${linkOrgId}/invoices` ? "text-[#22D3EE]" : "inherit"}><FileText className="h-4 w-4" strokeWidth={1.5} /></span>
@@ -189,10 +178,10 @@ export function Sidebar() {
                     href={`/organization/${linkOrgId}/expenses`}
                     onClick={close}
                     className={cn(
-                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                       pathname === `/organization/${linkOrgId}/expenses`
-                        ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                        : "text-white/60"
+                        ? "bg-white/[0.09] text-white font-bold"
+                        : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                     )}
                   >
                     <span className={pathname === `/organization/${linkOrgId}/expenses` ? "text-[#22D3EE]" : "inherit"}><Receipt className="h-4 w-4" strokeWidth={1.5} /></span>
@@ -206,10 +195,10 @@ export function Sidebar() {
                     href={`/organization/${linkOrgId}/streams`}
                     onClick={close}
                     className={cn(
-                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                       pathname === `/organization/${linkOrgId}/streams`
-                        ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                        : "text-white/60"
+                        ? "bg-white/[0.09] text-white font-bold"
+                        : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                     )}
                   >
                     <span className={pathname === `/organization/${linkOrgId}/streams` ? "text-[#22D3EE]" : "inherit"}><TrendingUp className="h-4 w-4" strokeWidth={1.5} /></span>
@@ -223,10 +212,10 @@ export function Sidebar() {
                     href={`/organization/${linkOrgId}/activity`}
                     onClick={close}
                     className={cn(
-                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                       pathname === `/organization/${linkOrgId}/activity`
-                        ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                        : "text-white/60"
+                        ? "bg-white/[0.09] text-white font-bold"
+                        : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                     )}
                   >
                     <span className={pathname === `/organization/${linkOrgId}/activity` ? "text-[#22D3EE]" : "inherit"}><Activity className="h-4 w-4" strokeWidth={1.5} /></span>
@@ -239,10 +228,10 @@ export function Sidebar() {
                   href={`/organization/${linkOrgId}/contracts`}
                   onClick={close}
                   className={cn(
-                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                     pathname === `/organization/${linkOrgId}/contracts`
-                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                      : "text-white/60"
+                      ? "bg-white/[0.09] text-white font-bold"
+                      : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                   )}
                 >
                   <span className={pathname === `/organization/${linkOrgId}/contracts` ? "text-[#22D3EE]" : "inherit"}><FileSignature className="h-4 w-4" strokeWidth={1.5} /></span>
@@ -255,10 +244,10 @@ export function Sidebar() {
                     href={`/organization/${linkOrgId}/members`}
                     onClick={close}
                     className={cn(
-                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                      "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                       pathname === `/organization/${linkOrgId}/members`
-                        ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                        : "text-white/60"
+                        ? "bg-white/[0.09] text-white font-bold"
+                        : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                     )}
                   >
                     <span className={pathname === `/organization/${linkOrgId}/members` ? "text-[#22D3EE]" : "inherit"}><UserPlus className="h-4 w-4" strokeWidth={1.5} /></span>
@@ -271,10 +260,10 @@ export function Sidebar() {
                   href={`/organization/${linkOrgId}/settings`}
                   onClick={close}
                   className={cn(
-                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                     pathname === `/organization/${linkOrgId}/settings`
-                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                      : "text-white/60"
+                      ? "bg-white/[0.09] text-white font-bold"
+                      : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                   )}
                 >
                   <span className={pathname === `/organization/${linkOrgId}/settings` ? "text-[#22D3EE]" : "inherit"}>{Icons.settings({})}</span>
@@ -291,10 +280,10 @@ export function Sidebar() {
                   href="/groups"
                   onClick={close}
                   className={cn(
-                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                     pathname === "/groups" || pathname.startsWith("/groups/")
-                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                      : "text-white/60"
+                      ? "bg-white/[0.09] text-white font-bold"
+                      : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                   )}
                 >
                   <span className={pathname === "/groups" || pathname.startsWith("/groups/") ? "text-[#22D3EE]" : "inherit"}>{Icons.groups({})}</span>
@@ -305,10 +294,10 @@ export function Sidebar() {
                   href="/friends"
                   onClick={close}
                   className={cn(
-                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                     pathname === "/friends"
-                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                      : "text-white/60"
+                      ? "bg-white/[0.09] text-white font-bold"
+                      : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                   )}
                 >
                   <span className={pathname === "/friends" ? "text-[#22D3EE]" : "inherit"}>{Icons.friends({})}</span>
@@ -319,10 +308,10 @@ export function Sidebar() {
                   href="/settings"
                   onClick={close}
                   className={cn(
-                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-3.5 text-[14px] font-medium transition-all",
+                    "splito-nav-item flex items-center gap-2.5 rounded-[13px] py-2.5 px-[13px] text-sm transition-all",
                     pathname === "/settings"
-                      ? "bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
-                      : "text-white/60"
+                      ? "bg-white/[0.09] text-white font-bold"
+                      : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                   )}
                 >
                   <span className={pathname === "/settings" ? "text-[#22D3EE]" : "inherit"}>{Icons.settings({})}</span>
@@ -330,14 +319,14 @@ export function Sidebar() {
                 </Link>
               </>
             )}
-          </div>
+          </nav>
 
           {/* Personal mode: GROUPS section + New group + user card */}
           {!isOrganizationMode && (
             <>
-              <div className="mt-7 flex-1 overflow-y-auto min-h-0 px-3.5">
-                <p className="text-[10px] font-extrabold tracking-[0.12em] uppercase text-white/50 px-3.5 mb-2">GROUPS</p>
-                <div className="flex flex-col gap-0.5">
+              <div className="mt-7 flex-1 overflow-y-auto min-h-0">
+                <p className="text-[10px] font-extrabold tracking-[0.12em] uppercase px-[13px] mb-2" style={{ color: "rgba(255,255,255,0.32)" }}>GROUPS</p>
+                <div className="flex flex-col gap-px">
                   {groups.map((g) => {
                     const isActive = pathname.startsWith(`/groups/${g.id}`);
                     return (
@@ -346,14 +335,11 @@ export function Sidebar() {
                         href={`/groups/${g.id}`}
                         onClick={close}
                         className={cn(
-                          "splito-nav-item flex items-center py-2 px-3.5 rounded-[13px] transition-all",
-                          isActive ? "bg-white/[0.09] text-white" : "text-white/60"
+                          "splito-nav-item flex items-center py-[9px] px-[13px] rounded-[12px] transition-all",
+                          isActive ? "bg-white/[0.09] text-white font-bold" : "text-white/60 font-medium hover:bg-white/[0.07] hover:text-[#e8e8e8]"
                         )}
                       >
-                        <span className={cn(
-                          "text-[13px] font-medium truncate flex-1",
-                          isActive ? "text-white font-semibold" : "inherit"
-                        )}>
+                        <span className="text-[13px] truncate flex-1">
                           {g.name}
                         </span>
                       </Link>
@@ -363,30 +349,35 @@ export function Sidebar() {
                     type="button"
                     onClick={() => {
                       close();
-                      if (pathname === "/groups" || pathname.startsWith("/groups/")) {
+                      if (pathname === "/groups") {
                         document.dispatchEvent(new CustomEvent("open-create-group-modal"));
                       } else {
                         router.push("/groups?openCreate=1");
                       }
                     }}
-                    className="w-full flex items-center gap-[9px] rounded-xl py-[9px] px-[13px] bg-transparent my-1.5 transition-all hover:bg-white/[0.04] cursor-pointer"
-                    style={{ border: "1.5px dashed rgba(255,255,255,0.1)" }}
+                    className="w-full flex items-center gap-[9px] rounded-[12px] py-[9px] px-[13px] bg-transparent my-1.5 transition-all cursor-pointer"
+                    style={{ border: "1.5px dashed rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.45)" }}
                   >
-                    <span className="text-[15px] leading-none" style={{ color: T.muted }}>+</span>
-                    <span className="text-[13px] font-medium" style={{ color: T.muted }}>New group</span>
+                    <span className="text-[15px] leading-none">+</span>
+                    <span className="text-[13px] font-medium">New group</span>
                   </button>
                 </div>
               </div>
-              <div className="px-3 pb-4 pt-5 mt-2">
-                <div className="flex items-center gap-2.5 py-3 px-3.5 rounded-2xl bg-white/[0.05] border border-white/[0.07]">
-                  <Avatar
-                    init={user?.name?.charAt(0)?.toUpperCase() || "Y"}
-                    color={A}
-                    size={34}
-                  />
+              <div className="mt-3">
+                <div className="flex items-center gap-2.5 py-3 px-[13px] rounded-2xl bg-white/[0.05] border border-white/[0.08]">
+                  <div
+                    className="w-[34px] h-[34px] rounded-full flex items-center justify-center text-[11px] font-extrabold shrink-0"
+                    style={{
+                      background: `${getUserColor(user?.name || "You")}1a`,
+                      border: `2px solid ${getUserColor(user?.name || "You")}33`,
+                      color: getUserColor(user?.name || "You"),
+                    }}
+                  >
+                    {user?.name?.charAt(0)?.toUpperCase() || "Y"}
+                  </div>
                   <div className="min-w-0 flex-1">
-                    <p className="text-[13px] font-bold truncate text-white">{user?.name || "You"}</p>
-                    <p className="text-[11px] text-white/60 truncate">{user?.email || "you@email.com"}</p>
+                    <p className="text-[13px] font-bold truncate" style={{ color: "#e8e8e8" }}>{user?.name || "You"}</p>
+                    <p className="text-[11px] truncate font-medium" style={{ color: "rgba(255,255,255,0.45)" }}>{user?.email || "you@email.com"}</p>
                   </div>
                 </div>
               </div>
@@ -395,32 +386,36 @@ export function Sidebar() {
 
           {/* Bottom Section (organization mode only; styled like personal user card) */}
           {isOrganizationMode && (
-              <div className="px-3 pb-4 pt-5 mt-2">
+              <div className="mt-3">
                 <div className="relative" ref={orgSwitcherRef}>
                   <button
                     id="sidebar-org-switcher-button"
                     type="button"
                     onClick={() => setOrgSwitcherOpen((v) => !v)}
                     className={cn(
-                      "flex w-full items-center gap-2.5 py-3 px-3.5 rounded-2xl text-left transition-colors",
-                      "bg-white/[0.05] border border-white/[0.07]",
+                      "flex w-full items-center gap-2.5 py-3 px-[13px] rounded-2xl text-left transition-colors",
+                      "bg-white/[0.05] border border-white/[0.08]",
                       "hover:bg-white/[0.07] hover:border-white/[0.1]",
                       orgSwitcherOpen && "bg-white/[0.07] border-white/[0.1]"
                     )}
-                    style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)" }}
                   >
-                    <Avatar
-                      init={currentOrg ? currentOrg.name.charAt(0).toUpperCase() : "?"}
-                      color={A}
-                      size={34}
-                    />
+                    <div
+                      className="w-[34px] h-[34px] rounded-full flex items-center justify-center text-[11px] font-extrabold shrink-0"
+                      style={{
+                        background: `${getUserColor(currentOrg?.name || "?")}1a`,
+                        border: `2px solid ${getUserColor(currentOrg?.name || "?")}33`,
+                        color: getUserColor(currentOrg?.name || "?"),
+                      }}
+                    >
+                      {currentOrg ? currentOrg.name.charAt(0).toUpperCase() : "?"}
+                    </div>
                     <div className="min-w-0 flex-1">
-                      <p className="text-[13px] font-bold truncate text-white">
+                      <p className="text-[13px] font-bold truncate" style={{ color: "#e8e8e8" }}>
                         {currentOrg?.name ?? "Select organization"}
                       </p>
-                      <p className="text-[11px] truncate" style={{ color: T.muted }}>Organization</p>
+                      <p className="text-[11px] truncate font-medium" style={{ color: "rgba(255,255,255,0.45)" }}>Organization</p>
                     </div>
-                    <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-60" style={{ color: T.muted }} strokeWidth={1.5} />
+                    <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-60" style={{ color: "rgba(255,255,255,0.45)" }} strokeWidth={1.5} />
                   </button>
 
                 <AnimatePresence>
@@ -457,7 +452,14 @@ export function Sidebar() {
                                 : "text-white/90 hover:bg-white/5 hover:text-white"
                             )}
                           >
-                            <div className="h-7 w-7 rounded-full bg-white/10 flex items-center justify-center text-[11px] font-bold shrink-0">
+                            <div
+                              className="h-7 w-7 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0"
+                              style={{
+                                background: `${getUserColor(org.name)}1a`,
+                                border: `1.5px solid ${getUserColor(org.name)}33`,
+                                color: getUserColor(org.name),
+                              }}
+                            >
                               {org.name.charAt(0).toUpperCase()}
                             </div>
                             <span className="truncate">{org.name}</span>

--- a/lib/splito-design.tsx
+++ b/lib/splito-design.tsx
@@ -17,6 +17,17 @@ export const T = {
   bright: "#f5f5f5",
 };
 
+export const FRIEND_COLORS = [A, "#A78BFA", G, "#FB923C", "#F472B6", "#FBBF24", "#818CF8"];
+
+export function getUserColor(name: string | null) {
+  if (!name) return A;
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return FRIEND_COLORS[Math.abs(hash) % FRIEND_COLORS.length];
+}
+
 export const fmt = (n: number): string =>
   `$${+n % 1 === 0 ? Math.abs(+n) : Math.abs(+n).toFixed(2)}`;
 


### PR DESCRIPTION
Settle Debts Modal (settle-debts-modal.tsx)                                                             
                                                                                                          
  - Crypto / Bank tabs now functional — added per-member state (memberMethods, memberChains,              
  memberBankCurrencies) so each debtor row independently tracks the selected payment method
  - On-chain settlement — chain selector grid (Stellar, Solana, Aptos, Base) with icons/colors, wallet    
  connect CTA, and "Don't trust app?" fallback button                                                     
  - Bank/Mark as Paid flow — searchable fiat currency dropdown per member, "Mark as Paid" button wired to
  useMarkAsPaid mutation                                                                                  
  - Removed inner scroll — eliminated max-h-[320px] overflow-y-auto from the debtor list so the whole
  modal scrolls naturally                                                                                 
  - Replaced post-total content with a single clean "Review & Confirm →" button
  - defaultExpandedMemberId prop — auto-expands a specific member row when modal is opened from a friend  
  or member card                                                                                          
  - showIndividualView always false — unified settle flow used everywhere                                 
                                                                                                          
  Group Layout (app/groups/[id]/layout.tsx)                                                               
                                                                                                          
  - Fixed modal overlay gap — removed overflow-y-auto and rounded-xl from the content wrapper div; modals 
  now cover the full viewport with no header gap            
  - Simplified SettleDebtsModal usage — removed specificAmount/specificDebtByCurrency props, added        
  defaultExpandedMemberId                                                                                 
   
  Group Info Header (group-info-header.tsx)                                                               
                                                            
  - Tab order changed — Splits → Activity → Members                                                       
  - Tab padding updated to 8px 20px to match design artifact
  - "Add Member" button moved from page content into the tabs row, only shown on the Members tab and only 
  for group admins                                                                                        
  - Z-index fixed to z-[40] so modals correctly render above the sticky header                            
                                                                                                          
  Members Page (app/groups/[id]/members/page.tsx)                                                         
                                                                                                          
  - Removed top section label + inline Add Member button (button moved to header)                         
  - Settle button now opens the unified SettleDebtsModal (via openSettle) instead of the old individual
  view                                                                                                    
                                                            
  Splits Page (app/groups/[id]/splits/page.tsx)                                                           
                                                            
  - Expense avatar now shows selected emoji — getCategoryStyle checks if category is a raw emoji and      
  renders it directly instead of falling back to         
  - Settle/Notify hover effects fixed — Settle uses .splito-sbtn (cyan fill + glow), Notify uses          
  .splito-abtn (cyan tint border)                                                                         
  - Delete button converted to <Btn variant="danger"> for consistent styling
                                                                                                          
  Add Expense Modal (add-expense-modal.tsx)                                                               
                                                                                                          
  - Emoji saved as category — payload sends categoryEmoji (e.g. 🎵) instead of generic "OTHER" so the     
  correct icon persists                                     
  - "Paid By" active color — selection border, glow, avatar fill, and name label now use each member's own
   avatar color (via getUserColor) instead of fixed cyan                                                  
  - Imported getUserColor and removed hardcoded local memberColors array
                                                                                                          
  Sidebar (sidebar.tsx)                                                                                   
                                                                                                          
  - "New group" button fixed — was dispatching custom event when inside any /groups/ path; now only       
  dispatches on exact /groups page, navigates to /groups?openCreate=1 from group detail pages
                                                                                                          
  Friends Page / FriendsList (friends-list.tsx)                                                           
   
  - Settle button now works — tracks selectedFriendId, finds the shared group with an outstanding balance,
   and opens SettleDebtsModal with correct balances, members, groupId, and defaultExpandedMemberId
  - Removed local AVATAR_COLORS array — replaced with getUserColor(friend.name) for consistency           
                                                                                                          
  Currency Dropdown (currency-dropdown.tsx)                                                               
                                                                                                          
  - Z-index raised to 200 — portal always renders above modals (z-50) and sticky headers (z-40)           
                                                            
  Settings Page (settings-page-content.tsx)                                                               
                                                            
  - Sticky header z-index set to 40 — currency dropdown portal (200) renders above it; modals (50) render 
  above the header correctly                                
                                                                                                          
  Design System (lib/splito-design.tsx)                                                                   
   
  - Avatar colors consistent everywhere — all components now use getUserColor(name) (deterministic name   
  hash); removed all local index-based color arrays from friends-list.tsx and add-expense-modal.tsx
                                                                                                          
  Add Member Modal (add-member-modal.tsx)                                                                 
   
  - Full UI rewrite to match design system — dark gradient, backdrop blur, uppercase label, inline styles 
  using A/T tokens, renamed "Add Admin" → "Add Member"    