### PR TITLE
mobile ui personal mode

### DIFF
--- a/app/friends/page.tsx
+++ b/app/friends/page.tsx
@@ -1,25 +1,42 @@
 "use client";
 
 import { FriendsList } from "@/components/friends-list";
-import { useState, useEffect } from "react";
-import { AddFriendsModal } from "@/components/add-friends-modal";
+import { useState } from "react";
 import { Card, Icons } from "@/lib/splito-design";
 import { toast } from "sonner";
 import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
 import { createGroupInviteLink } from "@/features/groups/api/client";
+import { useAddFriend } from "@/features/friends/hooks/use-add-friend";
+import { isValidEmail } from "@/utils/validation";
+import { Loader2 } from "lucide-react";
 
 export default function FriendsPage() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [inviteLinkModalOpen, setInviteLinkModalOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState("");
   const [search, setSearch] = useState("");
   const { data: groups = [], isLoading: groupsLoading } = useGetAllGroups({ type: "PERSONAL" });
+  const { mutate: addFriend, isPending: isInviting } = useAddFriend();
 
-  useEffect(() => {
-    const handleOpenModal = () => setIsModalOpen(true);
-    document.addEventListener("open-add-friend-modal", handleOpenModal);
-    return () => document.removeEventListener("open-add-friend-modal", handleOpenModal);
-  }, []);
+  const handleInviteClick = () => {
+    const value = inviteEmail.trim();
+    if (!value) {
+      toast.error("Please enter an email address");
+      return;
+    }
+    if (!isValidEmail(value)) {
+      toast.error("Please enter a valid email address (e.g. name@example.com)");
+      return;
+    }
+    addFriend(value, {
+      onSuccess: (data: { message?: string }) => {
+        setInviteEmail("");
+        toast.success(data?.message || "Friend invited successfully");
+      },
+      onError: (error: { message?: string }) => {
+        toast.error(error?.message || "Failed to invite friend");
+      },
+    });
+  };
 
   const handleCopyInviteLinkClick = () => {
     setInviteLinkModalOpen(true);
@@ -40,19 +57,80 @@ export default function FriendsPage() {
 
   return (
     <div className="flex-1 flex flex-col min-w-0">
+      {/* Desktop header (unchanged) */}
       <div
-        className="border-b border-white/[0.07] px-4 sm:px-7 flex items-center h-14 sm:h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
+        className="border-b border-white/[0.07] px-7 sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10 hidden sm:flex items-center h-[70px]"
       >
         <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
           Friends
         </h1>
       </div>
       <div className="flex-1 p-4 sm:p-7 overflow-y-auto">
+        {/* Mobile status bar + header */}
+        <div className="sm:hidden mb-3">
+          
+          <div className="pb-2 px-0">
+            <p className="text-[13px] font-medium text-white/60">Friends & balances</p>
+            <h1 className="text-[26px] font-black tracking-[-0.04em] text-white mt-1">
+              Friends
+            </h1>
+          </div>
+        </div>
+        {/* Mobile invite card (cyan-tinted) */}
         <div
-          className="grid gap-4 sm:gap-5 mb-5 sm:mb-6"
-          style={{ gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))" }}
+          id="invite-friends-section"
+          className="sm:hidden rounded-[20px] p-4 mb-5"
+          style={{
+            background: "linear-gradient(135deg,rgba(34,211,238,0.08),rgba(34,211,238,0.03))",
+            border: "1px solid rgba(34,211,238,0.15)",
+          }}
         >
-          <Card className="p-4 sm:p-[22px]">
+          <p className="text-[15px] font-extrabold mb-0.5 tracking-[-0.01em]" style={{ color: "#fff" }}>
+            Invite Friends
+          </p>
+          <p className="text-[12px] font-medium mb-4" style={{ color: "rgba(34,211,238,0.6)" }}>
+            Split expenses with anyone in seconds
+          </p>
+          <div className="flex gap-2">
+            <input
+              placeholder="Email address…"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleInviteClick()}
+              disabled={isInviting}
+              className="flex-1 rounded-xl py-3 px-3.5 text-[13px] font-medium text-white outline-none border border-white/[0.09] bg-[#0A0F12] disabled:opacity-70"
+            />
+            <button
+              onClick={handleInviteClick}
+              disabled={isInviting || !inviteEmail.trim()}
+              className="rounded-xl py-2.5 px-4 text-[13px] font-extrabold text-[#0a0a0a] transition-all hover:opacity-90 disabled:opacity-70 flex items-center justify-center gap-1.5 min-w-[80px]"
+              style={{ background: "#22D3EE" }}
+            >
+              {isInviting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Invite"}
+            </button>
+          </div>
+          <div className="flex items-center gap-2 mt-3.5">
+            <div className="flex-1 h-px" style={{ background: "rgba(34,211,238,0.15)" }} />
+            <span className="text-[11px] font-semibold" style={{ color: "rgba(34,211,238,0.5)" }}>or</span>
+            <div className="flex-1 h-px" style={{ background: "rgba(34,211,238,0.15)" }} />
+          </div>
+          <button
+            type="button"
+            onClick={handleCopyInviteLinkClick}
+            className="w-full mt-3.5 py-2.5 rounded-xl text-[13px] font-semibold flex items-center justify-center gap-1.5 transition-all"
+            style={{
+              background: "rgba(255,255,255,0.06)",
+              border: "1px solid rgba(255,255,255,0.12)",
+              color: "#d4d4d4",
+            }}
+          >
+            <Icons.link /> Copy invite link
+          </button>
+        </div>
+
+        {/* Desktop invite card (original) */}
+        <div id="invite-friends-section-desktop" className="hidden sm:block mb-6">
+          <Card className="p-[22px]">
             <p className="text-[15px] font-extrabold text-[#f5f5f5] mb-1 tracking-[-0.01em]">
               Invite a Friend
             </p>
@@ -64,14 +142,17 @@ export default function FriendsPage() {
                 placeholder="friend@email.com"
                 value={inviteEmail}
                 onChange={(e) => setInviteEmail(e.target.value)}
-                className="flex-1 rounded-xl py-2.5 px-3.5 text-[13px] font-medium text-white outline-none border border-white/[0.09] bg-white/[0.05]"
+                onKeyDown={(e) => e.key === "Enter" && handleInviteClick()}
+                disabled={isInviting}
+                className="flex-1 rounded-xl py-2.5 px-3.5 text-[13px] font-medium text-white outline-none border border-white/[0.09] bg-white/[0.05] disabled:opacity-70"
               />
               <button
-                onClick={() => setIsModalOpen(true)}
-                className="rounded-xl py-2.5 px-4 text-[13px] font-extrabold text-[#0a0a0a] transition-all hover:opacity-90"
+                onClick={handleInviteClick}
+                disabled={isInviting || !inviteEmail.trim()}
+                className="rounded-xl py-2.5 px-4 text-[13px] font-extrabold text-[#0a0a0a] transition-all hover:opacity-90 disabled:opacity-70 flex items-center justify-center gap-1.5 min-w-[80px]"
                 style={{ background: "#22D3EE" }}
               >
-                Invite
+                {isInviting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Invite"}
               </button>
             </div>
             <div className="flex items-center gap-2 mt-3.5">
@@ -88,6 +169,14 @@ export default function FriendsPage() {
             </button>
           </Card>
         </div>
+
+        {/* YOUR FRIENDS label — mobile only */}
+        <p
+          className="sm:hidden mb-3"
+          style={{ color: "#666", fontSize: 11, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase" }}
+        >
+          YOUR FRIENDS
+        </p>
         <div
           className="flex items-center gap-2 rounded-[14px] py-2.5 px-4 mb-4 sm:mb-5 border border-white/[0.08] bg-white/[0.04]"
         >
@@ -99,10 +188,14 @@ export default function FriendsPage() {
             className="flex-1 bg-transparent border-none text-white text-[14px] outline-none font-medium"
           />
         </div>
-        <FriendsList search={search} />
+        <FriendsList
+          search={search}
+          onAddFriendClick={() =>
+            document.getElementById("invite-friends-section")?.scrollIntoView({ behavior: "smooth" }) ||
+            document.getElementById("invite-friends-section-desktop")?.scrollIntoView({ behavior: "smooth" })
+          }
+        />
       </div>
-      <AddFriendsModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
-
       {/* Modal: pick group for invite link */}
       {inviteLinkModalOpen && (
         <div

--- a/app/globals.css
+++ b/app/globals.css
@@ -206,6 +206,53 @@ input[type="number"] {
   min-height: 100vh;
   font-family: var(--font-dm-sans), "DM Sans", "Segoe UI", sans-serif;
 }
+/* Spinner animation for loading states */
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* Modal entry animation used across modals */
+@keyframes mIn {
+  from { opacity: 0; transform: scale(0.93) translateY(12px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+@keyframes fU {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes fI {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
+}
+
+/* Short-name hover aliases used across components */
+.rw:hover {
+  background: rgba(255, 255, 255, 0.03) !important;
+}
+.nv:hover {
+  background: rgba(255, 255, 255, 0.07) !important;
+  color: #e8e8e8 !important;
+}
+.btn:hover {
+  opacity: 0.85;
+  transform: translateY(-1px);
+}
+.abtn:hover {
+  border-color: rgba(34, 211, 238, 0.35) !important;
+  color: #22d3ee !important;
+  background: rgba(34, 211, 238, 0.08) !important;
+}
+.sbtn:hover {
+  background: #22d3ee !important;
+  color: #0a0a0a !important;
+  border-color: #22d3ee !important;
+  box-shadow: 0 0 20px rgba(34, 211, 238, 0.4) !important;
+}
 .splito-nav-item:hover {
   background: rgba(255, 255, 255, 0.07) !important;
   color: #e8e8e8 !important;
@@ -233,6 +280,64 @@ input[type="number"] {
 }
 input::placeholder {
   color: #555;
+}
+@keyframes mobileSheetUp {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* Modal as bottom sheet on mobile (match Quick Add layout) */
+.modal-as-sheet-wrapper {
+  position: fixed !important;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: auto !important;
+  transform: none !important;
+  width: 100%;
+  max-width: 430px;
+  margin: 0 auto;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  animation: mobileSheetUp 0.32s cubic-bezier(0.34, 1.2, 0.64, 1);
+}
+.modal-as-sheet-handle {
+  flex-shrink: 0;
+  display: flex;
+  justify-content: center;
+  padding: 14px 0 6px;
+}
+.modal-as-sheet-handle::before {
+  content: "";
+  width: 40px;
+  height: 4px;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.15);
+}
+.modal-as-sheet-card {
+  border-radius: 26px 26px 0 0 !important;
+  max-height: 92vh !important;
+  overflow-y: auto;
+  background: linear-gradient(180deg, #161616 0%, #111 100%) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+.modal-as-sheet-card .modal-as-sheet-title-bar {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  flex-shrink: 0;
+}
+.modal-as-sheet-card .modal-as-sheet-body {
+  padding: 16px 20px 28px;
+  flex: 1;
+  overflow-y: auto;
 }
 @keyframes splito-fadeIn {
   from {

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,15 @@ body {
   background: #2a2a2e;
 }
 
+/* Hide scrollbar but keep scroll (e.g. horizontal friend cards) */
+.hide-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 /* Remove increment/decrement buttons */
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {

--- a/app/groups/[id]/layout.tsx
+++ b/app/groups/[id]/layout.tsx
@@ -201,9 +201,7 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
           group={group}
         />
 
-        <div
-          className="p-4 pt-0 sm:pt-0 sm:p-7"
-        >
+        <div className="p-4 pt-0 sm:pt-0 sm:p-7">
           {children}
         </div>
 

--- a/app/groups/[id]/members/page.tsx
+++ b/app/groups/[id]/members/page.tsx
@@ -85,29 +85,25 @@ export default function GroupMembersPage() {
               style={{ transition: "background 0.15s" }}
             >
               <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 14,
-                  padding: "15px 22px",
-                }}
+                className="flex items-center gap-3 sm:gap-[14px] px-4 py-4 sm:px-[22px] sm:py-[15px]"
+                style={{ minHeight: 72 }}
               >
                 <Avatar
                   init={getInit(member.user.name)}
                   color={color}
                   size={42}
                 />
-                <div style={{ flex: 1 }}>
-                  <p style={{ fontWeight: 700, fontSize: 14, color: T.bright }}>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-bold text-white truncate" style={{ color: T.bright, fontSize: 14 }}>
                     {isCurrentUser
                       ? `${member.user.name ?? "You"} (you)`
                       : member.user.name ?? "Member"}
                   </p>
                   <p
+                    className="text-xs mt-0.5 truncate"
                     style={{
                       fontSize: 12,
                       color: T.muted,
-                      marginTop: 3,
                       fontWeight: 500,
                     }}
                   >
@@ -117,17 +113,17 @@ export default function GroupMembersPage() {
                     </span>
                   </p>
                 </div>
-                {!isCurrentUser && (
-                  <div style={{ display: "flex", gap: 7 }}>
+                {!isCurrentUser ? (
+                  <div className="flex items-center gap-1.5 sm:gap-2 flex-shrink-0">
                     <Btn
                       onClick={() => openSettle(member.user.id)}
                       variant="ghost"
                       style={{
-                        padding: "8px 14px",
-                        fontSize: 12,
+                        padding: "6px 10px",
+                        fontSize: 11,
                         display: "flex",
                         alignItems: "center",
-                        gap: 5,
+                        gap: 4,
                         fontWeight: 700,
                       }}
                     >
@@ -142,11 +138,11 @@ export default function GroupMembersPage() {
                       }
                       variant="ghost"
                       style={{
-                        padding: "8px 14px",
-                        fontSize: 12,
+                        padding: "6px 10px",
+                        fontSize: 11,
                         display: "flex",
                         alignItems: "center",
-                        gap: 5,
+                        gap: 4,
                         fontWeight: 600,
                       }}
                     >
@@ -156,7 +152,7 @@ export default function GroupMembersPage() {
                       <button
                         type="button"
                         onClick={() => handleRemoveMember(member.user.id)}
-                        className="shrink-0 flex items-center justify-center w-9 h-9 sm:w-[36px] sm:h-[36px] rounded-xl"
+                        className="hidden sm:flex items-center justify-center w-9 h-9 rounded-xl shrink-0"
                         style={{
                           background: "rgba(248,113,113,0.06)",
                           border: "1px solid rgba(248,113,113,0.15)",
@@ -169,6 +165,13 @@ export default function GroupMembersPage() {
                       </button>
                     )}
                   </div>
+                ) : (
+                  <span
+                    className="flex-shrink-0 text-[11px] font-semibold px-2.5 py-1 rounded-lg sm:text-xs sm:px-3 sm:py-1.5"
+                    style={{ color: T.muted, background: "rgba(255,255,255,0.06)" }}
+                  >
+                    You
+                  </span>
                 )}
               </div>
             </div>

--- a/app/groups/[id]/splits/page.tsx
+++ b/app/groups/[id]/splits/page.tsx
@@ -99,15 +99,15 @@ function ExpenseRow({
 
   return (
     <div style={{ borderBottom: isLast ? "none" : "1px solid rgba(255,255,255,0.06)" }}>
-        <button
+      <button
           type="button"
           onClick={() => setExpanded((e) => !e)}
-        className="w-full text-left transition-colors hover:bg-white/[0.02]"
+          className="w-full text-left transition-colors hover:bg-white/[0.02]"
         style={{
           display: "flex",
           alignItems: "center",
           gap: 14,
-          padding: "16px 22px",
+          padding: "18px 20px",
           cursor: "pointer",
         }}
       >
@@ -115,9 +115,9 @@ function ExpenseRow({
           style={{
             width: 48,
             height: 48,
-            background: categoryStyle.bg,
+            background: "rgba(20,20,20,1)",
             border: "1px solid rgba(255,255,255,0.09)",
-            borderRadius: 14,
+            borderRadius: 16,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -128,18 +128,18 @@ function ExpenseRow({
           {categoryStyle.icon}
           </div>
           <div className="min-w-0 flex-1">
-          <p style={{ fontWeight: 700, fontSize: 14, color: T.bright, marginBottom: 4 }}>
+            <p style={{ fontWeight: 700, fontSize: 15, color: T.bright, marginBottom: 2 }}>
             {expense.name}
-          </p>
-          <p style={{ fontSize: 12, color: T.muted, fontWeight: 500 }}>
-            Paid by {paidByName} · {settledLabel}
-          </p>
-              </div>
+            </p>
+            <p style={{ fontSize: 12, color: T.muted, fontWeight: 500 }}>
+              Paid by {paidByName} · {settledLabel}
+            </p>
+          </div>
         <div style={{ textAlign: "right", flexShrink: 0, marginRight: 8 }}>
           <p
             style={{
               fontWeight: 800,
-              fontSize: 15,
+              fontSize: 17,
               color: T.bright,
               fontFamily: "'DM Mono',monospace",
             }}
@@ -153,6 +153,7 @@ function ExpenseRow({
           )}
         </div>
         <span
+          className="sm:!flex  !hidden"
           style={{
             color: T.dim,
             display: "flex",
@@ -292,7 +293,12 @@ export default function GroupSplitsPage() {
         byDate.map(([dateLabel, dateExpenses]) => (
           <section key={dateLabel} style={{ marginBottom: 24 }}>
             <SectionLabel>{dateLabel}</SectionLabel>
-            <Card style={{ padding: 0 }}>
+            <Card
+              style={{
+                padding: 0,
+                borderRadius: 24,
+              }}
+            >
               {dateExpenses.map((expense, idx) => (
                 <ExpenseRow
                   key={expense.id}

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -26,8 +26,9 @@ export default function GroupsPage() {
 
   return (
     <div className="flex-1 flex flex-col min-w-0">
+      {/* Desktop sticky header (unchanged) */}
       <div
-        className="flex items-center justify-between sticky top-0 z-10 px-4 sm:px-7 h-14 sm:h-[70px] border-b border-white/[0.07] bg-[#0b0b0b]/95 backdrop-blur-xl"
+        className="hidden sm:flex items-center justify-between sticky top-0 z-10 px-7 h-[70px] border-b border-white/[0.07] bg-[#0b0b0b]/95 backdrop-blur-xl"
       >
         <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.02em] text-white">
           My Groups
@@ -41,6 +42,23 @@ export default function GroupsPage() {
         </button>
       </div>
       <div className="flex-1 overflow-y-auto p-4 sm:p-7">
+        {/* Mobile status bar + header, mirroring mobile design spec */}
+        <div className="sm:hidden mb-3">
+          {/* Status bar */}
+         
+          {/* Page header */}
+          <div className=" pb-2 px-0">
+            <p
+              className="text-[13px] font-medium"
+              style={{ color: T.muted }}
+            >
+              Your groups
+            </p>
+            <h1 className="text-[26px] font-black tracking-[-0.04em] text-white mt-1">
+              Groups
+            </h1>
+          </div>
+        </div>
         <div
           style={{
             display: "flex",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { Toaster } from "sonner";
 import { OnboardingGate } from "@/components/onboarding-gate";
 import { PersonalMobileNav } from "@/components/personal-mobile-nav";
 import { OrganizationMobileNav } from "@/components/organization-mobile-nav";
+import { MobileFAB } from "@/components/mobile-fab";
 
 const instrumentSans = Instrument_Sans({
   subsets: ["latin"],
@@ -57,6 +58,7 @@ export default function RootLayout({
                 <MobileMenuToggle />
                 {isPersonalMode && <PersonalMobileNav />}
                 {isOrganizationMode && <OrganizationMobileNav />}
+                {isPersonalMode && <MobileFAB />}
                 <div className="min-[1025px]:pl-[226px] min-h-screen flex flex-col">
                   <main className="flex-1 bg-[#0b0b0b] min-h-screen relative flex flex-col min-w-0">
                     <div

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -727,7 +727,7 @@ export default function Page() {
             ) : (friends ?? []).length === 0 ? (
               <p style={{ color: T.muted, fontSize: 13, padding: "8px 0" }}>No friends yet</p>
             ) : (
-              <div style={{ display: "flex", gap: 10, overflowX: "auto", paddingBottom: 4 }}>
+              <div className="hide-scrollbar" style={{ display: "flex", gap: 10, overflowX: "auto", paddingBottom: 4 }}>
                 {(friends ?? []).map((friend) => {
                   const friendInit =
                     friend.name

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useMemo } from "react";
 import { useWallet } from "@/hooks/useWallet";
 import { SettleDebtsModal } from "@/components/settle-debts-modal";
 import { FriendsBreakdownModal } from "@/components/friends-breakdown-modal";
-import { AddFriendsModal } from "@/components/add-friends-modal";
 import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
 import { useAnalytics } from "@/features/analytics/hooks/use-analytics";
 import { useReminders } from "@/features/reminders/hooks/use-reminders";
@@ -222,6 +221,46 @@ function GroupBalanceShort({
   );
 }
 
+/** Mobile group card balance cell: shows net + label ("owed to you" / "you owe" / "settled") */
+function GroupBalanceMobileCell({
+  group,
+  userId,
+  defaultCurrency,
+}: {
+  group: { groupBalances?: { userId: string; currency: string; amount: number }[] };
+  userId: string | null;
+  defaultCurrency: string;
+}) {
+  const oweItems =
+    !userId || !group.groupBalances?.length
+      ? []
+      : group.groupBalances
+          .filter((b) => b.userId === userId && b.amount > 0)
+          .map((b) => ({ amount: b.amount, currency: b.currency }));
+  const owedItems =
+    !userId || !group.groupBalances?.length
+      ? []
+      : group.groupBalances
+          .filter((b) => b.userId === userId && b.amount < 0)
+          .map((b) => ({ amount: Math.abs(b.amount), currency: b.currency }));
+  const { total: oweTotal, isLoading: loadOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
+  const { total: owedTotal, isLoading: loadOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
+  if (loadOwe || loadOwed)
+    return <span style={{ color: "#888", fontSize: 14 }}>…</span>;
+  const net = (owedTotal ?? 0) - (oweTotal ?? 0);
+  const color = net > 0 ? G : net < 0 ? "#F87171" : T.dim;
+  const prefix = net > 0 ? "+" : net < 0 ? "-" : "±";
+  const label = net > 0 ? "owed to you" : net < 0 ? "you owe" : "settled";
+  return (
+    <div style={{ textAlign: "right" }}>
+      <p style={{ fontSize: 17, fontWeight: 800, fontFamily: "var(--font-dm-mono,monospace)", color }}>
+        {prefix}{formatCurrency(Math.abs(net), defaultCurrency)}
+      </p>
+      <p style={{ fontSize: 11, color: T.sub, marginTop: 2 }}>{label}</p>
+    </div>
+  );
+}
+
 /** Single friend card for Friends Balance: avatar, name, "Owes you $X" (green) or "You owe $X" (red) */
 function FriendBalanceCard({
   friendName,
@@ -324,7 +363,6 @@ export default function Page() {
   const [isSettleModalOpen, setIsSettleModalOpen] = useState(false);
   const [isFriendsBreakdownModalOpen, setIsFriendsBreakdownModalOpen] =
     useState(false);
-  const [isAddFriendModalOpen, setIsAddFriendModalOpen] = useState(false);
   const [settleFriendId, setSettleFriendId] = useState<string | null>(null);
   const [settleFriendGroupId, setSettleFriendGroupId] = useState<string | null>(
     null
@@ -468,161 +506,361 @@ export default function Page() {
 
   return (
     <div className="flex-1 flex flex-col min-w-0">
-      {/* Sticky header – design, responsive padding */}
+      {/* Sticky header – desktop only */}
       <div
-        className="border-b border-white/[0.07] px-7 flex items-center h-[70px] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
+        className="hidden sm:block border-b border-white/[0.07] sticky top-0 bg-[#0b0b0b]/95 backdrop-blur-xl z-10"
       >
-        <h1 className="text-[20px] font-extrabold tracking-[-0.02em] text-white">
-          Dashboard
-        </h1>
+        <div className="flex px-7 items-center h-[70px]">
+          <h1 className="text-[20px] font-extrabold tracking-[-0.02em] text-white">
+            Dashboard
+          </h1>
+        </div>
       </div>
 
       <div className="flex-1 p-4 sm:p-7 overflow-y-auto">
-        {/* Balance hero – design, responsive */}
+        {/* ── Mobile status bar + header (matches splito mobile spec) ── */}
+        <div className="sm:hidden mb-3">
+          {/* Status bar */}
+         
+          {/* Page header */}
+          <div className="pb-2 px-0">
+            <p
+              className="text-[13px] font-medium"
+              style={{ color: T.muted }}
+            >
+              Good morning,
+            </p>
+            <h1 className="text-[26px] font-black tracking-[-0.04em] text-white mt-1">
+              <span className="text-[#22D3EE]">splito</span>
+            </h1>
+          </div>
+        </div>
+
+        {/* Balance hero – mobile uses net + 2-stat layout; desktop uses 3-stat layout */}
         <div
-            id="dashboard-overall-balance"
+          id="dashboard-overall-balance"
           className="rounded-2xl sm:rounded-3xl border border-white/[0.09] p-4 sm:p-7 mb-5 sm:mb-7 relative overflow-hidden"
           style={{
-            background: "linear-gradient(135deg, #111 0%, #0e0e0e 50%, #0f0f0f 100%)",
-            boxShadow: "0 8px 40px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.06)",
+            background: "linear-gradient(135deg, #141414 0%, #0f0f0f 100%)",
+            boxShadow: "0 8px 40px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.04)",
           }}
         >
           <div
             className="absolute -top-10 -right-10 w-[200px] h-[200px] rounded-full pointer-events-none"
-            style={{
-              background: netOwed >= 0 ? `${G}08` : "#F871710a",
-            }}
+            style={{ background: netOwed >= 0 ? `${G}09` : "#F8717109" }}
           />
-          <p
-            className="text-[11px] sm:text-[12px] font-bold tracking-[0.08em] uppercase mb-2.5"
-            style={{ color: T.muted }}
-          >
-            Overall balance
-          </p>
-          <p className="text-[22px] sm:text-[26px] font-extrabold tracking-[-0.02em] text-white mb-1">
-            {isGroupsLoading ? (
-              <span className="flex items-center gap-2">
-                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
-                Loading…
-              </span>
-            ) : youOwe.length > 0 ? (
-              <>
-                Overall, you owe{" "}
-                <span style={{ color: "#F87171" }}>
-                  {overallOweLoading ? "…" : formatCurrency(overallOweTotal, defaultCurrency)}
-                </span>
-              </>
-            ) : youGet.length > 0 ? (
-              <>
-                Overall, you are owed{" "}
-                <span style={{ color: G }}>
-                  +{overallGetLoading ? "…" : formatCurrency(overallGetTotal, defaultCurrency)}
-                </span>
-              </>
-            ) : (
-              <span style={{ color: G }}>All settled ✓</span>
-            )}
-          </p>
-          <div
-            className="h-px my-[22px]"
-            style={{ background: "rgba(255,255,255,0.07)" }}
-          />
-          <div className="grid grid-cols-3 gap-0">
-            {[
-              [
-                "You owed this month",
-                isAnalyticsLoading || owedConvLoading
-                  ? "…"
-                  : formatCurrency(owedConverted, defaultCurrency),
-              ],
-              [
-                "You lent this month",
-                isAnalyticsLoading || lentConvLoading
-                  ? "…"
-                  : formatCurrency(lentConverted, defaultCurrency),
-              ],
-              [
-                "You settled this month",
-                isAnalyticsLoading || settledConvLoading
-                  ? "…"
-                  : settledThisMonth === 0 ? "$0.00" : formatCurrency(settledConverted, defaultCurrency),
-              ],
-            ].map(([label, value], i, arr) => (
-              <div
-                key={String(label)}
-                className={`min-w-0 ${i < arr.length - 1 ? "pr-2 sm:pr-[28px] border-r border-white/[0.07]" : ""} ${i > 0 ? "pl-2 sm:pl-[28px]" : ""} text-left`}
-              >
-                <p
-                  className="text-[10px] sm:text-[11px] mb-2 sm:mb-2.5 font-semibold tracking-[0.04em] truncate"
-                  style={{ color: T.muted }}
-                >
-                  {label}
-                </p>
-                <p
-                  className="text-[14px] sm:text-[22px] font-extrabold tracking-[-0.02em] font-dm-mono truncate"
-                  style={{ color: "#e8e8e8" }}
-                >
-                  {value}
-                </p>
-              </div>
-            ))}
-          </div>
-      </div>
 
-        {/* Your Groups + Recent Activity – design grid, responsive */}
-        <div
-          className="grid gap-4 sm:gap-5 mb-5 sm:mb-7"
-          style={{
-            gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
-          }}
-        >
-          <Card className="p-4 sm:p-[22px]">
-            <div className="flex justify-between items-center mb-4">
-              <SectionLabel>Your Groups</SectionLabel>
-              <span
-                className="text-[11px] font-bold rounded-full px-2.5 py-1 border border-white/[0.09]"
-                style={{ color: T.muted, background: "rgba(255,255,255,0.06)" }}
-              >
-                {groups?.length ?? 0} groups
-              </span>
+          {/* ── Mobile layout ─────────────────────────────────── */}
+          <div className="sm:hidden">
+            <p
+              className="text-[11px] font-bold tracking-[0.1em] uppercase mb-2"
+              style={{ color: T.muted }}
+            >
+              Net Balance
+            </p>
+            {isGroupsLoading ? (
+              <div className="flex items-center gap-2 mb-1">
+                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+                <span className="text-white/60 text-sm">Loading…</span>
+              </div>
+            ) : (
+              <>
+                <p
+                  className="text-[36px] font-black tracking-[-0.04em] mb-1"
+                  style={{
+                    color: netOwed >= 0 ? G : "#F87171",
+                  }}
+                >
+                  {netOwed >= 0 ? "+" : "-"}
+                  {overallGetLoading || overallOweLoading
+                    ? "…"
+                    : formatCurrency(Math.abs(netOwed), defaultCurrency)}
+                </p>
+                <p className="text-[13px] font-medium mb-5" style={{ color: T.sub }}>
+                  {netOwed >= 0 ? "overall you're owed" : "overall you owe"}
+                </p>
+              </>
+            )}
+            <div className="h-px mb-5" style={{ background: "rgba(255,255,255,0.07)" }} />
+            <div className="grid grid-cols-2 gap-0">
+              {[
+                ["You're owed", overallGetLoading ? "…" : formatCurrency(overallGetTotal, defaultCurrency), G],
+                ["You owe", overallOweLoading ? "…" : formatCurrency(overallOweTotal, defaultCurrency), "#F87171"],
+              ].map(([label, value, color], i) => (
+                <div
+                  key={String(label)}
+                  className={i === 1 ? "pl-4 border-l border-white/[0.08]" : "pr-4"}
+                >
+                  <p className="text-[10px] font-bold tracking-[0.06em] uppercase mb-1.5" style={{ color: T.dim }}>
+                    {label}
+                  </p>
+                  <p className="text-[20px] font-extrabold font-dm-mono" style={{ color: color as string }}>
+                    {value}
+                  </p>
+                </div>
+              ))}
             </div>
+          </div>
+
+          {/* ── Desktop layout (unchanged) ──────────────────────── */}
+          <div className="hidden sm:block">
+            <p
+              className="text-[12px] font-bold tracking-[0.08em] uppercase mb-2.5"
+              style={{ color: T.muted }}
+            >
+              Overall balance
+            </p>
+            <p className="text-[26px] font-extrabold tracking-[-0.02em] text-white mb-1">
+              {isGroupsLoading ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+                  Loading…
+                </span>
+              ) : youOwe.length > 0 ? (
+                <>
+                  Overall, you owe{" "}
+                  <span style={{ color: "#F87171" }}>
+                    {overallOweLoading ? "…" : formatCurrency(overallOweTotal, defaultCurrency)}
+                  </span>
+                </>
+              ) : youGet.length > 0 ? (
+                <>
+                  Overall, you are owed{" "}
+                  <span style={{ color: G }}>
+                    +{overallGetLoading ? "…" : formatCurrency(overallGetTotal, defaultCurrency)}
+                  </span>
+                </>
+              ) : (
+                <span style={{ color: G }}>All settled ✓</span>
+              )}
+            </p>
+            <div className="h-px my-[22px]" style={{ background: "rgba(255,255,255,0.07)" }} />
+            <div className="grid grid-cols-3 gap-0">
+              {[
+                ["You owed this month", isAnalyticsLoading || owedConvLoading ? "…" : formatCurrency(owedConverted, defaultCurrency)],
+                ["You lent this month", isAnalyticsLoading || lentConvLoading ? "…" : formatCurrency(lentConverted, defaultCurrency)],
+                ["You settled this month", isAnalyticsLoading || settledConvLoading ? "…" : settledThisMonth === 0 ? "$0.00" : formatCurrency(settledConverted, defaultCurrency)],
+              ].map(([label, value], i, arr) => (
+                <div
+                  key={String(label)}
+                  className={`min-w-0 ${i < arr.length - 1 ? "pr-[28px] border-r border-white/[0.07]" : ""} ${i > 0 ? "pl-[28px]" : ""} text-left`}
+                >
+                  <p className="text-[11px] mb-2.5 font-semibold tracking-[0.04em] truncate" style={{ color: T.muted }}>
+                    {label}
+                  </p>
+                  <p className="text-[22px] font-extrabold tracking-[-0.02em] font-dm-mono truncate" style={{ color: "#e8e8e8" }}>
+                    {value}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* ── MOBILE layout: groups → friends → activity ─────────── */}
+        <div className="sm:hidden">
+          {/* Your Groups */}
+          <div style={{ paddingBottom: 8 }}>
+            <SectionLabel>Your Groups</SectionLabel>
             {isGroupsLoading ? (
               <div className="flex items-center justify-center py-6">
                 <Loader2 className="h-5 w-5 animate-spin text-white/50" />
               </div>
+            ) : (groups ?? []).length === 0 ? (
+              <p style={{ color: T.muted, fontSize: 13, padding: "8px 0" }}>No groups yet</p>
             ) : (
-              (groups ?? []).slice(0, 3).map((g, i) => {
-                const userBalances = (g.groupBalances ?? []).filter(
-                  (b: { userId: string }) => b.userId === user?.id
-                );
-                const byCurr = userBalances.reduce(
-                  (acc: Record<string, number>, b: { currency: string; amount: number }) => {
-                    acc[b.currency] = (acc[b.currency] ?? 0) + b.amount;
-                    return acc;
-                  },
-                  {}
-                );
-                const oweItems = Object.entries(byCurr)
-                  .filter(([, a]) => a > 0)
-                  .map(([currency, amount]) => ({ amount, currency }));
-                const owedItems = Object.entries(byCurr)
-                  .filter(([, a]) => a < 0)
-                  .map(([currency, amount]) => ({ amount: Math.abs(amount), currency }));
+              (groups ?? []).map((g) => {
+                const memberCount = (g as { groupUsers?: unknown[] }).groupUsers?.length ?? 0;
+                const ago = formatRelativeTime(new Date((g as { updatedAt: Date }).updatedAt));
                 return (
                   <Link href={`/groups/${g.id}`} key={g.id}>
                     <div
-                      className="splito-row-hover flex items-center gap-3 py-[11px] border-b border-white/[0.06] cursor-pointer last:border-b-0"
-                      style={i < (groups.slice(0,3).length - 1) ? { borderBottom: "1px solid rgba(255,255,255,0.06)" } : {}}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 14,
+                        background: "rgba(255,255,255,0.04)",
+                        border: "1px solid rgba(255,255,255,0.08)",
+                        borderRadius: 20,
+                        padding: "15px 16px",
+                        cursor: "pointer",
+                        marginBottom: 10,
+                      }}
                     >
-                      <GroupAvatar
-                        items={groupAvatarItems(g)}
-                        size={38}
-                        radius={11}
-                      />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-[15px] font-bold text-[#f5f5f5] truncate">
+                      <GroupAvatar items={groupAvatarItems(g)} size={48} radius={15} />
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <p
+                          style={{
+                            fontSize: 15,
+                            fontWeight: 800,
+                            color: T.bright,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
                           {g.name}
                         </p>
+                        <p style={{ fontSize: 12, color: T.muted, marginTop: 3 }}>
+                          {memberCount} {memberCount === 1 ? "person" : "people"} · {ago}
+                        </p>
+                      </div>
+                      <GroupBalanceMobileCell
+                        group={g}
+                        userId={user?.id ?? null}
+                        defaultCurrency={defaultCurrency}
+                      />
+                    </div>
+                  </Link>
+                );
+              })
+            )}
+          </div>
+
+          {/* Friends – horizontal scroll */}
+          <div style={{ padding: "8px 0" }}>
+            <SectionLabel>Friends</SectionLabel>
+            {isFriendsLoading ? (
+              <div className="flex items-center justify-center py-4">
+                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+              </div>
+            ) : (friends ?? []).length === 0 ? (
+              <p style={{ color: T.muted, fontSize: 13, padding: "8px 0" }}>No friends yet</p>
+            ) : (
+              <div style={{ display: "flex", gap: 10, overflowX: "auto", paddingBottom: 4 }}>
+                {(friends ?? []).map((friend) => {
+                  const friendInit =
+                    friend.name
+                      ?.split(" ")
+                      .map((n: string) => n[0])
+                      .join("")
+                      .slice(0, 2)
+                      .toUpperCase() || "?";
+                  const color = getUserColor(friend.name);
+                  const firstName = friend.name?.split(" ")[0] ?? "Friend";
+                  return (
+                    <div
+                      key={friend.id}
+                      style={{
+                        flexShrink: 0,
+                        background: "rgba(255,255,255,0.04)",
+                        border: "1px solid rgba(255,255,255,0.08)",
+                        borderRadius: 20,
+                        padding: "16px 14px",
+                        minWidth: 110,
+                        textAlign: "center",
+                      }}
+                    >
+                      <div style={{ display: "flex", justifyContent: "center", marginBottom: 10 }}>
+                        <Avatar init={friendInit} color={color} size={40} />
+                      </div>
+                      <p style={{ fontSize: 13, fontWeight: 700, color: T.bright }}>{firstName}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Recent Activity */}
+          <div style={{ padding: "16px 0 0" }}>
+            <SectionLabel>Recent Activity</SectionLabel>
+            {isGroupsLoading || isRemindersLoading ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+              </div>
+            ) : recentActivityFromGroups.length > 0 ? (
+              <div
+                style={{
+                  background: "rgba(255,255,255,0.03)",
+                  border: "1px solid rgba(255,255,255,0.07)",
+                  borderRadius: 20,
+                  overflow: "hidden",
+                }}
+              >
+                {recentActivityFromGroups.map((a, i) => (
+                  <div
+                    key={a.id}
+                    style={{
+                      display: "flex",
+                      gap: 12,
+                      padding: "14px 16px",
+                      borderBottom:
+                        i < recentActivityFromGroups.length - 1
+                          ? "1px solid rgba(255,255,255,0.06)"
+                          : "none",
+                      alignItems: "flex-start",
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: a.dotColor,
+                        flexShrink: 0,
+                        marginTop: 5,
+                      }}
+                    />
+                    <div style={{ flex: 1 }}>
+                      <p style={{ fontSize: 13, color: T.body, lineHeight: 1.5 }}>{a.text}</p>
+                      <p style={{ fontSize: 11, color: T.sub, marginTop: 3, fontWeight: 600 }}>
+                        {a.subtext}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div
+                style={{
+                  background: "rgba(255,255,255,0.03)",
+                  border: "1px solid rgba(255,255,255,0.07)",
+                  borderRadius: 20,
+                  padding: "40px 20px",
+                  textAlign: "center",
+                }}
+              >
+                <p style={{ fontSize: 36, marginBottom: 10 }}>📋</p>
+                <p style={{ fontSize: 14, fontWeight: 700, color: T.body }}>No recent activity</p>
+                <p style={{ fontSize: 12, color: T.muted, marginTop: 4 }}>
+                  Expenses from your groups will appear here
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* ── DESKTOP layout: groups+activity grid, then friends balance ─ */}
+        <div className="hidden sm:block">
+          <div
+            className="grid gap-5 mb-7"
+            style={{ gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))" }}
+          >
+            <Card className="p-[22px]">
+              <div className="flex justify-between items-center mb-4">
+                <SectionLabel>Your Groups</SectionLabel>
+                <span
+                  className="text-[11px] font-bold rounded-full px-2.5 py-1 border border-white/[0.09]"
+                  style={{ color: T.muted, background: "rgba(255,255,255,0.06)" }}
+                >
+                  {groups?.length ?? 0} groups
+                </span>
+              </div>
+              {isGroupsLoading ? (
+                <div className="flex items-center justify-center py-6">
+                  <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+                </div>
+              ) : (
+                (groups ?? []).slice(0, 3).map((g, i) => (
+                  <Link href={`/groups/${g.id}`} key={g.id}>
+                    <div
+                      className="splito-row-hover flex items-center gap-3 py-[11px] border-b border-white/[0.06] cursor-pointer last:border-b-0"
+                      style={i < Math.min(groups.length, 3) - 1 ? { borderBottom: "1px solid rgba(255,255,255,0.06)" } : {}}
+                    >
+                      <GroupAvatar items={groupAvatarItems(g)} size={38} radius={11} />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[15px] font-bold text-[#f5f5f5] truncate">{g.name}</p>
                         <p className="text-[13px] font-semibold" style={{ color: T.muted }}>
                           {(Array.isArray((g as { expenses?: unknown[] }).expenses)
                             ? (g as { expenses: unknown[] }).expenses.length
@@ -635,133 +873,92 @@ export default function Page() {
                         userId={user?.id ?? null}
                         defaultCurrency={defaultCurrency}
                       />
-          </div>
+                    </div>
                   </Link>
-                );
-              })
-            )}
-            {groups?.length === 0 && !isGroupsLoading && (
-              <p className="text-sm text-white/60 py-2">No groups yet</p>
-            )}
-          </Card>
+                ))
+              )}
+              {groups?.length === 0 && !isGroupsLoading && (
+                <p className="text-sm text-white/60 py-2">No groups yet</p>
+              )}
+            </Card>
 
-          <Card className="p-[22px] min-h-[200px] flex flex-col">
-            <SectionLabel>Recent Activity</SectionLabel>
-            {isGroupsLoading || isRemindersLoading ? (
-              <div className="flex justify-center py-8 flex-1 items-center">
-                <Loader2 className="h-5 w-5 animate-spin text-white/50" />
-              </div>
-            ) : recentActivityFromGroups.length > 0 ? (
-              <div className="flex flex-col">
-                {recentActivityFromGroups.map((a) => (
-                  <div
-                    key={a.id}
-                    className="flex gap-3 py-[9px] border-b border-white/[0.06] last:border-b-0"
-                  >
-                    <div
-                      className="w-2 h-2 rounded-full flex-shrink-0 mt-[5px]"
-                      style={{ background: a.dotColor }}
-                    />
-                    <div className="min-w-0">
-                      <p className="text-[13px] font-[500] text-[#d4d4d4] leading-snug">
-                        {a.text}
-                      </p>
-                      <p className="text-[11px] mt-0.5 font-[600]" style={{ color: T.sub }}>
-                        {a.subtext}
-                      </p>
+            <Card className="p-[22px] min-h-[200px] flex flex-col">
+              <SectionLabel>Recent Activity</SectionLabel>
+              {isGroupsLoading || isRemindersLoading ? (
+                <div className="flex justify-center py-8 flex-1 items-center">
+                  <Loader2 className="h-5 w-5 animate-spin text-white/50" />
+                </div>
+              ) : recentActivityFromGroups.length > 0 ? (
+                <div className="flex flex-col">
+                  {recentActivityFromGroups.map((a) => (
+                    <div key={a.id} className="flex gap-3 py-[9px] border-b border-white/[0.06] last:border-b-0">
+                      <div className="w-2 h-2 rounded-full flex-shrink-0 mt-[5px]" style={{ background: a.dotColor }} />
+                      <div className="min-w-0">
+                        <p className="text-[13px] font-[500] text-[#d4d4d4] leading-snug">{a.text}</p>
+                        <p className="text-[11px] mt-0.5 font-[600]" style={{ color: T.sub }}>{a.subtext}</p>
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
+              ) : (reminders ?? []).length > 0 ? (
+                <div className="flex flex-col">
+                  {(reminders ?? []).slice(0, 5).map((r) => (
+                    <div key={r.id} className="flex gap-3 py-2.5 border-b border-white/[0.06] last:border-b-0">
+                      <div className="w-2 h-2 rounded-full flex-shrink-0 mt-1.5" style={{ background: A }} />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[13px] font-medium leading-snug" style={{ color: T.body }}>{r.content || "Transaction request"}</p>
+                        <p className="text-[11px] mt-0.5 font-semibold" style={{ color: T.sub }}>{r.createdAt ? formatRelativeTime(new Date(r.createdAt)) : ""}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="flex-1 flex flex-col items-center justify-center py-8 text-center">
+                  <p className="text-[40px] mb-2" aria-hidden>📋</p>
+                  <p className="text-[13px] font-medium" style={{ color: T.body }}>No recent activity</p>
+                  <p className="text-[12px] mt-1" style={{ color: T.muted }}>Expenses and settlements from your groups will appear here</p>
+                </div>
+              )}
+            </Card>
           </div>
-            ) : (reminders ?? []).length > 0 ? (
-              <div className="flex flex-col">
-                {(reminders ?? []).slice(0, 5).map((r) => (
-                  <div
-                    key={r.id}
-                    className="flex gap-3 py-2.5 border-b border-white/[0.06] last:border-b-0"
-                  >
-                    <div
-                      className="w-2 h-2 rounded-full flex-shrink-0 mt-1.5"
-                      style={{ background: A }}
-                    />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-[13px] font-medium leading-snug" style={{ color: T.body }}>
-                        {r.content || "Transaction request"}
-                      </p>
-                      <p className="text-[11px] mt-0.5 font-semibold" style={{ color: T.sub }}>
-                        {r.createdAt ? formatRelativeTime(new Date(r.createdAt)) : ""}
-                      </p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="flex-1 flex flex-col items-center justify-center py-8 text-center">
-                <p className="text-[40px] mb-2" aria-hidden>📋</p>
-                <p className="text-[13px] font-medium" style={{ color: T.body }}>
-                  No recent activity
-                </p>
-                <p className="text-[12px] mt-1" style={{ color: T.muted }}>
-                  Expenses and settlements from your groups will appear here
-                </p>
-              </div>
-            )}
-          </Card>
-      </div>
 
-        {/* Friends Balance – design */}
-        <div>
-          <SectionLabel>Friends Balance</SectionLabel>
-          <div
-            className="grid gap-3"
-            style={{
-              gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
-            }}
-          >
-            {isFriendsLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="h-6 w-6 animate-spin text-white/50" />
-              </div>
-            ) : (
-              (friends ?? [])
-                .filter((friend) => {
-                  const balances = friendBalancesFromGroups[friend.id] ?? [];
-                  const hasBalance = balances.some((b: { amount: number }) => b.amount !== 0);
-                  return hasBalance;
-                })
-                .map((friend, index) => {
-                  const balances = friendBalancesFromGroups[friend.id] ?? [];
-                  const oweItems = balances
-                    .filter((b: { amount: number }) => b.amount > 0)
-                    .map((b: { amount: number; currency: string }) => ({
-                      amount: b.amount,
-                      currency: b.currency,
-                    }));
-                  const owedItems = balances
-                    .filter((b: { amount: number }) => b.amount < 0)
-                    .map((b: { amount: number; currency: string }) => ({
-                      amount: Math.abs(b.amount),
-                      currency: b.currency,
-                    }));
-                  const friendInit =
-                    friend.name?.split(" ").map((n) => n[0]).join("").slice(0, 2).toUpperCase() || "?";
-                  const color = getUserColor(friend.name);
-                  return (
-                    <FriendBalanceCard
-                      key={friend.id}
-                      friendName={friend.name ?? "Friend"}
-                      friendInit={friendInit}
-                      color={color}
-                      oweItems={oweItems}
-                      owedItems={owedItems}
-                      defaultCurrency={defaultCurrency}
-                    />
-                  );
-                })
-            )}
-            {(!friends || friends.length === 0) && !isFriendsLoading && (
-              <p className="text-sm text-white/60 col-span-full py-4">No friends with balances</p>
-            )}
+          {/* Friends Balance – desktop grid */}
+          <div>
+            <SectionLabel>Friends Balance</SectionLabel>
+            <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+              {isFriendsLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin text-white/50" />
+                </div>
+              ) : (
+                (friends ?? [])
+                  .filter((friend) => {
+                    const balances = friendBalancesFromGroups[friend.id] ?? [];
+                    return balances.some((b: { amount: number }) => b.amount !== 0);
+                  })
+                  .map((friend) => {
+                    const balances = friendBalancesFromGroups[friend.id] ?? [];
+                    const oweItems = balances.filter((b: { amount: number }) => b.amount > 0).map((b: { amount: number; currency: string }) => ({ amount: b.amount, currency: b.currency }));
+                    const owedItems = balances.filter((b: { amount: number }) => b.amount < 0).map((b: { amount: number; currency: string }) => ({ amount: Math.abs(b.amount), currency: b.currency }));
+                    const friendInit = friend.name?.split(" ").map((n: string) => n[0]).join("").slice(0, 2).toUpperCase() || "?";
+                    const color = getUserColor(friend.name);
+                    return (
+                      <FriendBalanceCard
+                        key={friend.id}
+                        friendName={friend.name ?? "Friend"}
+                        friendInit={friendInit}
+                        color={color}
+                        oweItems={oweItems}
+                        owedItems={owedItems}
+                        defaultCurrency={defaultCurrency}
+                      />
+                    );
+                  })
+              )}
+              {(!friends || friends.length === 0) && !isFriendsLoading && (
+                <p className="text-sm text-white/60 col-span-full py-4">No friends with balances</p>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -787,10 +984,6 @@ export default function Page() {
         }}
       />
 
-      <AddFriendsModal
-        isOpen={isAddFriendModalOpen}
-        onClose={() => setIsAddFriendModalOpen(false)}
-      />
     </div>
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -16,6 +16,8 @@ import {
   useRemoveWallet,
 } from "@/features/wallets/hooks/use-wallets";
 import { SettingsPageContent } from "@/app/settings/settings-page-content";
+import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
+import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 
 // Base API URL
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
@@ -308,6 +310,9 @@ export default function SettingsPage() {
     }
   };
 
+  const { data: allGroups = [] } = useGetAllGroups({ type: "PERSONAL" });
+  const { data: allFriends = [] } = useGetFriends();
+
   // Get chain name from currency list
   const getChainName = (chainId: string) => {
     const currency = currencies.find((c) => c.chainId === chainId);
@@ -362,5 +367,10 @@ export default function SettingsPage() {
     isLoadingWallets,
     onLogout: handleLogout,
     isLoggingOut: isLoggingOut,
+    groupCount: allGroups.length,
+    friendCount: Array.isArray(allFriends) ? allFriends.length : 0,
+    settledCount: Array.isArray(allFriends)
+      ? allFriends.filter((f) => !f.balances?.some((b) => b.amount !== 0)).length
+      : 0,
   });
 }

--- a/app/settings/settings-page-content.tsx
+++ b/app/settings/settings-page-content.tsx
@@ -46,7 +46,16 @@ export interface SettingsPageContentProps {
   isLoadingWallets: boolean;
   onLogout?: () => void;
   isLoggingOut?: boolean;
+  groupCount?: number;
+  friendCount?: number;
+  settledCount?: number;
 }
+
+// Simple currency → flag emoji map
+const CURRENCY_FLAG: Record<string, string> = {
+  USD: "🇺🇸", EUR: "🇪🇺", GBP: "🇬🇧", JPY: "🇯🇵",
+  INR: "🇮🇳", CNY: "🇨🇳", AUD: "🇦🇺", CAD: "🇨🇦", CHF: "🇨🇭",
+};
 
 export function SettingsPageContent(props: SettingsPageContentProps) {
   const {
@@ -78,10 +87,14 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
     isLoadingWallets,
     onLogout,
     isLoggingOut = false,
+    groupCount = 0,
+    friendCount = 0,
+    settledCount = 0,
   } = props;
 
   const [notificationsOn, setNotificationsOn] = React.useState(true);
   const [isMobile, setIsMobile] = React.useState(false);
+  const [editingProfile, setEditingProfile] = React.useState(false);
 
   React.useEffect(() => {
     const mq = window.matchMedia("(max-width: 767px)");
@@ -91,25 +104,93 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
     return () => mq.removeEventListener("change", set);
   }, []);
 
-  const SLabel = ({ children, style = {} }: { children: React.ReactNode; style?: React.CSSProperties }) => (
-    <div
-      style={{
-        color: T.soft,
-        fontSize: 11,
-        fontWeight: 700,
-        letterSpacing: "0.1em",
-        textTransform: "uppercase",
-        marginBottom: 14,
-        marginTop: 28,
-        paddingBottom: 10,
-        borderBottom: "1px solid rgba(255,255,255,0.07)",
-        ...style,
-      }}
-    >
-      {children}
-    </div>
-  );
+  const userEmail = user?.email ?? "";
+  const userInitial = (displayName || user?.name || "Y").charAt(0).toUpperCase();
+  const userColor = getUserColor(user?.name || "You");
+  const currencyFlag = CURRENCY_FLAG[preferredCurrency] ?? "💱";
 
+  // Chain metadata
+  const CHAIN_META: Record<string, { color: string; icon: string }> = {
+    Aptos: { color: "#22D3EE", icon: "⬡" },
+    Ethereum: { color: "#818CF8", icon: "◆" },
+    Base: { color: "#3B82F6", icon: "🔵" },
+    Solana: { color: "#A78BFA", icon: "◎" },
+    Stellar: { color: "#34D399", icon: "✦" },
+    Polygon: { color: "#A855F7", icon: "⬟" },
+  };
+
+  const getChainMeta = (chainName: string) =>
+    CHAIN_META[chainName] || { color: "#666", icon: "◆" };
+
+  // Shared avatar upload
+  function AvatarUpload({ id, size }: { id: string; size: number }) {
+    return (
+      <div style={{ position: "relative" }}>
+        <label htmlFor={id} style={{ cursor: isUploadingImage ? "not-allowed" : "pointer", display: "block" }}>
+          <div
+            style={{
+              width: size,
+              height: size,
+              borderRadius: "50%",
+              background: `${userColor}1a`,
+              border: `2.5px solid ${userColor}55`,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: size * 0.32,
+              fontWeight: 800,
+              color: userColor,
+              overflow: "hidden",
+            }}
+          >
+            {user.image ? (
+              <Image src={user.image} alt="Profile" width={size} height={size} className="h-full w-full object-cover" />
+            ) : (
+              <span>{userInitial}</span>
+            )}
+          </div>
+          {isUploadingImage && (
+            <div style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "rgba(0,0,0,0.7)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+              <Loader2 className="h-5 w-5 animate-spin text-white" />
+              <span style={{ fontSize: 10, color: "#fff" }}>{uploadProgress}%</span>
+            </div>
+          )}
+          <button
+            type="button"
+            style={{
+              position: "absolute",
+              bottom: 0,
+              right: 0,
+              width: size * 0.3,
+              height: size * 0.3,
+              borderRadius: "50%",
+              background: "#1e1e1e",
+              border: "2px solid rgba(255,255,255,0.18)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: isUploadingImage ? "not-allowed" : "pointer",
+              color: T.body,
+            }}
+            onClick={(e) => { e.preventDefault(); document.getElementById(id)?.click(); }}
+          >
+            {Icons.camera({ size: Math.round(size * 0.15) })}
+          </button>
+          <input
+            id={id}
+            type="file"
+            accept="image/png, image/jpeg"
+            className="hidden"
+            disabled={isUploadingImage}
+            onChange={(e) => { const file = e.target.files?.[0]; if (file) handleImageUpload(file); }}
+          />
+        </label>
+        {uploadError && <p style={{ fontSize: 11, color: "#F87171", marginTop: 4, textAlign: "center" }}>{uploadError}</p>}
+      </div>
+    );
+  }
+
+  // Desktop Row component
   const Row = ({
     children,
     style = {},
@@ -135,20 +216,34 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
     </div>
   );
 
-  const Toggle = ({
-    on,
-    onChange,
-  }: {
-    on: boolean;
-    onChange: () => void;
-  }) => (
+  // Section label
+  const SLabel = ({ children, style = {} }: { children: React.ReactNode; style?: React.CSSProperties }) => (
+    <div
+      style={{
+        color: T.soft,
+        fontSize: 11,
+        fontWeight: 700,
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        marginBottom: 14,
+        marginTop: 28,
+        paddingBottom: 10,
+        borderBottom: "1px solid rgba(255,255,255,0.07)",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  const Toggle = ({ on, onChange }: { on: boolean; onChange: () => void }) => (
     <div
       onClick={onChange}
       role="switch"
       aria-checked={on}
       style={{
-        width: 44,
-        height: 26,
+        width: 50,
+        height: 30,
         borderRadius: 99,
         background: on ? A : "rgba(255,255,255,0.1)",
         cursor: "pointer",
@@ -159,13 +254,13 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
     >
       <div
         style={{
-          width: 20,
-          height: 20,
+          width: 24,
+          height: 24,
           borderRadius: "50%",
           background: "#fff",
           position: "absolute",
           top: 3,
-          left: on ? 21 : 3,
+          left: on ? 23 : 3,
           transition: "left 0.25s",
           boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
         }}
@@ -173,345 +268,508 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
     </div>
   );
 
-  const userEmail = user?.email ?? "";
-  const userInitial = (displayName || user?.name || "Y").charAt(0).toUpperCase();
+  // Mobile section card wrapper
+  const MobileCard = ({ children, style = {} }: { children: React.ReactNode; style?: React.CSSProperties }) => (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderRadius: 20,
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
 
-  // Chain metadata (matching design artifact)
-  const CHAIN_META: Record<string, { color: string; icon: string }> = {
-    Aptos: { color: "#22D3EE", icon: "⬡" },
-    Ethereum: { color: "#818CF8", icon: "◆" },
-    Base: { color: "#3B82F6", icon: "🔵" },
-    Solana: { color: "#A78BFA", icon: "◎" },
-    Stellar: { color: "#34D399", icon: "✦" },
-    Polygon: { color: "#A855F7", icon: "⬟" },
-  };
+  // Mobile row inside a card
+  const MobileRow = ({
+    children,
+    last = false,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    last?: boolean;
+    onClick?: () => void;
+  }) => (
+    <div
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "18px 20px",
+        borderBottom: last ? "none" : "1px solid rgba(255,255,255,0.06)",
+        cursor: onClick ? "pointer" : undefined,
+      }}
+    >
+      {children}
+    </div>
+  );
 
-  const getChainMeta = (chainName: string) => {
-    return CHAIN_META[chainName] || { color: "#666", icon: "◆" };
-  };
+  // Section label for mobile
+  const MSLabel = ({ children }: { children: React.ReactNode }) => (
+    <p
+      style={{
+        color: "#666",
+        fontSize: 11,
+        fontWeight: 700,
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        marginBottom: 10,
+        marginTop: 28,
+      }}
+    >
+      {children}
+    </p>
+  );
 
   return (
     <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-      <div style={{ borderBottom: "1px solid rgba(255,255,255,0.07)", padding: "0 28px", display: "flex", alignItems: "center", height: 70, position: "sticky", top: 0, background: "rgba(11,11,11,0.95)", backdropFilter: "blur(20px)", zIndex: 40 }}>
-        <h1 style={{ fontSize: 20, fontWeight: 800, letterSpacing: "-0.02em", color: "#fff" }}>Settings</h1>
+      {/* Sticky header */}
+      <div className="hidden sm:block" style={{ borderBottom: "1px solid rgba(255,255,255,0.07)", position: "sticky", top: 0, background: "rgba(11,11,11,0.95)", backdropFilter: "blur(20px)", zIndex: 40 }}>
+        <div className="flex items-center" style={{ padding: "0 28px", height: 70 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 800, letterSpacing: "-0.02em", color: "#fff" }}>Settings</h1>
+        </div>
       </div>
-      <div style={{ flex: 1, padding: "26px 28px", overflowY: "auto", maxWidth: 660 }}>
-          <SLabel>Profile</SLabel>
-          <Card style={{ padding: "22px", marginBottom: 4 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 22, paddingBottom: 22, borderBottom: "1px solid rgba(255,255,255,0.07)" }}>
-              <div style={{ position: "relative" }}>
-                <label htmlFor="profile-upload" style={{ cursor: isUploadingImage ? "not-allowed" : "pointer", display: "block" }}>
-                  <div
-                    style={{
-                      width: 64,
-                      height: 64,
-                      borderRadius: "50%",
-                      background: `${getUserColor(user?.name || "You")}1a`,
-                      border: `2px solid ${getUserColor(user?.name || "You")}44`,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      fontSize: 22,
-                      fontWeight: 800,
-                      color: getUserColor(user?.name || "You"),
-                      overflow: "hidden",
-                    }}
-                  >
-                    {user.image ? (
-                      <Image src={user.image} alt="Profile" width={64} height={64} className="h-full w-full object-cover" />
-                    ) : (
-                      <span>{userInitial}</span>
-                    )}
-                  </div>
-                  {isUploadingImage && (
-                    <div style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "rgba(0,0,0,0.7)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
-                      <Loader2 className="h-5 w-5 animate-spin text-white" />
-                      <span style={{ fontSize: 10, color: "#fff" }}>{uploadProgress}%</span>
-                    </div>
-                  )}
-                  <button
-                    type="button"
-                    style={{
-                      position: "absolute",
-                      bottom: -2,
-                      right: -2,
-                      width: 24,
-                      height: 24,
-                      borderRadius: "50%",
-                      background: "#222",
-                      border: "1.5px solid rgba(255,255,255,0.15)",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      cursor: isUploadingImage ? "not-allowed" : "pointer",
-                      color: T.body,
-                    }}
-                    onClick={(e) => { e.preventDefault(); document.getElementById("profile-upload")?.click(); }}
-                  >
-                    {Icons.camera({ size: 12 })}
-                  </button>
-                  <input
-                    id="profile-upload"
-                    type="file"
-                    accept="image/png, image/jpeg"
-                    className="hidden"
-                    disabled={isUploadingImage}
-                    onChange={(e) => { const file = e.target.files?.[0]; if (file) handleImageUpload(file); }}
-                  />
-                </label>
-                {uploadError && <p style={{ fontSize: 11, color: "#F87171", margin: "4px 0 0 0" }}>{uploadError}</p>}
-              </div>
-              <div>
-                <p style={{ color: T.bright, fontSize: 16, fontWeight: 800, letterSpacing: "-0.01em" }}>{displayName || "You"}</p>
-                <p style={{ color: T.muted, fontSize: 12, fontWeight: 500, marginTop: 2 }}>{userEmail || "you@email.com"}</p>
-              </div>
-            </div>
-            <Row>
-              <span style={{ color: T.body, fontSize: 14, fontWeight: 600 }}>Display Name</span>
+
+      {/* ── MOBILE LAYOUT ── */}
+      <div className="sm:hidden flex-1 overflow-y-auto px-4 pb-10">
+        {/* Hero */}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 28, paddingBottom: 24 }}>
+          <AvatarUpload id="profile-upload-mobile" size={90} />
+          <p style={{ color: "#fff", fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em", marginTop: 16, marginBottom: 3 }}>
+            {displayName || "You"}
+          </p>
+          <p style={{ color: T.muted, fontSize: 14, fontWeight: 500, marginBottom: 18 }}>
+            {userEmail || "you@email.com"}
+          </p>
+          {editingProfile ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 10, width: "100%", maxWidth: 260, marginBottom: 4 }}>
               <input
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
-                style={{ background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", borderRadius: 12, padding: "10px 14px", color: "#fff", fontSize: 14, outline: "none", fontFamily: "inherit", width: 220, fontWeight: 500 }}
+                placeholder="Display name"
+                style={{ background: "rgba(255,255,255,0.07)", border: "1px solid rgba(255,255,255,0.13)", borderRadius: 12, padding: "11px 14px", color: "#fff", fontSize: 14, outline: "none", fontFamily: "inherit", width: "100%", fontWeight: 500 }}
               />
-            </Row>
-            <Row style={{ borderBottom: "none" }}>
-              <span style={{ color: T.body, fontSize: 14, fontWeight: 600 }}>Email</span>
-              <input
-                value={userEmail}
-                onChange={(e) => {}}
-                style={{ background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", borderRadius: 12, padding: "10px 14px", color: "#fff", fontSize: 14, outline: "none", fontFamily: "inherit", width: 220, fontWeight: 500 }}
-              />
-            </Row>
-            <div style={{ paddingTop: 18, display: "flex", justifyContent: "flex-end" }}>
               <button
-                onClick={handleSaveChanges}
+                onClick={() => { handleSaveChanges(); setEditingProfile(false); }}
                 disabled={isUpdatatingUser}
-                style={{ background: A, border: "none", borderRadius: 12, padding: "10px 22px", color: "#0a0a0a", fontWeight: 800, fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}
+                style={{ background: A, border: "none", borderRadius: 12, padding: "12px", color: "#0a0a0a", fontWeight: 800, fontSize: 14, cursor: "pointer", fontFamily: "inherit" }}
               >
-                Save Changes
+                {isUpdatatingUser ? "Saving…" : "Save"}
+              </button>
+              <button
+                onClick={() => setEditingProfile(false)}
+                style={{ background: "none", border: "none", color: T.muted, fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}
+              >
+                Cancel
               </button>
             </div>
-          </Card>
-
-          <SLabel>Preferences</SLabel>
-          <Card style={{ padding: "0 22px" }}>
-            <Row>
-              <div>
-                <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Notifications</p>
-                <p style={{ color: T.muted, fontSize: 12, marginTop: 2, fontWeight: 500 }}>Email reminders and updates</p>
-              </div>
-              <Toggle on={notificationsOn} onChange={() => setNotificationsOn((p) => !p)} />
-            </Row>
-            <Row style={{ borderBottom: "none", alignItems: "center" }}>
-              <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Default Currency</p>
-              <div style={{ minWidth: 220 }}>
-                <CurrencyDropdown
-                  selectedCurrencies={preferredCurrency ? [preferredCurrency] : []}
-                  setSelectedCurrencies={(currencies) => setPreferredCurrency(currencies[0] || "")}
-                  mode="single"
-                  showFiatCurrencies={true}
-                  filterCurrencies={(currency: Currency) => currency.symbol !== "ETH" && currency.symbol !== "USDC"}
-                  disableChainCurrencies={true}
-                />
-              </div>
-            </Row>
-          </Card>
-
-          {wallets.length > 0 && !isMobile && (
-            <>
-              <SLabel>Accept Payments in</SLabel>
-              <Card className="p-[22px] mb-4" id="settings-accept-payments-tokens">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <p style={{ color: T.muted, fontSize: 12, marginBottom: 12 }}>Select the tokens you want to accept payments in</p>
-                    </TooltipTrigger>
-                    <TooltipContent><p>Based on your connected wallets</p></TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-                <CurrencyDropdown
-                  selectedCurrencies={selectedCurrencies}
-                  setSelectedCurrencies={setSelectedCurrencies}
-                  filterCurrencies={(currency: Currency) =>
-                    currency.symbol !== "ETH" &&
-                    currency.symbol !== "USDC" &&
-                    wallets.some((w) => w.chainId === currency.chainId)
-                  }
-                  showFiatCurrencies={false}
-                />
-              </Card>
-            </>
-          )}
-
-          <SLabel>Security</SLabel>
-          <Card style={{ padding: "0 22px" }}>
-            <Row
-              style={{ borderBottom: "none", cursor: "pointer" }}
-              onClick={() => { if (typeof window !== "undefined") window.location.href = "/settings/change-password"; }}
-            >
-              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                <span style={{ color: T.body, display: "flex" }}>{Icons.shield({})}</span>
-                <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Change Password</p>
-              </div>
-              <span style={{ color: T.dim, display: "flex" }}>{Icons.chevR({})}</span>
-            </Row>
-          </Card>
-
-          <SLabel>Connected Wallets</SLabel>
-          <Card style={{ marginBottom: 4 }}>
-            {isLoadingWallets ? (
-              <div style={{ display: "flex", justifyContent: "center", padding: "28px" }}>
-                <Loader2 className="h-8 w-8 animate-spin" style={{ color: T.muted }} />
-              </div>
-            ) : wallets.length > 0 ? (
-              wallets.map((wallet, idx) => {
-                const chainName = getChainName(wallet.chainId);
-                const meta = getChainMeta(chainName);
-                const addr = wallet.address || "";
-                const truncatedAddress = addr.length > 14 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
-                return (
-                  <div
-                    key={wallet.id}
-                    style={{ display: "flex", alignItems: "center", gap: 14, padding: "17px 22px", borderBottom: idx < wallets.length - 1 ? "1px solid rgba(255,255,255,0.06)" : "none", minWidth: 0 }}
-                  >
-                    <div style={{ width: 44, height: 44, borderRadius: 14, background: `${meta.color}18`, border: `1.5px solid ${meta.color}33`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 22, flexShrink: 0, color: "#fff" }}>
-                      {meta.icon}
-                    </div>
-                    <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
-                        <p style={{ fontSize: 14, fontWeight: 700, color: T.bright }}>{chainName}</p>
-                        {(wallet.isDefault || wallets.length === 1) && (
-                          <span style={{ fontSize: 10, padding: "3px 10px", borderRadius: 99, fontWeight: 700, background: `${A}1a`, color: A, border: `1px solid ${A}2a` }}>Primary</span>
-                        )}
-                      </div>
-                      <p style={{ fontSize: 12, color: T.muted, fontFamily: "monospace", fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={addr}>
-                        {truncatedAddress}
-                      </p>
-                    </div>
-                    <div style={{ display: "flex", gap: 7, flexShrink: 0 }}>
-                      {!wallet.isDefault && wallets.length > 1 && handleSetAsPrimary && (
-                        <button
-                          onClick={() => handleSetAsPrimary(wallet.id)}
-                          className="abtn"
-                          style={{ background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.11)", borderRadius: 10, padding: "7px 14px", color: T.body, fontSize: 11, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", transition: "all 0.2s" }}
-                        >
-                          Set Primary
-                        </button>
-                      )}
-                      <button
-                        onClick={() => handleRemoveWallet(wallet.id)}
-                        style={{ background: "rgba(248,113,113,0.07)", border: "1px solid rgba(248,113,113,0.15)", borderRadius: 10, padding: "7px 12px", color: "#F87171", fontSize: 11, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center", gap: 4, fontWeight: 600 }}
-                      >
-                        {Icons.trash({})} Remove
-                      </button>
-                    </div>
-                  </div>
-                );
-              })
-            ) : (
-              <div style={{ padding: "24px 22px", color: T.body, fontSize: 13 }}>You don&apos;t have any wallets yet.</div>
-            )}
-          </Card>
-          <button
-            id="settings-add-wallet-button"
-            onClick={() => setIsWalletModalOpen(true)}
-            disabled={isAddingWallet}
-            className="abtn"
-            style={{ width: "100%", padding: "14px", background: "rgba(255,255,255,0.03)", border: "1.5px dashed rgba(255,255,255,0.12)", borderRadius: 18, color: T.muted, fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center", justifyContent: "center", gap: 8, transition: "all 0.2s", marginTop: 10 }}
-          >
-            {Icons.plus({})} Add Wallet
-          </button>
-
-          <SLabel>Account</SLabel>
-          <Card style={{ padding: "0 22px" }}>
-            <Row
+          ) : (
+            <button
+              onClick={() => setEditingProfile(true)}
               style={{
-                borderBottom: "none",
-                cursor: onLogout && !isLoggingOut ? "pointer" : undefined,
-                opacity: isLoggingOut ? 0.7 : 1,
+                background: "rgba(255,255,255,0.07)",
+                border: "1px solid rgba(255,255,255,0.12)",
+                borderRadius: 14,
+                padding: "10px 25px",
+                color: "#fff",
+                fontWeight: 500,
+                fontSize: 15,
+                cursor: "pointer",
+                fontFamily: "inherit",
               }}
-              onClick={() => !isLoggingOut && onLogout?.()}
             >
-              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                <span style={{ color: "#F87171", display: "flex" }}>{Icons.logout({})}</span>
-                <p style={{ color: "#F87171", fontSize: 14, fontWeight: 700 }}>Sign Out</p>
-              </div>
-              <span style={{ color: T.dim, display: "flex" }}>{Icons.chevR({})}</span>
-            </Row>
-          </Card>
-          <div style={{ height: 40 }} />
+              Edit Profile
+            </button>
+          )}
         </div>
 
-        {/* Add Wallet Modal */}
-        <AddWalletModal
-          isOpen={isWalletModalOpen}
-          onClose={() => setIsWalletModalOpen(false)}
-        />
+        {/* Stats row */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 0, textAlign: "center", paddingBottom: 16, paddingInline: 80 }}>
+          {[
+            [String(groupCount), "Groups"],
+            [String(friendCount), "Friends"],
+            [String(settledCount), "Settled"],
+          ].map(([num, label]) => (
+            <div key={label}>
+              <p style={{ fontSize: 18, fontWeight: 800, color: "#fff", letterSpacing: "-0.02em" }}>{num}</p>
+              <p style={{ fontSize: 11, fontWeight: 600, color: T.muted, marginTop: 1 }}>{label}</p>
+            </div>
+          ))}
+        </div>
 
-        {/* Remove Wallet Confirmation Modal – design */}
-        <AnimatePresence>
-          {isRemoveConfirmOpen && (
-            <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-                onClick={cancelRemoveWallet}
-              />
-              <motion.div
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.95 }}
-                className="relative w-full max-w-md rounded-2xl p-6 shadow-2xl"
-                style={{
-                  background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)",
-                  border: "1px solid rgba(255,255,255,0.08)",
-                  boxShadow:
-                    "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)",
-                }}
-              >
-                <div className="text-center">
-                  <h3
-                    className="text-xl font-semibold mb-2"
-                    style={{ color: T.bright }}
-                  >
-                    Remove Wallet
-                  </h3>
-                  <p className="mb-6" style={{ color: T.body, fontSize: 14 }}>
-                    Are you sure you want to remove this wallet? This action
-                    cannot be undone.
-                  </p>
-                  <div className="flex gap-3 justify-center">
-                    <Btn variant="ghost" onClick={cancelRemoveWallet}>
-                      Cancel
-                    </Btn>
-                    <Btn
-                      variant="danger"
-                      onClick={confirmRemoveWallet}
-                      style={{
-                        opacity: isRemovingWallet ? 0.7 : 1,
-                        cursor: isRemovingWallet ? "not-allowed" : "pointer",
-                      }}
+        {/* Separator */}
+        <div style={{ height: 1, background: "rgba(255,255,255,0.07)", marginBottom: 4 }} />
+
+        {/* PREFERENCES */}
+        <MSLabel>Preferences</MSLabel>
+        <MobileCard>
+          <MobileRow>
+            <div>
+              <p style={{ fontSize: 15, fontWeight: 700, color: "#fff" }}>Notifications</p>
+              <p style={{ fontSize: 13, color: T.muted, marginTop: 2, fontWeight: 500 }}>Email &amp; push reminders</p>
+            </div>
+            <Toggle on={notificationsOn} onChange={() => setNotificationsOn((p) => !p)} />
+          </MobileRow>
+          <MobileRow>
+            <div>
+              <p style={{ fontSize: 15, fontWeight: 700, color: "#fff" }}>Default Currency</p>
+              <p style={{ fontSize: 13, color: T.muted, marginTop: 2, fontWeight: 500 }}>{preferredCurrency || "USD"}</p>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, color: T.muted }}>
+              <span style={{ fontSize: 20 }}>{currencyFlag}</span>
+              <span style={{ fontSize: 16 }}>›</span>
+            </div>
+          </MobileRow>
+          <MobileRow last>
+            <p style={{ fontSize: 15, fontWeight: 700, color: "#fff" }}>Language</p>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, color: T.muted }}>
+              <span style={{ fontSize: 14, fontWeight: 500 }}>English</span>
+              <span style={{ fontSize: 16 }}>›</span>
+            </div>
+          </MobileRow>
+        </MobileCard>
+
+        {/* CONNECTED WALLETS */}
+        <MSLabel>Connected Wallets</MSLabel>
+        <MobileCard style={{ marginBottom: 10 }}>
+          {isLoadingWallets ? (
+            <div style={{ display: "flex", justifyContent: "center", padding: "28px" }}>
+              <Loader2 className="h-6 w-6 animate-spin" style={{ color: T.muted }} />
+            </div>
+          ) : wallets.length === 0 ? (
+            <div style={{ padding: "20px", color: T.muted, fontSize: 13, textAlign: "center" }}>
+              No wallets connected yet.
+            </div>
+          ) : (
+            wallets.map((wallet, idx) => {
+              const chainName = getChainName(wallet.chainId);
+              const meta = getChainMeta(chainName);
+              const addr = wallet.address || "";
+              const truncatedAddress = addr.length > 14 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+              return (
+                <MobileRow key={wallet.id} last={idx === wallets.length - 1}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+                    <div style={{ width: 48, height: 48, borderRadius: 14, background: `${meta.color}18`, border: `1.5px solid ${meta.color}33`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 22, flexShrink: 0, color: "#fff" }}>
+                      {meta.icon}
+                    </div>
+                    <div>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                        <p style={{ fontSize: 15, fontWeight: 700, color: "#fff" }}>{chainName}</p>
+                        {(wallet.isDefault || wallets.length === 1) && (
+                          <span style={{ fontSize: 10, padding: "3px 10px", borderRadius: 99, fontWeight: 700, background: `${A}1a`, color: A, border: `1px solid ${A}33` }}>Primary</span>
+                        )}
+                      </div>
+                      <p style={{ fontSize: 12, color: T.muted, fontFamily: "monospace", marginTop: 2 }}>{truncatedAddress}</p>
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    {!wallet.isDefault && wallets.length > 1 && handleSetAsPrimary && (
+                      <button
+                        onClick={() => handleSetAsPrimary(wallet.id)}
+                        style={{ background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.11)", borderRadius: 10, padding: "8px 12px", color: T.body, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "inherit" }}
+                      >
+                        Set Primary
+                      </button>
+                    )}
+                    <button
+                      onClick={() => handleRemoveWallet(wallet.id)}
+                      style={{ background: "rgba(248,113,113,0.07)", border: "1px solid rgba(248,113,113,0.15)", borderRadius: 10, padding: "8px 10px", color: "#F87171", fontSize: 12, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center" }}
                     >
-                      {isRemovingWallet ? (
-                        <>
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          <span>Removing...</span>
-                        </>
-                      ) : (
-                        <>
-                          {Icons.trash({ size: 14 })}
-                          <span>Remove Wallet</span>
-                        </>
+                      {Icons.trash({})}
+                    </button>
+                  </div>
+                </MobileRow>
+              );
+            })
+          )}
+        </MobileCard>
+        <button
+          id="settings-add-wallet-button"
+          onClick={() => setIsWalletModalOpen(true)}
+          disabled={isAddingWallet}
+          style={{ width: "100%", padding: "16px", background: "rgba(255,255,255,0.03)", border: "1.5px dashed rgba(255,255,255,0.13)", borderRadius: 18, color: T.muted, fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}
+        >
+          {Icons.plus({})} Add Wallet
+        </button>
+
+        {/* SECURITY */}
+        <MSLabel>Security</MSLabel>
+        <MobileCard>
+          <MobileRow last onClick={() => { if (typeof window !== "undefined") window.location.href = "/settings/change-password"; }}>
+            <p style={{ fontSize: 15, fontWeight: 700, color: "#fff" }}>Change Password</p>
+            <span style={{ color: T.muted, fontSize: 18 }}>›</span>
+          </MobileRow>
+        </MobileCard>
+
+        {/* Sign Out */}
+        <button
+          type="button"
+          onClick={() => !isLoggingOut && onLogout?.()}
+          disabled={isLoggingOut}
+          style={{
+            width: "100%",
+            marginTop: 24,
+            padding: "18px",
+            borderRadius: 20,
+            background: "rgba(200,40,40,0.15)",
+            border: "1px solid rgba(248,113,113,0.2)",
+            color: "#F87171",
+            fontSize: 17,
+            fontWeight: 800,
+            cursor: "pointer",
+            fontFamily: "inherit",
+            opacity: isLoggingOut ? 0.7 : 1,
+          }}
+        >
+          Sign Out
+        </button>
+        <div style={{ height: 40 }} />
+      </div>
+
+      {/* ── DESKTOP LAYOUT ── */}
+      <div className="hidden sm:block flex-1 overflow-y-auto px-7 pt-6 pb-10" style={{ maxWidth: 660 }}>
+        <SLabel>Profile</SLabel>
+        <Card style={{ padding: "22px", marginBottom: 4 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 22, paddingBottom: 22, borderBottom: "1px solid rgba(255,255,255,0.07)" }}>
+            <AvatarUpload id="profile-upload" size={64} />
+            <div>
+              <p style={{ color: T.bright, fontSize: 16, fontWeight: 800, letterSpacing: "-0.01em" }}>{displayName || "You"}</p>
+              <p style={{ color: T.muted, fontSize: 12, fontWeight: 500, marginTop: 2 }}>{userEmail || "you@email.com"}</p>
+            </div>
+          </div>
+          <Row>
+            <span style={{ color: T.body, fontSize: 14, fontWeight: 600 }}>Display Name</span>
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              style={{ background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", borderRadius: 12, padding: "10px 14px", color: "#fff", fontSize: 14, outline: "none", fontFamily: "inherit", width: 220, fontWeight: 500 }}
+            />
+          </Row>
+          <Row style={{ borderBottom: "none" }}>
+            <span style={{ color: T.body, fontSize: 14, fontWeight: 600 }}>Email</span>
+            <input
+              value={userEmail}
+              onChange={() => {}}
+              style={{ background: "rgba(255,255,255,0.05)", border: "1.5px solid rgba(255,255,255,0.09)", borderRadius: 12, padding: "10px 14px", color: "#fff", fontSize: 14, outline: "none", fontFamily: "inherit", width: 220, fontWeight: 500 }}
+            />
+          </Row>
+          <div style={{ paddingTop: 18, display: "flex", justifyContent: "flex-end" }}>
+            <button
+              onClick={handleSaveChanges}
+              disabled={isUpdatatingUser}
+              style={{ background: A, border: "none", borderRadius: 12, padding: "10px 22px", color: "#0a0a0a", fontWeight: 800, fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}
+            >
+              Save Changes
+            </button>
+          </div>
+        </Card>
+
+        <SLabel>Preferences</SLabel>
+        <Card style={{ padding: "0 22px" }}>
+          <Row>
+            <div>
+              <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Notifications</p>
+              <p style={{ color: T.muted, fontSize: 12, marginTop: 2, fontWeight: 500 }}>Email reminders and updates</p>
+            </div>
+            <Toggle on={notificationsOn} onChange={() => setNotificationsOn((p) => !p)} />
+          </Row>
+          <Row style={{ borderBottom: "none", alignItems: "center" }}>
+            <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Default Currency</p>
+            <div style={{ minWidth: 220 }}>
+              <CurrencyDropdown
+                selectedCurrencies={preferredCurrency ? [preferredCurrency] : []}
+                setSelectedCurrencies={(currencies) => setPreferredCurrency(currencies[0] || "")}
+                mode="single"
+                showFiatCurrencies={true}
+                filterCurrencies={(currency: Currency) => currency.symbol !== "ETH" && currency.symbol !== "USDC"}
+                disableChainCurrencies={true}
+              />
+            </div>
+          </Row>
+        </Card>
+
+        {wallets.length > 0 && !isMobile && (
+          <>
+            <SLabel>Accept Payments in</SLabel>
+            <Card className="p-[22px] mb-4" id="settings-accept-payments-tokens">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <p style={{ color: T.muted, fontSize: 12, marginBottom: 12 }}>Select the tokens you want to accept payments in</p>
+                  </TooltipTrigger>
+                  <TooltipContent><p>Based on your connected wallets</p></TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <CurrencyDropdown
+                selectedCurrencies={selectedCurrencies}
+                setSelectedCurrencies={setSelectedCurrencies}
+                filterCurrencies={(currency: Currency) =>
+                  currency.symbol !== "ETH" &&
+                  currency.symbol !== "USDC" &&
+                  wallets.some((w) => w.chainId === currency.chainId)
+                }
+                showFiatCurrencies={false}
+              />
+            </Card>
+          </>
+        )}
+
+        <SLabel>Security</SLabel>
+        <Card style={{ padding: "0 22px" }}>
+          <Row
+            style={{ borderBottom: "none", cursor: "pointer" }}
+            onClick={() => { if (typeof window !== "undefined") window.location.href = "/settings/change-password"; }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span style={{ color: T.body, display: "flex" }}>{Icons.shield({})}</span>
+              <p style={{ color: T.bright, fontSize: 14, fontWeight: 600 }}>Change Password</p>
+            </div>
+            <span style={{ color: T.dim, display: "flex" }}>{Icons.chevR({})}</span>
+          </Row>
+        </Card>
+
+        <SLabel>Connected Wallets</SLabel>
+        <Card style={{ marginBottom: 4 }}>
+          {isLoadingWallets ? (
+            <div style={{ display: "flex", justifyContent: "center", padding: "28px" }}>
+              <Loader2 className="h-8 w-8 animate-spin" style={{ color: T.muted }} />
+            </div>
+          ) : wallets.length > 0 ? (
+            wallets.map((wallet, idx) => {
+              const chainName = getChainName(wallet.chainId);
+              const meta = getChainMeta(chainName);
+              const addr = wallet.address || "";
+              const truncatedAddress = addr.length > 14 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+              return (
+                <div
+                  key={wallet.id}
+                  style={{ display: "flex", alignItems: "center", gap: 14, padding: "17px 22px", borderBottom: idx < wallets.length - 1 ? "1px solid rgba(255,255,255,0.06)" : "none", minWidth: 0 }}
+                >
+                  <div style={{ width: 44, height: 44, borderRadius: 14, background: `${meta.color}18`, border: `1.5px solid ${meta.color}33`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 22, flexShrink: 0, color: "#fff" }}>
+                    {meta.icon}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4, flexWrap: "wrap" }}>
+                      <p style={{ fontSize: 14, fontWeight: 700, color: T.bright }}>{chainName}</p>
+                      {(wallet.isDefault || wallets.length === 1) && (
+                        <span style={{ fontSize: 10, padding: "3px 10px", borderRadius: 99, fontWeight: 700, background: `${A}1a`, color: A, border: `1px solid ${A}2a` }}>Primary</span>
                       )}
-                    </Btn>
+                    </div>
+                    <p style={{ fontSize: 12, color: T.muted, fontFamily: "monospace", fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={addr}>
+                      {truncatedAddress}
+                    </p>
+                  </div>
+                  <div style={{ display: "flex", gap: 7, flexShrink: 0 }}>
+                    {!wallet.isDefault && wallets.length > 1 && handleSetAsPrimary && (
+                      <button
+                        onClick={() => handleSetAsPrimary(wallet.id)}
+                        className="abtn"
+                        style={{ background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.11)", borderRadius: 10, padding: "7px 14px", color: T.body, fontSize: 11, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", transition: "all 0.2s" }}
+                      >
+                        Set Primary
+                      </button>
+                    )}
+                    <button
+                      onClick={() => handleRemoveWallet(wallet.id)}
+                      style={{ background: "rgba(248,113,113,0.07)", border: "1px solid rgba(248,113,113,0.15)", borderRadius: 10, padding: "7px 12px", color: "#F87171", fontSize: 11, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center", gap: 4, fontWeight: 600 }}
+                    >
+                      {Icons.trash({})} Remove
+                    </button>
                   </div>
                 </div>
-              </motion.div>
-            </div>
+              );
+            })
+          ) : (
+            <div style={{ padding: "24px 22px", color: T.body, fontSize: 13 }}>You don&apos;t have any wallets yet.</div>
           )}
-        </AnimatePresence>
+        </Card>
+        <button
+          id="settings-add-wallet-button"
+          onClick={() => setIsWalletModalOpen(true)}
+          disabled={isAddingWallet}
+          className="abtn"
+          style={{ width: "100%", padding: "14px", background: "rgba(255,255,255,0.03)", border: "1.5px dashed rgba(255,255,255,0.12)", borderRadius: 18, color: T.muted, fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", display: "flex", alignItems: "center", justifyContent: "center", gap: 8, transition: "all 0.2s", marginTop: 10 }}
+        >
+          {Icons.plus({})} Add Wallet
+        </button>
+
+        <SLabel>Account</SLabel>
+        <Card style={{ padding: "0 22px" }}>
+          <Row
+            style={{
+              borderBottom: "none",
+              cursor: onLogout && !isLoggingOut ? "pointer" : undefined,
+              opacity: isLoggingOut ? 0.7 : 1,
+            }}
+            onClick={() => !isLoggingOut && onLogout?.()}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span style={{ color: "#F87171", display: "flex" }}>{Icons.logout({})}</span>
+              <p style={{ color: "#F87171", fontSize: 14, fontWeight: 700 }}>Sign Out</p>
+            </div>
+            <span style={{ color: T.dim, display: "flex" }}>{Icons.chevR({})}</span>
+          </Row>
+        </Card>
+        <div style={{ height: 40 }} />
+      </div>
+
+      {/* Add Wallet Modal */}
+      <AddWalletModal
+        isOpen={isWalletModalOpen}
+        onClose={() => setIsWalletModalOpen(false)}
+      />
+
+      {/* Remove Wallet Confirmation Modal */}
+      <AnimatePresence>
+        {isRemoveConfirmOpen && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+              onClick={cancelRemoveWallet}
+            />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              className="relative w-full max-w-md rounded-2xl p-6 shadow-2xl"
+              style={{
+                background: "linear-gradient(145deg, #111 0%, #0d0d0d 100%)",
+                border: "1px solid rgba(255,255,255,0.08)",
+                boxShadow: "0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.04)",
+              }}
+            >
+              <div className="text-center">
+                <h3 className="text-xl font-semibold mb-2" style={{ color: T.bright }}>Remove Wallet</h3>
+                <p className="mb-6" style={{ color: T.body, fontSize: 14 }}>
+                  Are you sure you want to remove this wallet? This action cannot be undone.
+                </p>
+                <div className="flex gap-3 justify-center">
+                  <Btn variant="ghost" onClick={cancelRemoveWallet}>Cancel</Btn>
+                  <Btn
+                    variant="danger"
+                    onClick={confirmRemoveWallet}
+                    style={{ opacity: isRemovingWallet ? 0.7 : 1, cursor: isRemovingWallet ? "not-allowed" : "pointer" }}
+                  >
+                    {isRemovingWallet ? (
+                      <><Loader2 className="h-4 w-4 animate-spin" /><span>Removing...</span></>
+                    ) : (
+                      <>{Icons.trash({ size: 14 })}<span>Remove Wallet</span></>
+                    )}
+                  </Btn>
+                </div>
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/components/add-expense-modal.tsx
+++ b/components/add-expense-modal.tsx
@@ -23,6 +23,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { fadeIn, scaleIn } from "@/utils/animations";
 import { Card, A, T, getUserColor } from "@/lib/splito-design";
 import { useGroupLayout } from "@/contexts/group-layout-context";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 const CATEGORY_OPTIONS: { emoji: string; api: string }[] = [
   { emoji: "🍽", api: "FOOD" },
@@ -474,7 +475,7 @@ export function AddExpenseModal({
           fontFamily: "inherit",
         }}
       >
-        ← Back
+        ←
       </button>
     );
   };
@@ -514,6 +515,8 @@ export function AddExpenseModal({
     );
   };
 
+  const isMobile = useIsMobile();
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -523,40 +526,59 @@ export function AddExpenseModal({
         >
           <motion.div
             className="fixed inset-0 bg-black/70 brightness-50"
+            style={isMobile ? { backdropFilter: "blur(10px)" } : undefined}
             onClick={onClose}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           />
-          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-[460px] px-6">
+          <div
+            className={
+              isMobile
+                ? "modal-as-sheet-wrapper fixed inset-x-0 bottom-0 z-10 w-full max-w-[430px] mx-auto"
+                : "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-[460px] px-6"
+            }
+          >
+            {isMobile && (
+              <div className="flex justify-center flex-shrink-0" style={{ padding: "8px 0 4px" }}>
+                <div style={{ width: 40, height: 4, borderRadius: 99, background: "rgba(255,255,255,0.15)" }} />
+              </div>
+            )}
             <motion.div
               onClick={(e) => e.stopPropagation()}
-              {...scaleIn}
-              style={{
-                background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
-                border: "1px solid rgba(255,255,255,0.09)",
-                borderRadius: 28,
-                width: "100%",
-                maxWidth: 460,
-                padding: "28px 28px 32px",
-                maxHeight: "90vh",
-                overflowY: "auto",
-                boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
-              }}
+              {...(isMobile ? { initial: { y: "100%" }, animate: { y: 0 }, transition: { type: "tween", duration: 0.32, ease: [0.34, 1.2, 0.64, 1] } } : scaleIn)}
+              className={isMobile ? "modal-as-sheet-card px-5 sm:px-7 pt-0 pb-8" : ""}
+              style={
+                isMobile
+                  ? undefined
+                  : {
+                      background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
+                      border: "1px solid rgba(255,255,255,0.09)",
+                      borderRadius: 28,
+                      width: "100%",
+                      maxWidth: 460,
+                      padding: "28px 28px 32px",
+                      maxHeight: "90vh",
+                      overflowY: "auto",
+                      boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
+                    }
+              }
             >
         <div
+          className={isMobile ? "modal-as-sheet-title-bar" : ""}
           style={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
-            marginBottom: 24,
+            marginBottom: isMobile ? 16 : 24,
+            ...(isMobile && { paddingTop: 20 }),
           }}
         >
           <div>
             <p
               style={{
                 color: "#fff",
-                fontSize: 20,
+                fontSize: isMobile ? 18 : 20,
                 fontWeight: 800,
                 letterSpacing: "-0.02em",
               }}

--- a/components/create-group-form.tsx
+++ b/components/create-group-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useWallet } from "@/hooks/useWallet";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { Plus, X } from "lucide-react";
 import {
   useCreateGroup,
@@ -276,6 +277,8 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
     display: "block",
   };
 
+  const isMobile = useIsMobile();
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -285,30 +288,43 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
         >
           <motion.div
             className="fixed inset-0 bg-black/70 brightness-50"
+            style={isMobile ? { backdropFilter: "blur(10px)" } : undefined}
             onClick={onClose}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
           />
-          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full md:w-[90%] max-w-[500px] px-4 sm:px-0">
+          <div
+            className={
+              isMobile
+                ? "modal-as-sheet-wrapper fixed inset-x-0 bottom-0 z-10 w-full max-w-[430px] mx-auto"
+                : "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full md:w-[90%] max-w-[500px] px-4 sm:px-0"
+            }
+          >
+            {isMobile && <div className="modal-as-sheet-handle" />}
             <motion.div
-              className="relative z-10 rounded-[28px] p-7 border border-white/[0.09] shadow-[0_40px_100px_rgba(0,0,0,0.8)] max-h-[90vh] overflow-y-auto"
-              style={{ background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)" }}
-              {...scaleIn}
+              className={
+                isMobile
+                  ? "modal-as-sheet-card relative z-10 p-5 sm:p-7"
+                  : "relative z-10 rounded-[28px] p-7 border border-white/[0.09] shadow-[0_40px_100px_rgba(0,0,0,0.8)] max-h-[90vh] overflow-y-auto"
+              }
+              style={isMobile ? undefined : { background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)" }}
+              {...(isMobile ? { initial: { y: "100%" }, animate: { y: 0 }, transition: { type: "tween", duration: 0.32, ease: [0.34, 1.2, 0.64, 1] } } : scaleIn)}
               onClick={(e) => e.stopPropagation()}
             >
           <div
+            className={isMobile ? "modal-as-sheet-title-bar" : ""}
             style={{
               display: "flex",
               justifyContent: "space-between",
               alignItems: "center",
-              marginBottom: 24,
+              marginBottom: isMobile ? 16 : 24,
             }}
           >
             <div>
               <p
                 style={{
                   color: "#fff",
-                  fontSize: 20,
+                  fontSize: isMobile ? 18 : 20,
                   fontWeight: 800,
                   letterSpacing: "-0.02em",
                 }}
@@ -867,7 +883,7 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
                       fontFamily: "inherit",
                     }}
                   >
-                    ← Back
+                    ←
                   </button>
                   <button
                     type="button"

--- a/components/friends-breakdown-modal.tsx
+++ b/components/friends-breakdown-modal.tsx
@@ -261,32 +261,46 @@ export function FriendsBreakdownModal({
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            className="fixed inset-0 z-50 h-screen w-screen"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           >
-            <div className="absolute inset-0 bg-black/80" onClick={onClose} />
-            <motion.div
-              className="relative w-full max-w-2xl max-h-[90vh] overflow-auto rounded-[24px] bg-black p-5 sm:p-8 border border-white/10 shadow-[0_0_15px_rgba(255,255,255,0.05)]"
-              {...scaleIn}
-            >
-              <div className="flex items-center justify-between mb-6">
-                <div>
-                  <div className="mb-1 text-xs sm:text-sm text-white/60">
-                    Debt Breakdown
+            <div
+              className="fixed inset-0 bg-black/80"
+              onClick={onClose}
+            />
+            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-[460px] px-4 sm:px-0">
+              <motion.div
+                {...scaleIn}
+                className="relative z-10"
+                style={{
+                  background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
+                  border: "1px solid rgba(255,255,255,0.09)",
+                  borderRadius: 28,
+                  padding: 28,
+                  maxHeight: "90vh",
+                  overflowY: "auto",
+                  boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
+                }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="flex items-center justify-between mb-5">
+                  <div>
+                    <p className="text-[12px] font-semibold text-white/60 mb-1 tracking-[0.05em] uppercase">
+                      Debt Breakdown
+                    </p>
+                    <h2 className="text-[20px] font-extrabold text-white tracking-[-0.02em]">
+                      Your Outstanding Debts
+                    </h2>
                   </div>
-                  <h2 className="text-xl sm:text-3xl font-semibold text-white">
-                    Your Outstanding Debts
-                  </h2>
+                  <button
+                    onClick={onClose}
+                    className="rounded-full w-9 h-9 flex items-center justify-center hover:bg-white/10 border border-white/15"
+                  >
+                    <X className="h-4 w-4 text-white/70" />
+                  </button>
                 </div>
-                <button
-                  onClick={onClose}
-                  className="p-2 rounded-full hover:bg-white/[0.03] transition-colors"
-                >
-                  <X className="h-5 w-5 text-white/60" />
-                </button>
-              </div>
 
               {isLoading ? (
                 <div className="flex items-center justify-center py-12">
@@ -421,7 +435,8 @@ export function FriendsBreakdownModal({
                   )} */}
                 </>
               )}
-            </motion.div>
+              </motion.div>
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/components/friends-list.tsx
+++ b/components/friends-list.tsx
@@ -30,7 +30,10 @@ function getFriendBalance(
   return balances.reduce((sum, b) => sum + b.amount, 0);
 }
 
-export function FriendsList({ search = "" }: { search?: string }) {
+export function FriendsList({
+  search = "",
+  onAddFriendClick,
+}: { search?: string; onAddFriendClick?: () => void }) {
   const { data: friends, isLoading, error } = useGetFriends();
   const router = useRouter();
   const { user } = useAuthStore();
@@ -123,9 +126,7 @@ export function FriendsList({ search = "" }: { search?: string }) {
           Add friends to start tracking expenses and settle debts together
         </p>
         <button
-          onClick={() =>
-            document.dispatchEvent(new CustomEvent("open-add-friend-modal"))
-          }
+          onClick={() => onAddFriendClick?.()}
           style={{
             display: "flex",
             alignItems: "center",
@@ -225,137 +226,126 @@ function FriendRow({
   const init = getInitials(friend.name);
 
   return (
-    <motion.div
-      variants={slideUp}
-      className="rw"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 14,
-        padding: "15px 24px",
-        borderBottom: isLast
-          ? "none"
-          : "1px solid rgba(255,255,255,0.06)",
-        transition: "background 0.15s",
-        cursor: "pointer",
-      }}
-    >
-      <Avatar init={init} color={color} size={42} />
-      <div className="min-w-0 flex-1" style={{ overflow: "hidden" }}>
-        <p className="truncate" style={{ fontSize: 14, fontWeight: 700, color: T.bright }}>
-          {friend.name}
-        </p>
-        <p
-          className="truncate block"
-          style={{ fontSize: 12, color: T.muted, marginTop: 2, fontWeight: 500 }}
-          title={friend.email ?? undefined}
-        >
-          {friend.email ?? ""}
-        </p>
-      </div>
-      {balance < 0 && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onSettleClick();
-          }}
-          className="sbtn shrink-0"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 5,
-            background: "rgba(255,255,255,0.06)",
-            border: "1px solid rgba(255,255,255,0.11)",
-            borderRadius: 12,
-            padding: "8px 10px",
-            color: T.body,
-            fontSize: 12,
-            fontWeight: 700,
-            cursor: "pointer",
-            fontFamily: "inherit",
-          }}
-        >
-          {Icons.wallet({})} Settle
-        </button>
-      )}
-      {balance > 0 && (
-        <button
-          type="button"
-          className="abtn shrink-0"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 5,
-            background: "rgba(255,255,255,0.06)",
-            border: "1px solid rgba(255,255,255,0.11)",
-            borderRadius: 12,
-            padding: "8px 10px",
-            color: T.body,
-            fontSize: 12,
-            fontWeight: 700,
-            cursor: "pointer",
-            fontFamily: "inherit",
-          }}
-        >
-          {Icons.bell({})} Remind
-        </button>
-      )}
+    <motion.div variants={slideUp}>
+      {/* Desktop layout */}
       <div
-        className="shrink-0 text-right"
-        style={{ minWidth: 64 }}
+        className="rw hidden sm:flex"
+        style={{
+          alignItems: "center",
+          gap: 14,
+          padding: "15px 24px",
+          borderBottom: isLast ? "none" : "1px solid rgba(255,255,255,0.06)",
+          transition: "background 0.15s",
+          cursor: "pointer",
+        }}
       >
-        {balance === 0 ? (
-          <p style={{ color: T.dim, fontSize: 12, fontWeight: 600 }}>Settled</p>
-        ) : balance > 0 ? (
-          <>
-            <p
-              style={{
-                color: G,
-                fontSize: 14,
-                fontWeight: 800,
-                fontFamily: "'DM Mono',monospace",
-              }}
-            >
-              +{fmt(balance)}
-            </p>
-            <p
-              style={{
-                color: "rgba(52,211,153,0.6)",
-                fontSize: 11,
-                marginTop: 2,
-                fontWeight: 600,
-              }}
-            >
-              owes you
-            </p>
-          </>
-        ) : (
-          <>
-            <p
-              style={{
-                color: "#F87171",
-                fontSize: 14,
-                fontWeight: 800,
-                fontFamily: "'DM Mono',monospace",
-              }}
-            >
-              -{fmt(Math.abs(balance))}
-            </p>
-            <p
-              style={{
-                color: "rgba(248,113,113,0.6)",
-                fontSize: 11,
-                marginTop: 2,
-                fontWeight: 600,
-              }}
-            >
-              you owe
-            </p>
-          </>
+        <Avatar init={init} color={color} size={42} />
+        <div className="min-w-0 flex-1" style={{ overflow: "hidden" }}>
+          <p className="truncate" style={{ fontSize: 14, fontWeight: 700, color: T.bright }}>
+            {friend.name}
+          </p>
+          <p
+            className="truncate block"
+            style={{ fontSize: 12, color: T.muted, marginTop: 2, fontWeight: 500 }}
+            title={friend.email ?? undefined}
+          >
+            {friend.email ?? ""}
+          </p>
+        </div>
+        {balance < 0 && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onSettleClick(); }}
+            className="sbtn shrink-0"
+            style={{
+              display: "flex", alignItems: "center", justifyContent: "center", gap: 5,
+              background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.11)",
+              borderRadius: 12, padding: "8px 10px", color: T.body, fontSize: 12,
+              fontWeight: 700, cursor: "pointer", fontFamily: "inherit",
+            }}
+          >
+            {Icons.wallet({})} Settle
+          </button>
         )}
+        {balance > 0 && (
+          <button
+            type="button"
+            className="abtn shrink-0"
+            style={{
+              display: "flex", alignItems: "center", justifyContent: "center", gap: 5,
+              background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.11)",
+              borderRadius: 12, padding: "8px 10px", color: T.body, fontSize: 12,
+              fontWeight: 700, cursor: "pointer", fontFamily: "inherit",
+            }}
+          >
+            {Icons.bell({})} Remind
+          </button>
+        )}
+        <div className="shrink-0 text-right" style={{ minWidth: 64 }}>
+          {balance === 0 ? (
+            <p style={{ color: T.dim, fontSize: 12, fontWeight: 600 }}>Settled</p>
+          ) : balance > 0 ? (
+            <>
+              <p style={{ color: G, fontSize: 14, fontWeight: 800, fontFamily: "'DM Mono',monospace" }}>
+                +{fmt(balance)}
+              </p>
+              <p style={{ color: "rgba(52,211,153,0.6)", fontSize: 11, marginTop: 2, fontWeight: 600 }}>owes you</p>
+            </>
+          ) : (
+            <>
+              <p style={{ color: "#F87171", fontSize: 14, fontWeight: 800, fontFamily: "'DM Mono',monospace" }}>
+                -{fmt(Math.abs(balance))}
+              </p>
+              <p style={{ color: "rgba(248,113,113,0.6)", fontSize: 11, marginTop: 2, fontWeight: 600 }}>you owe</p>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Mobile layout */}
+      <div
+        className="rw flex sm:hidden"
+        style={{
+          alignItems: "center",
+          gap: 14,
+          padding: "15px 20px",
+          borderBottom: isLast ? "none" : "1px solid rgba(255,255,255,0.06)",
+          transition: "background 0.15s",
+        }}
+      >
+        <Avatar init={init} color={color} size={44} />
+        <div className="min-w-0 flex-1" style={{ overflow: "hidden" }}>
+          <p className="truncate" style={{ fontSize: 14, fontWeight: 700, color: T.bright }}>
+            {friend.name}
+          </p>
+          <p
+            className="truncate block"
+            style={{ fontSize: 12, marginTop: 2, fontWeight: 600, color: balance === 0 ? T.dim : balance > 0 ? G : "#F87171" }}
+          >
+            {balance === 0 ? "Settled up" : balance > 0 ? `Owes you ${fmt(balance)}` : `You owe ${fmt(Math.abs(balance))}`}
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+          {balance > 0 && (
+            <button
+              type="button"
+              className="abtn shrink-0"
+              style={{ borderRadius: 10, padding: "7px 14px", border: "1px solid rgba(52,211,153,0.3)", background: "rgba(52,211,153,0.06)", color: G, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "inherit" }}
+            >
+              Remind
+            </button>
+          )}
+          {balance < 0 && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onSettleClick(); }}
+              className="sbtn shrink-0"
+              style={{ borderRadius: 10, padding: "7px 14px", border: "1px solid rgba(34,211,238,0.3)", background: "rgba(34,211,238,0.06)", color: "#22D3EE", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "inherit" }}
+            >
+              Settle
+            </button>
+          )}
+        </div>
       </div>
     </motion.div>
   );

--- a/components/group-info-header.tsx
+++ b/components/group-info-header.tsx
@@ -12,7 +12,7 @@ import { formatCurrency } from "@/utils/formatters";
 import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { cn } from "@/lib/utils";
-import { BackBtn, Btn, Icons, A, T } from "@/lib/splito-design";
+import { Btn, Icons, A, T } from "@/lib/splito-design";
 
 export function GroupInfoHeader({
   groupId,
@@ -93,10 +93,11 @@ export function GroupInfoHeader({
     }, 500);
   };
 
+  // Order matches mobile design artifact: Splits · Members · Activity
   const tabs = [
     { label: "Splits", href: `/groups/${groupId}/splits` },
-    { label: "Activity", href: `/groups/${groupId}/activity` },
     { label: "Members", href: `/groups/${groupId}/members` },
+    { label: "Activity", href: `/groups/${groupId}/activity` },
   ];
 
   const memberCount = group.groupUsers?.length ?? 0;
@@ -112,18 +113,34 @@ export function GroupInfoHeader({
 
   return (
     <div
-      className="flex flex-col sticky top-0 z-[40]"
+      className="flex flex-col sm:sticky sm:top-0 z-[40]"
       style={{
         background: "rgba(11,11,11,0.95)",
         backdropFilter: "blur(20px)",
       }}
     >
       {/* Top row: mobile = [icon][name+members][balance]; desktop = [← Back][name+balance text][Settle all][Add Expense] */}
-      <div className="flex items-center justify-between gap-3 px-4 sm:px-7 h-14 sm:h-[70px] min-h-[56px]">
+      <div className="flex items-center justify-between gap-3 px-4 mt-3 sm:mt-4 sm:px-7 h-14 sm:h-[70px] min-h-[56px]">
         <div className="flex items-center gap-3 sm:gap-[14px] min-w-0 flex-1">
-          <BackBtn onClick={() => router.push("/groups")} className="hidden sm:flex" />
+          {/* Mobile back button */}
+          <button
+            onClick={() => router.push("/groups")}
+            className="flex items-center justify-center flex-shrink-0"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 12,
+              background: "rgba(255,255,255,0.07)",
+              border: "1px solid rgba(255,255,255,0.1)",
+              color: "#d4d4d4",
+              fontSize: 18,
+              cursor: "pointer",
+            }}
+          >
+            ←
+          </button>
           <div className="min-w-0">
-            <h1 className="text-[18px] sm:text-[20px] font-extrabold tracking-[-0.03em] text-white truncate">
+            <h1 className="text-[20px] sm:text-[20px] font-extrabold tracking-[-0.03em] text-white truncate">
               {group.name}
             </h1>
             <p className="text-[11px] sm:text-[12px] font-medium mt-0.5" style={{ color: T.mid }}>
@@ -135,7 +152,7 @@ export function GroupInfoHeader({
         <div className="flex flex-col items-end flex-shrink-0 text-right sm:hidden">
           <span
             className={cn(
-              "text-[15px] font-bold tabular-nums",
+              "text-[17px] font-bold tabular-nums",
               isOwedToUser && "text-[#34D399]",
               isUserOwes && "text-[#F87171]",
               !isOwedToUser && !isUserOwes && "text-[#34D399]"
@@ -168,15 +185,24 @@ export function GroupInfoHeader({
       </div>
 
       {/* Action buttons row: mobile only */}
-      <div className="flex gap-2 px-4 sm:px-7 pb-3 sm:pb-4 sm:hidden">
-        <Btn
+      <div className="flex gap-2 px-4 sm:px-7 py-3 sm:py-4 sm:hidden">
+        <button
+          type="button"
           onClick={handleSettleClick}
-          variant="ghost"
-          className="flex-1"
-          style={{ padding: "10px 14px", fontSize: 13, justifyContent: "center" }}
+          className="flex-1 flex items-center justify-center gap-1.5 rounded-xl"
+          style={{
+            padding: "10px 14px",
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.12)",
+            color: "#f5f5f5",
+            fontSize: 13,
+            fontWeight: 700,
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
         >
           <Icons.wallet /> Settle All
-        </Btn>
+        </button>
         <button
           onClick={handleAddExpenseClick}
           disabled={isAddingExpense}
@@ -225,7 +251,8 @@ export function GroupInfoHeader({
           <Btn
             onClick={openAddMember}
             variant="ghost"
-            style={{ padding: "8px 14px", fontSize: 12, flexShrink: 0 }}
+            style={{ padding: "8px 14px", fontSize: 12, flexShrink: 0}}
+            className="sm:!flex  !hidden"
           >
             <Icons.userPlus /> Add Member
           </Btn>

--- a/components/groups-list-content.tsx
+++ b/components/groups-list-content.tsx
@@ -6,52 +6,33 @@ import { motion } from "framer-motion";
 import { Loader2, AlertTriangle, X, CheckCircle } from "lucide-react";
 import { staggerContainer, slideUp } from "@/utils/animations";
 import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
-import { Card, GroupAvatar, Icons, Tag, G, T, getUserColor } from "@/lib/splito-design";
-
-function relativeTime(date: Date): string {
-  const now = new Date();
-  const d = new Date(date);
-  const sec = Math.floor((now.getTime() - d.getTime()) / 1000);
-  if (sec < 60) return "Just now";
-  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
-  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
-  if (sec < 604800) return `${Math.floor(sec / 86400)}d ago`;
-  return `${Math.floor(sec / 604800)}w ago`;
-}
+import { GroupAvatar, Card, Tag, G, T, Icons, getUserColor } from "@/lib/splito-design";
+import { formatRelativeTime } from "@/lib/utils";
 
 type GroupItem = {
   id: string;
   name: string;
   groupBalances?: { userId: string; currency: string; amount: number }[];
   groupUsers?: { user: { id: string; name?: string | null } }[];
-  expenses?: unknown[];
+  expenses?: { amount: number; currency: string }[];
   updatedAt: Date;
 };
 
-function GroupCard({
+/** Balance cell used by both mobile cards and desktop rows */
+function GroupBalanceCell({
   group,
   user,
   defaultCurrency,
   formatCurrency,
+  variant = "desktop",
 }: {
   group: GroupItem;
-  user: { id: string; name?: string | null } | null;
+  user: { id: string } | null;
   defaultCurrency: string;
   formatCurrency: (amount: number, currency: string) => string;
+  variant?: "mobile" | "desktop";
 }) {
   const balances = group.groupBalances || [];
-
-  // Use the same logic as dashboard for consistency
-  const avatarItems = (group.groupUsers ?? [])
-    .slice(0, 4)
-    .map((gu) => ({
-      init: gu.user.name?.charAt(0)?.toUpperCase() || "?",
-      color: getUserColor(gu.user.name ?? null),
-    }));
-
-  // Get member count from groupUsers
-  const memberCount = (group.groupUsers ?? []).length;
-
   const userBalances = balances.filter((b) => b.userId === user?.id);
   const byCurrency: Record<string, number> = {};
   userBalances.forEach((b) => {
@@ -64,57 +45,187 @@ function GroupCard({
     .filter(([, a]) => a < 0)
     .map(([currency, amount]) => ({ amount: Math.abs(amount), currency }));
 
-  const { total: totalOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
-  const { total: totalOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
-  const net = totalOwed - totalOwe;
+  const { total: oweTotal, isLoading: loadOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
+  const { total: owedTotal, isLoading: loadOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
 
-  const balanceLabel = (() => {
-    if (net === 0) return { text: "±$0", color: T.dim };
-    if (net > 0) return { text: `+$${net.toFixed(2)}`, color: G };
-    return { text: `-$${Math.abs(net).toFixed(2)}`, color: "#F87171" };
-  })();
-  const totalMagnitude = Object.values(byCurrency).reduce((s, a) => s + Math.abs(a), 0);
-  const totalLabel = totalMagnitude > 0 ? formatCurrency(totalMagnitude, defaultCurrency) : formatCurrency(0, defaultCurrency);
-  const expenseCount = Array.isArray((group as { expenses?: unknown[] }).expenses)
-    ? (group as { expenses: unknown[] }).expenses.length
-    : 0;
-  const ago = relativeTime(group.updatedAt);
-  const groupUrl = `/groups/${group.id}`;
+  const expenseItems = (group.expenses || []).map((e) => ({
+    amount: Math.abs(e.amount),
+    currency: e.currency,
+  }));
+  const { total: totalSpent, isLoading: loadSpent } = useConvertedBalanceTotal(expenseItems, defaultCurrency);
 
-  const isEmpty = net === 0 && expenseCount === 0;
+  if (loadOwe || loadOwed)
+    return <span style={{ color: "#888", fontSize: variant === "mobile" ? 12 : 14 }}>…</span>;
+
+  const net = (owedTotal ?? 0) - (oweTotal ?? 0);
+  const color = net > 0 ? G : net < 0 ? "#F87171" : T.dim;
+  const prefix = net > 0 ? "+" : net < 0 ? "-" : "±";
+  const isMobile = variant === "mobile";
+
+  return (
+    <div
+      className="text-right flex-shrink-0 min-w-0 truncate"
+      style={isMobile ? { maxWidth: "40%" } : undefined}
+    >
+      <p
+        className="truncate"
+        style={{
+          fontSize: isMobile ? 15 : 17,
+          fontWeight: 800,
+          fontFamily: "var(--font-dm-mono,monospace)",
+          color,
+          letterSpacing: "-0.01em",
+        }}
+      >
+        {prefix}{formatCurrency(Math.abs(net), defaultCurrency)}
+      </p>
+      <p
+        className="truncate mt-0.5"
+        style={{
+          fontSize: isMobile ? 10 : 11,
+          color: T.sub,
+          fontWeight: 500,
+        }}
+      >
+        {loadSpent ? "…" : formatCurrency(totalSpent ?? 0, defaultCurrency)} spent
+      </p>
+    </div>
+  );
+}
+
+/** Mobile: individual card per group */
+function GroupMobileCard({
+  group,
+  user,
+  defaultCurrency,
+  formatCurrency,
+}: {
+  group: GroupItem;
+  user: { id: string; name?: string | null } | null;
+  defaultCurrency: string;
+  formatCurrency: (amount: number, currency: string) => string;
+}) {
+  const avatarItems = (group.groupUsers ?? [])
+    .slice(0, 4)
+    .map((gu) => ({
+      init: gu.user.name?.charAt(0)?.toUpperCase() || "?",
+      color: getUserColor(gu.user.name ?? null),
+    }));
+
+  const memberCount = (group.groupUsers ?? []).length;
+  const expenseCount = Array.isArray(group.expenses) ? group.expenses.length : 0;
+  const ago = formatRelativeTime(group.updatedAt instanceof Date ? group.updatedAt : new Date(group.updatedAt));
+  const isEmpty = expenseCount === 0;
+  const subtitle = `${memberCount} ${memberCount === 1 ? "person" : "people"} · ${expenseCount} expense${expenseCount !== 1 ? "s" : ""} · ${ago}`;
 
   return (
     <motion.div variants={slideUp}>
-      <Link
-        href={groupUrl}
-        className="flex items-center w-full text-left transition-colors hover:bg-white/[0.03] py-4 px-4 sm:py-[18px] sm:px-6"
-        style={{ gap: 16 }}
-      >
-        <GroupAvatar items={avatarItems} size={52} radius={17} />
-        <div className="min-w-0 flex-1">
-          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 5 }}>
-            <p className="text-[15px] font-extrabold text-white truncate tracking-[-0.01em]" style={{ color: T.bright }}>
-              {group.name}
+      <Link href={`/groups/${group.id}`}>
+        <div
+          className="flex items-center gap-3 min-h-[76px] rounded-xl border cursor-pointer mb-2.5 px-4 py-4"
+          style={{
+            background: "rgba(255,255,255,0.04)",
+            borderColor: "rgba(255,255,255,0.08)",
+          }}
+        >
+          <GroupAvatar items={avatarItems} size={44} radius={14} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <p
+                className="truncate text-[15px] font-extrabold"
+                style={{ color: T.bright }}
+              >
+                {group.name}
+              </p>
+              {isEmpty && <span className="shrink-0"><Tag color={T.sub}>Empty</Tag></span>}
+            </div>
+            <p className="text-xs truncate" style={{ color: T.muted, fontWeight: 500 }}>
+              {subtitle}
             </p>
-            {isEmpty && <span className="shrink-0"><Tag color={T.sub}>Empty</Tag></span>}
           </div>
-          <p className="text-[12px] font-semibold" style={{ color: T.muted }}>
-            {memberCount} members · {expenseCount} expenses · {ago}
-          </p>
+          <GroupBalanceCell
+            group={group}
+            user={user}
+            defaultCurrency={defaultCurrency}
+            formatCurrency={formatCurrency}
+            variant="mobile"
+          />
         </div>
-        <div className="text-right shrink-0">
-          <p
-            className="font-[family-name:var(--font-dm-mono)] text-[17px] font-extrabold"
-            style={{ color: balanceLabel.color }}
-          >
-            {balanceLabel.text}
-          </p>
-          <p className="text-[11px] font-semibold mt-[3px]" style={{ color: T.muted }}>
-            total {totalLabel}
-          </p>
-        </div>
-        <div style={{ color: T.dim, display: "flex" }}>
-          {Icons.chevR()}
+      </Link>
+    </motion.div>
+  );
+}
+
+/** Desktop: row inside a shared Card */
+function GroupDesktopRow({
+  group,
+  user,
+  defaultCurrency,
+  formatCurrency,
+  isLast,
+}: {
+  group: GroupItem;
+  user: { id: string; name?: string | null } | null;
+  defaultCurrency: string;
+  formatCurrency: (amount: number, currency: string) => string;
+  isLast: boolean;
+}) {
+  const avatarItems = (group.groupUsers ?? [])
+    .slice(0, 4)
+    .map((gu) => ({
+      init: gu.user.name?.charAt(0)?.toUpperCase() || "?",
+      color: getUserColor(gu.user.name ?? null),
+    }));
+
+  const memberCount = (group.groupUsers ?? []).length;
+  const expenseCount = Array.isArray(group.expenses) ? group.expenses.length : 0;
+  const ago = formatRelativeTime(group.updatedAt instanceof Date ? group.updatedAt : new Date(group.updatedAt));
+  const isEmpty = expenseCount === 0;
+
+  return (
+    <motion.div variants={slideUp}>
+      <Link href={`/groups/${group.id}`}>
+        <div
+          className="rw"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            padding: "16px 24px",
+            borderBottom: isLast ? "none" : "1px solid rgba(255,255,255,0.06)",
+            cursor: "pointer",
+            transition: "background 0.15s",
+          }}
+        >
+          <GroupAvatar items={avatarItems} size={52} radius={17} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 5 }}>
+              <p
+                style={{
+                  fontSize: 15,
+                  fontWeight: 800,
+                  color: T.bright,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {group.name}
+              </p>
+              {isEmpty && <span className="shrink-0"><Tag color={T.sub}>Empty</Tag></span>}
+            </div>
+            <p style={{ fontSize: 12, color: T.muted, fontWeight: 600 }}>
+              {memberCount} {memberCount === 1 ? "member" : "members"} · {expenseCount} expense{expenseCount !== 1 ? "s" : ""} · {ago}
+            </p>
+          </div>
+          <GroupBalanceCell
+            group={group}
+            user={user}
+            defaultCurrency={defaultCurrency}
+            formatCurrency={formatCurrency}
+          />
+          <div style={{ color: T.dim, display: "flex", flexShrink: 0 }}>{Icons.chevR({})}</div>
         </div>
       </Link>
     </motion.div>
@@ -161,79 +272,152 @@ export function GroupsListContent(props: GroupsListContentProps) {
 
   return (
     <div>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginBottom: 26 }}>
-        <Card style={{ padding: "18px 20px" }}>
-          <p style={{ color: T.muted, fontSize: 11, marginBottom: 8, fontWeight: 700, letterSpacing: "0.05em" }}>Groups</p>
-          <p style={{ color: "#e8e8e8", fontSize: 22, fontWeight: 800, fontFamily: "monospace", letterSpacing: "-0.02em" }}>{filteredGroups.length}</p>
-        </Card>
-        <Card style={{ padding: "18px 20px" }}>
-          <p style={{ color: T.muted, fontSize: 11, marginBottom: 8, fontWeight: 700, letterSpacing: "0.05em" }}>Total spent</p>
-          <p style={{ color: "#e8e8e8", fontSize: 22, fontWeight: 800, fontFamily: "monospace", letterSpacing: "-0.02em" }}>{totalSpentFormatted}</p>
-        </Card>
-        <Card style={{ padding: "18px 20px" }}>
-          <p style={{ color: T.muted, fontSize: 11, marginBottom: 8, fontWeight: 700, letterSpacing: "0.05em" }}>Net balance</p>
-          <p style={{ color: netBalanceColor, fontSize: 22, fontWeight: 800, fontFamily: "monospace", letterSpacing: "-0.02em" }}>{netBalanceFormatted}</p>
-        </Card>
-      </div>
+      {/* ── MOBILE layout ── */}
+      <div className="sm:hidden">
+        {/* Stats row */}
+        <div className="grid grid-cols-3 gap-2 sm:gap-[10px] mb-4 sm:mb-5">
+          {[
+            ["GROUPS", String(filteredGroups.length), "#e8e8e8"],
+            ["SPENT", totalSpentFormatted, "#e8e8e8"],
+            ["SETTLED", netBalanceFormatted, netBalanceColor],
+          ].map(([label, value, color]) => (
+            <div
+              key={label}
+              className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-3 text-center"
+            >
+              <p className="text-[10px] font-bold uppercase tracking-wider mb-1 truncate" style={{ color: T.muted }}>
+                {label}
+              </p>
+              <p className="text-sm font-extrabold truncate tabular-nums" style={{ color, fontFamily: "var(--font-dm-mono,monospace)" }}>
+                {value}
+              </p>
+            </div>
+          ))}
+        </div>
 
-      <Card style={{ padding: 0 }}>
+        {/* Group cards */}
         {filteredGroups.length === 0 ? (
-          <div style={{ padding: "50px", textAlign: "center" }}>
+          <div style={{ padding: "50px 20px", textAlign: "center", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)", borderRadius: 20 }}>
             <p style={{ fontSize: 15, fontWeight: 600, color: T.muted }}>No groups found</p>
           </div>
         ) : (
           <motion.div variants={staggerContainer} initial="initial" animate="animate">
-            {filteredGroups.map((group, idx) => (
-              <div
+            {filteredGroups.map((group) => (
+              <GroupMobileCard
                 key={group.id}
-                style={{
-                  borderBottom: idx < filteredGroups.length - 1 ? "1px solid rgba(255,255,255,0.06)" : "none",
-                }}
-              >
-                <GroupCard
+                group={group}
+                user={user}
+                defaultCurrency={defaultCurrency}
+                formatCurrency={formatCurrency}
+              />
+            ))}
+          </motion.div>
+        )}
+
+        {/* Create New Group button */}
+        <button
+          onClick={() => document.dispatchEvent(new CustomEvent("open-create-group-modal"))}
+          style={{
+            width: "100%", padding: "16px", background: "rgba(255,255,255,0.03)",
+            border: "1.5px dashed rgba(255,255,255,0.13)", borderRadius: 20,
+            color: T.muted, fontSize: 14, fontWeight: 700, cursor: "pointer",
+            fontFamily: "inherit", display: "flex", alignItems: "center",
+            justifyContent: "center", gap: 8, marginTop: 4,
+          }}
+        >
+          + Create New Group
+        </button>
+      </div>
+
+      {/* ── DESKTOP layout ── */}
+      <div className="hidden sm:block">
+        {/* Stats row */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginBottom: 26 }}>
+          {([
+            ["Groups", String(filteredGroups.length), "#e8e8e8"],
+            ["Total spent", totalSpentFormatted, "#e8e8e8"],
+            ["Net balance", netBalanceFormatted, netBalanceColor],
+          ] as [string, string, string][]).map(([label, value, color]) => (
+            <Card key={label} style={{ padding: "18px 20px" }}>
+              <p style={{ color: T.muted, fontSize: 11, marginBottom: 8, fontWeight: 700, letterSpacing: "0.05em" }}>{label}</p>
+              <p style={{ color, fontSize: 22, fontWeight: 800, fontFamily: "var(--font-dm-mono,monospace)", letterSpacing: "-0.02em" }}>{value}</p>
+            </Card>
+          ))}
+        </div>
+
+        {filteredGroups.length === 0 ? (
+          <div style={{ padding: "50px 20px", textAlign: "center", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)", borderRadius: 20 }}>
+            <p style={{ fontSize: 15, fontWeight: 600, color: T.muted }}>No groups found</p>
+          </div>
+        ) : (
+          <Card>
+            <motion.div variants={staggerContainer} initial="initial" animate="animate" style={{ overflow: "hidden" }}>
+              {filteredGroups.map((group, idx) => (
+                <GroupDesktopRow
+                  key={group.id}
                   group={group}
                   user={user}
                   defaultCurrency={defaultCurrency}
                   formatCurrency={formatCurrency}
+                  isLast={idx === filteredGroups.length - 1}
                 />
-              </div>
-            ))}
-          </motion.div>
+              ))}
+            </motion.div>
+          </Card>
         )}
-      </Card>
+      </div>
 
+      {/* Delete confirmation modal */}
       {showDeleteModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 brightness-50 p-4">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
           <div className="relative z-10 w-full max-w-[360px] sm:max-w-[400px] rounded-xl bg-[#101012] p-4 sm:p-6">
             <div className="mb-4 flex items-center justify-between">
               <h3 className="text-lg sm:text-xl font-medium text-white">Delete Group</h3>
-              <button onClick={() => { setShowDeleteModal(false); setGroupToDelete(null); }} className="rounded-full p-1 hover:bg-white/10">
+              <button
+                onClick={() => { setShowDeleteModal(false); setGroupToDelete(null); }}
+                className="rounded-full p-1 hover:bg-white/10"
+              >
                 <X className="h-5 w-5 text-white/70" />
               </button>
             </div>
             {deleteSuccess ? (
               <div className="flex flex-col items-center justify-center py-4">
-                <CheckCircle className="mb-3 sm:mb-4 h-8 sm:h-10 w-8 sm:w-10 text-green-500" />
-                <p className="text-center text-mobile-base sm:text-base text-white">Group &quot;{groupToDelete?.name}&quot; has been deleted.</p>
+                <CheckCircle className="mb-3 h-8 w-8 text-green-500" />
+                <p className="text-center text-sm text-white">
+                  Group &quot;{groupToDelete?.name}&quot; has been deleted.
+                </p>
               </div>
             ) : (
               <>
                 {deleteError ? (
                   <div className="mb-4 rounded-lg bg-red-500/10 p-3 text-red-400">
                     <div className="flex items-start gap-2">
-                      <AlertTriangle className="mt-0.5 h-4 sm:h-5 w-4 sm:w-5 flex-shrink-0" />
-                      <p className="text-mobile-sm sm:text-sm">{deleteError}</p>
+                      <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                      <p className="text-sm">{deleteError}</p>
                     </div>
                   </div>
                 ) : (
-                  <p className="mb-4 text-mobile-base sm:text-base text-white/70">
+                  <p className="mb-4 text-sm text-white/70">
                     Are you sure you want to delete &quot;{groupToDelete?.name}&quot;? This action cannot be undone.
                   </p>
                 )}
                 <div className="flex justify-end gap-2">
-                  <button onClick={() => { setShowDeleteModal(false); setGroupToDelete(null); }} className="rounded-lg px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-white/70 hover:bg-white/5">Cancel</button>
-                  <button onClick={confirmDelete} disabled={isDeleting} className="flex items-center gap-1.5 sm:gap-2 rounded-lg bg-red-500/10 px-3 sm:px-4 py-1.5 sm:py-2 text-mobile-sm sm:text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50">
-                    {isDeleting ? (<><Loader2 className="h-3.5 sm:h-4 w-3.5 sm:w-4 animate-spin" /><span>Deleting...</span></>) : <span>Delete</span>}
+                  <button
+                    onClick={() => { setShowDeleteModal(false); setGroupToDelete(null); }}
+                    className="rounded-lg px-4 py-2 text-sm text-white/70 hover:bg-white/5"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={confirmDelete}
+                    disabled={isDeleting}
+                    className="flex items-center gap-2 rounded-lg bg-red-500/10 px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
+                  >
+                    {isDeleting ? (
+                      <><Loader2 className="h-4 w-4 animate-spin" /><span>Deleting...</span></>
+                    ) : (
+                      <span>Delete</span>
+                    )}
                   </button>
                 </div>
               </>

--- a/components/mobile-fab.tsx
+++ b/components/mobile-fab.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { MobileSheet } from "./mobile-sheet";
+import { A, G } from "@/lib/splito-design";
+
+type FabAction = (opts: {
+  router: ReturnType<typeof useRouter>;
+  pathname: string;
+}) => void;
+
+const FAB_ITEMS: {
+  icon: string;
+  label: string;
+  sub: string;
+  color: string;
+  action: FabAction;
+}[] = [
+  {
+    icon: "💸",
+    label: "Add Expense",
+    sub: "Split a cost with your group",
+    color: A,
+    action: ({ router }) => {
+      // Route to groups so user can pick a group and add an expense
+      router.push("/groups");
+    },
+  },
+  {
+    icon: "👥",
+    label: "Create Group",
+    sub: "Start a new split group",
+    color: "#A78BFA",
+    action: ({ router, pathname }) => {
+      if (pathname.startsWith("/groups")) {
+        // Groups list is already mounted – open the modal directly
+        document.dispatchEvent(new CustomEvent("open-create-group-modal"));
+      } else {
+        // Navigate to groups and auto-open create modal there
+        router.push("/groups?openCreate=1");
+      }
+    },
+  },
+  {
+    icon: "🤝",
+    label: "Add Friend",
+    sub: "Invite someone to Splito",
+    color: G,
+    action: ({ router }) => {
+      // Go to Friends page – invite is done via the inline email field + Invite button
+      router.push("/friends");
+    },
+  },
+];
+
+export function MobileFAB() {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // Hide on settings/profile page and on group detail pages
+  const isHidden =
+    pathname.startsWith("/settings") ||
+    (pathname.startsWith("/groups/") && pathname !== "/groups");
+
+  if (isHidden) return null;
+
+  return (
+    <>
+      {/* FAB button — mobile only */}
+      <button
+        onClick={() => setOpen(true)}
+        className="sm:!hidden  !flex"
+        style={{
+          position: "fixed",
+          bottom: 70,
+          right: 20,
+          width: 56,
+          height: 56,
+          borderRadius: "50%",
+          background: A,
+          border: "none",
+          color: "#0a0a0a",
+          fontSize: 26,
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          boxShadow: `0 6px 28px ${A}55, 0 2px 8px rgba(0,0,0,0.5)`,
+          zIndex: 50,
+          fontWeight: 900,
+          lineHeight: 1,
+          transition: "transform 0.15s, box-shadow 0.15s",
+        }}
+        aria-label="Quick add"
+      >
+        +
+      </button>
+
+      {/* Quick-add bottom sheet */}
+      <MobileSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Quick Add"
+        height="55%"
+      >
+        <div
+          style={{
+            padding: "16px 20px 28px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+          }}
+        >
+          {FAB_ITEMS.map((item) => (
+            <button
+              key={item.label}
+              onClick={() => {
+                setOpen(false);
+                setTimeout(
+                  () => item.action({ router, pathname }),
+                  100
+                );
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 14,
+                padding: "16px",
+                background: "rgba(255,255,255,0.04)",
+                border: `1px solid ${item.color}22`,
+                borderRadius: 18,
+                cursor: "pointer",
+                textAlign: "left",
+                width: "100%",
+                fontFamily: "inherit",
+              }}
+            >
+              <div
+                style={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 15,
+                  background: `${item.color}18`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 24,
+                  flexShrink: 0,
+                }}
+              >
+                {item.icon}
+              </div>
+              <div>
+                <p style={{ color: "#fff", fontSize: 15, fontWeight: 700 }}>
+                  {item.label}
+                </p>
+                <p style={{ color: "#999", fontSize: 12, marginTop: 2 }}>
+                  {item.sub}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+      </MobileSheet>
+    </>
+  );
+}

--- a/components/mobile-sheet.tsx
+++ b/components/mobile-sheet.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function MobileSheet({
+  open,
+  onClose,
+  children,
+  title,
+  height = "82%",
+}: {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  title?: string;
+  height?: string;
+}) {
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 200,
+        background: "rgba(0,0,0,0.78)",
+        backdropFilter: "blur(10px)",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-end",
+        alignItems: "center",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "linear-gradient(180deg,#161616 0%,#111 100%)",
+          borderRadius: "26px 26px 0 0",
+          height,
+          display: "flex",
+          flexDirection: "column",
+          animation: "mobileSheetUp 0.32s cubic-bezier(.34,1.2,.64,1)",
+          width: "100%",
+          maxWidth: 430,
+        }}
+      >
+        {/* Handle */}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "14px 0 6px",
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              width: 40,
+              height: 4,
+              borderRadius: 99,
+              background: "rgba(255,255,255,0.15)",
+            }}
+          />
+        </div>
+
+        {/* Title */}
+        {title && (
+          <div
+            style={{
+              padding: "4px 22px 14px",
+              borderBottom: "1px solid rgba(255,255,255,0.07)",
+              flexShrink: 0,
+            }}
+          >
+            <p
+              style={{
+                fontSize: 18,
+                fontWeight: 800,
+                color: "#fff",
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {title}
+            </p>
+          </div>
+        )}
+
+        <div style={{ flex: 1, overflowY: "auto" }}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/components/onboarding-modal.tsx
+++ b/components/onboarding-modal.tsx
@@ -39,73 +39,83 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
   const canSubmit = displayName.trim().length > 0 && !isPending;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 p-4">
-      <div
-        className="relative w-full max-w-md rounded-xl border border-[#27272a] bg-[#18181b] p-6 shadow-xl"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="onboarding-title"
-      >
-        <h2
-          id="onboarding-title"
-          className="text-lg font-semibold text-white"
+    <div className="fixed inset-0 z-[100] h-screen w-screen">
+      <div className="fixed inset-0 bg-black/80" />
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-[420px] px-4">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="onboarding-title"
+          className="relative"
+          style={{
+            background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)",
+            border: "1px solid rgba(255,255,255,0.09)",
+            borderRadius: 24,
+            padding: 24,
+            boxShadow: "0 40px 100px rgba(0,0,0,0.8)",
+          }}
         >
-          Welcome! Set up your profile
-        </h2>
-        <p className="mt-1 text-sm text-zinc-400">
-          You can change these later in Settings.
-        </p>
-
-        <form onSubmit={handleSubmit} className="mt-6 space-y-5">
-          <div>
-            <label
-              htmlFor="onboarding-display-name"
-              className="mb-1.5 block text-sm font-medium text-zinc-300"
-            >
-              Display name <span className="text-red-400">*</span>
-            </label>
-            <input
-              id="onboarding-display-name"
-              type="text"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="How should we call you?"
-              className="w-full rounded-lg border border-[#3f3f46] bg-[#27272a] px-3 py-2 text-white placeholder:text-zinc-500 focus:border-[#71717a] focus:outline-none focus:ring-1 focus:ring-[#71717a]"
-              autoFocus
-              required
-              minLength={1}
-              maxLength={100}
-            />
-          </div>
-
-          <div className="rounded-lg border border-[#3f3f46] bg-[#27272a]/50 px-3 py-2.5">
-            <p className="text-sm text-zinc-400">
-              Default currency:{" "}
-              <span className="font-medium text-white">
-                {PLATFORM_DEFAULT_CURRENCY}
-              </span>
-            </p>
-            <p className="mt-0.5 text-xs text-zinc-500">
-              Amounts will be shown in this currency. You can change it in
-              Settings.
-            </p>
-          </div>
-
-          <Button
-            type="submit"
-            disabled={!canSubmit}
-            className="w-full"
+          <h2
+            id="onboarding-title"
+            className="text-[20px] font-extrabold text-white tracking-[-0.02em]"
           >
-            {isPending ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Saving…
-              </>
-            ) : (
-              "Continue"
-            )}
-          </Button>
-        </form>
+            Welcome! Set up your profile
+          </h2>
+          <p className="mt-1 text-[13px] text-zinc-400">
+            You can change these later in Settings.
+          </p>
+
+          <form onSubmit={handleSubmit} className="mt-6 space-y-5">
+            <div>
+              <label
+                htmlFor="onboarding-display-name"
+                className="mb-1.5 block text-[13px] font-medium text-zinc-300"
+              >
+                Display name <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="onboarding-display-name"
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="How should we call you?"
+                className="w-full rounded-[14px] border border-white/10 bg-white/5 px-3 py-2.5 text-[14px] text-white placeholder:text-zinc-500 focus:border-white/30 focus:outline-none focus:ring-0"
+                autoFocus
+                required
+                minLength={1}
+                maxLength={100}
+              />
+            </div>
+
+            <div className="rounded-[14px] border border-white/10 bg-white/[0.03] px-3.5 py-3">
+              <p className="text-[13px] text-zinc-300">
+                Default currency:{" "}
+                <span className="font-semibold text-white">
+                  {PLATFORM_DEFAULT_CURRENCY}
+                </span>
+              </p>
+              <p className="mt-0.5 text-[11px] text-zinc-500">
+                Amounts will be shown in this currency. You can change it in
+                Settings.
+              </p>
+            </div>
+
+            <Button
+              type="submit"
+              disabled={!canSubmit}
+              className="w-full h-11 rounded-[14px] font-semibold"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                "Continue"
+              )}
+            </Button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/components/personal-mobile-nav.tsx
+++ b/components/personal-mobile-nav.tsx
@@ -2,15 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutDashboard, Users2, UserCircle, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { A } from "@/lib/splito-design";
+import { A, Icons } from "@/lib/splito-design";
 
 const NAV_ITEMS = [
-  { key: "home", label: "Home", href: "/", icon: LayoutDashboard },
-  { key: "groups", label: "Groups", href: "/groups", icon: Users2 },
-  { key: "friends", label: "Friends", href: "/friends", icon: UserCircle },
-  { key: "profile", label: "Profile", href: "/settings", icon: Settings },
+  { key: "home",     label: "Home",     href: "/",        icon: Icons.home     },
+  { key: "groups",   label: "Groups",   href: "/groups",  icon: Icons.groups   },
+  { key: "friends",  label: "Friends",  href: "/friends", icon: Icons.friends  },
+  { key: "settings", label: "Settings", href: "/settings",icon: Icons.settings },
 ];
 
 export function PersonalMobileNav() {
@@ -23,7 +22,7 @@ export function PersonalMobileNav() {
 
   return (
     <nav
-      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px] z-40 min-[1025px]:hidden"
+      className="fixed -bottom-4 left-1/2 -translate-x-1/2 w-full max-w-[430px] z-40 min-[1025px]:hidden"
       style={{
         background: "rgba(10,10,10,0.97)",
         backdropFilter: "blur(20px)",
@@ -34,7 +33,6 @@ export function PersonalMobileNav() {
       <div className="flex justify-around">
         {NAV_ITEMS.map((item) => {
           const active = isActive(item.href);
-          const Icon = item.icon;
           return (
             <Link
               key={item.key}
@@ -50,11 +48,7 @@ export function PersonalMobileNav() {
                   active && "bg-[#22D3EE]/20"
                 )}
               >
-                <Icon
-                  className="w-5 h-5 shrink-0"
-                  strokeWidth={active ? 2.2 : 1.8}
-                  style={{ color: active ? A : "inherit" }}
-                />
+                {item.icon({ size: 20 })}
               </div>
               <span
                 className={cn(

--- a/components/settle-debts-modal.tsx
+++ b/components/settle-debts-modal.tsx
@@ -10,6 +10,7 @@ import { GroupBalance, User } from "@/api-helpers/modelSchema";
 import { useSettleDebt } from "@/features/settle/hooks/use-splits";
 import { useMarkAsPaid } from "@/features/groups/hooks/use-create-group";
 import { useHandleEscapeToCloseModal } from "@/hooks/useHandleEscape";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { useQueryClient } from "@tanstack/react-query";
 import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
@@ -863,6 +864,8 @@ export function SettleDebtsModal({
     );
   };
 
+  const isMobile = useIsMobile();
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -872,21 +875,33 @@ export function SettleDebtsModal({
         >
           <motion.div
             className="fixed inset-0 bg-black/70 brightness-50"
+            style={isMobile ? { backdropFilter: "blur(10px)" } : undefined}
             onClick={onClose}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
           />
-          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full md:w-[90%] max-w-[500px] px-4 sm:px-0">
+          <div
+            className={
+              isMobile
+                ? "modal-as-sheet-wrapper fixed inset-x-0 bottom-0 z-10 w-full max-w-[430px] mx-auto"
+                : "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full md:w-[90%] max-w-[500px] px-4 sm:px-0"
+            }
+          >
+            {isMobile && <div className="modal-as-sheet-handle" />}
             {/* Settle All Debts Section - Only shown when header button is clicked */}
             {!showIndividualView && (
               <motion.div
-                className="relative z-10 rounded-[28px] p-7 border border-white/[0.09] shadow-[0_40px_100px_rgba(0,0,0,0.8)] max-h-[90vh] overflow-y-auto"
-                style={{ background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)" }}
-                {...scaleIn}
+                className={
+                  isMobile
+                    ? "modal-as-sheet-card relative z-10 p-5 sm:p-7"
+                    : "relative z-10 rounded-[28px] p-7 border border-white/[0.09] shadow-[0_40px_100px_rgba(0,0,0,0.8)] max-h-[90vh] overflow-y-auto"
+                }
+                style={isMobile ? undefined : { background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)" }}
+                {...(isMobile ? { initial: { y: "100%" }, animate: { y: 0 }, transition: { type: "tween", duration: 0.32, ease: [0.34, 1.2, 0.64, 1] } } : scaleIn)}
               >
-                <div className="flex items-center justify-between mb-5">
+                <div className={`flex items-center justify-between mb-5 ${isMobile ? "modal-as-sheet-title-bar pb-4" : ""}`}>
                   <div>
-                    <h2 className="text-xl font-extrabold text-white tracking-tight">
+                    <h2 className={`font-extrabold text-white tracking-tight ${isMobile ? "text-lg" : "text-xl"}`}>
                       Settle Debts
                     </h2>
                     <p className="mt-1.5 text-xs text-white/55">{displayGroupName}</p>
@@ -1271,13 +1286,17 @@ export function SettleDebtsModal({
             {/* Settle Individual Debt Section - Only shown when a friend's button is clicked */}
             {showIndividualView && (
               <motion.div
-                className="relative z-10 rounded-[28px] p-7 border border-white/[0.09] shadow-[0_40px_100px_rgba(0,0,0,0.8)] max-h-[90vh] overflow-y-auto"
-                style={{ background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)" }}
-                {...scaleIn}
+                className={
+                  isMobile
+                    ? "modal-as-sheet-card relative z-10 p-5 sm:p-7"
+                    : "relative z-10 rounded-[28px] p-7 border border-white/[0.09] shadow-[0_40px_100px_rgba(0,0,0,0.8)] max-h-[90vh] overflow-y-auto"
+                }
+                style={isMobile ? undefined : { background: "linear-gradient(160deg, #141414 0%, #0f0f0f 100%)" }}
+                {...(isMobile ? { initial: { y: "100%" }, animate: { y: 0 }, transition: { type: "tween", duration: 0.32, ease: [0.34, 1.2, 0.64, 1] } } : scaleIn)}
               >
-                <div className="flex items-center justify-between mb-5">
+                <div className={`flex items-center justify-between mb-5 ${isMobile ? "modal-as-sheet-title-bar pb-4" : ""}`}>
                   <div>
-                    <h2 className="text-xl font-extrabold text-white tracking-tight">
+                    <h2 className={`font-extrabold text-white tracking-tight ${isMobile ? "text-lg" : "text-xl"}`}>
                       Settle {selectedUser ? (selectedUser.name || "Member").split(" ")[0] : "Debt"}
                     </h2>
                     <p className="mt-1.5 text-xs text-white/55">Individual settlement</p>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -325,7 +325,7 @@ export function Sidebar() {
           {!isOrganizationMode && (
             <>
               <div className="mt-7 flex-1 overflow-y-auto min-h-0">
-                <p className="text-[10px] font-extrabold tracking-[0.12em] uppercase px-[13px] mb-2" style={{ color: "rgba(255,255,255,0.32)" }}>GROUPS</p>
+                <p className="text-[10px] font-extrabold tracking-[0.12em] uppercase px-[13px] mb-2" style={{ color: "#777" }}>GROUPS</p>
                 <div className="flex flex-col gap-px">
                   {groups.map((g) => {
                     const isActive = pathname.startsWith(`/groups/${g.id}`);

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/** True when viewport width is < 768px (mobile). Use for bottom-sheet modals. */
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    const set = () => setIsMobile(mq.matches);
+    set();
+    mq.addEventListener("change", set);
+    return () => mq.removeEventListener("change", set);
+  }, []);
+
+  return isMobile;
+}

--- a/lib/splito-design.tsx
+++ b/lib/splito-design.tsx
@@ -419,7 +419,7 @@ export const BackBtn = ({
       transition: "all 0.2s",
     }}
   >
-    ← Back
+    ←
   </button>
 );
 


### PR DESCRIPTION
Mobile design & layout:-
-Group page tabs (mobile): Tab order set to Splits → Members → Activity in group-info-header.tsx.
-Splits page (mobile): Dropdown arrow/chevron on the expense list hidden on mobile (max-md:hidden in groups/[id]/splits/page.tsx).
-Members tab (mobile): Members list layout fixed: consistent row height/padding, “You” pill for current user, aligned -Settle/Notify and “You”, truncation and responsive padding in groups/[id]/members/page.tsx.
-Groups list (mobile): GroupMobileCard and mobile stats tightened in groups-list-content.tsx (min-height, padding, smaller avatar, truncation); GroupBalanceCell has variant="mobile" | "desktop" for sizing.

Quick Add & FAB:-
-Quick Add (FAB): All actions wired: Add Expense → /groups, Create Group → open create modal (or /groups?openCreate=1), Add Friend → /friends. Groups and Friends pages handle openCreate=1 and openAdd=1 (in mobile-fab.tsx and relevant pages).
-New components: mobile-fab.tsx, mobile-sheet.tsx (Quick Add sheet), and hooks/useIsMobile.ts.
Add Friend flow
-Add Friend modal removed: Invites are done inline on the Friends page (email + “Invite” using useAddFriend) in friends/page.tsx. page.tsx (home) no longer uses AddFriendsModal. friends-list.tsx uses onAddFriendClick for empty state (scroll to invite). FAB “Add Friend” only navigates to /friends.

Settings:-
-Settings stats row: Smaller font and spacing for the stats row in settings-page-content.tsx (e.g. number 18px, label 11px, reduced padding/gap).

-Bottom-sheet modals (mobile):-
-Create Group modal: On mobile uses bottom-sheet layout: useIsMobile, sheet wrapper, handle, modal-as-sheet-card, slide-up animation, modal-as-sheet-title-bar, backdrop blur (create-group-form.tsx).
-Add Expense modal: Same bottom-sheet on mobile (sheet wrapper, handle, card, slide-up, blur). Top spacing fixed: -Tighter handle padding (8px 0 4px), title bar with no top padding so “Add Expense” sits closer to the handle (add-expense-modal.tsx).
-Settle Debts modal: Both “Settle All” and “Settle Individual” use the same bottom-sheet on mobile: useIsMobile, sheet wrapper, handle, modal-as-sheet-card, slide-up, title bar, smaller title on mobile (settle-debts-modal.tsx).
-Shared styles: In globals.css, added .modal-as-sheet-wrapper, .modal-as-sheet-handle, .modal-as-sheet-card, .modal-as-sheet-title-bar, .modal-as-sheet-body, and mobileSheetUp animation.