### PR TITLE
bug fixes

### DIFF
--- a/app/organization/[organizationId]/expenses/page.tsx
+++ b/app/organization/[organizationId]/expenses/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { useParams } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
 import { useGetExpenses, useCreateExpense, useDeleteExpense } from "@/features/expenses/hooks/use-create-expense";
@@ -9,6 +10,8 @@ import { toast } from "sonner";
 import { formatCurrency } from "@/utils/formatters";
 import { Card, SectionLabel, T, A } from "@/lib/splito-design";
 import { motion, AnimatePresence } from "framer-motion";
+import CurrencyDropdown from "@/components/currency-dropdown";
+import type { Currency } from "@/features/currencies/api/client";
 
 type Expense = {
   id: string;
@@ -54,6 +57,8 @@ export default function OrganizationExpensesPage() {
   const createExpenseMutation = useCreateExpense(organizationId);
   const deleteExpenseMutation = useDeleteExpense(organizationId);
 
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
   const [modalOpen, setModalOpen] = useState(false);
   const [expenseToDelete, setExpenseToDelete] = useState<Expense | null>(null);
   const [form, setForm] = useState({
@@ -305,7 +310,7 @@ export default function OrganizationExpensesPage() {
       )}
 
       {/* ── Add Expense Modal ── */}
-      <AnimatePresence>
+      {mounted && createPortal(<AnimatePresence>
         {modalOpen && (
           <motion.div
             initial={{ opacity: 0 }}
@@ -392,17 +397,15 @@ export default function OrganizationExpensesPage() {
                     >
                       Currency
                     </label>
-                    <input
-                      type="text"
-                      value={form.currency}
-                      onChange={(e) =>
-                        setForm((p) => ({
-                          ...p,
-                          currency: e.target.value.toUpperCase(),
-                        }))
+                    <CurrencyDropdown
+                      selectedCurrencies={form.currency ? [form.currency] : []}
+                      setSelectedCurrencies={(currencies) =>
+                        setForm((p) => ({ ...p, currency: currencies[0] || "USD" }))
                       }
-                      placeholder="USD"
-                      className="w-full rounded-xl px-4 py-3 text-[14px] bg-white/[0.05] border border-white/[0.09] text-white placeholder-white/25 outline-none focus:border-white/20 transition-colors"
+                      mode="single"
+                      showFiatCurrencies={true}
+                      disableChainCurrencies={true}
+                      filterCurrencies={(c: Currency) => c.symbol !== "ETH" && c.symbol !== "USDC"}
                     />
                   </div>
                 </div>
@@ -459,7 +462,7 @@ export default function OrganizationExpensesPage() {
                     onChange={(e) =>
                       setForm((p) => ({ ...p, expenseDate: e.target.value }))
                     }
-                    className="w-full rounded-xl px-4 py-3 text-[14px] bg-white/[0.05] border border-white/[0.09] text-white outline-none focus:border-white/20 transition-colors"
+                    className="w-full rounded-xl px-4 py-3 text-[14px] bg-white/[0.05] border border-white/[0.09] text-white outline-none focus:border-white/20 transition-colors [color-scheme:dark]"
                   />
                 </div>
 
@@ -493,10 +496,10 @@ export default function OrganizationExpensesPage() {
             </motion.div>
           </motion.div>
         )}
-      </AnimatePresence>
+      </AnimatePresence>, document.body)}
 
       {/* ── Delete confirm ── */}
-      <AnimatePresence>
+      {mounted && createPortal(<AnimatePresence>
         {expenseToDelete && (
           <motion.div
             initial={{ opacity: 0 }}
@@ -571,7 +574,7 @@ export default function OrganizationExpensesPage() {
             </motion.div>
           </motion.div>
         )}
-      </AnimatePresence>
+      </AnimatePresence>, document.body)}
     </div>
   );
 }

--- a/app/organization/[organizationId]/layout.tsx
+++ b/app/organization/[organizationId]/layout.tsx
@@ -67,7 +67,7 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
   const [invoiceToEdit, setInvoiceToEdit] = useState<InvoiceForEdit | null>(null);
   const [isStreamModalOpen, setIsStreamModalOpen] = useState(false);
   const [streamToEdit, setStreamToEdit] = useState<IncomeStream | null>(null);
-  const [streamForm, setStreamForm] = useState({ name: "", currency: "USD", expectedAmount: "" as string | number, description: "" });
+  const [streamForm, setStreamForm] = useState({ name: "", currency: "USD", expectedAmount: "" as string | number, description: "", streamDate: new Date().toISOString().slice(0, 10) });
   const [isCreateContractModalOpen, setIsCreateContractModalOpen] = useState(false);
 
   const updateGroupMutation = useUpdateGroup();
@@ -123,7 +123,7 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
 
   const openAddStreamModal = () => {
     setStreamToEdit(null);
-    setStreamForm({ name: "", currency: "USD", expectedAmount: "", description: "" });
+    setStreamForm({ name: "", currency: "USD", expectedAmount: "", description: "", streamDate: new Date().toISOString().slice(0, 10) });
     setIsStreamModalOpen(true);
   };
 
@@ -134,6 +134,7 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
       currency: stream.currency,
       expectedAmount: stream.expectedAmount ?? "",
       description: stream.description ?? "",
+      streamDate: new Date(stream.streamDate).toISOString().slice(0, 10),
     });
     setIsStreamModalOpen(true);
   };
@@ -143,12 +144,12 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
     const expectedNum = streamForm.expectedAmount === "" ? null : Number(streamForm.expectedAmount);
     if (streamToEdit) {
       updateStreamMutation.mutate(
-        { organizationId, streamId: streamToEdit.id, payload: { name: streamForm.name.trim(), currency: streamForm.currency, expectedAmount: expectedNum, description: streamForm.description.trim() || null } },
+        { organizationId, streamId: streamToEdit.id, payload: { name: streamForm.name.trim(), currency: streamForm.currency, expectedAmount: expectedNum, description: streamForm.description.trim() || null, streamDate: streamForm.streamDate } },
         { onSuccess: () => { toast.success("Stream updated"); setIsStreamModalOpen(false); setStreamToEdit(null); }, onError: () => toast.error("Failed to update stream") }
       );
     } else {
       createStreamMutation.mutate(
-        { organizationId, payload: { name: streamForm.name.trim(), currency: streamForm.currency, expectedAmount: expectedNum ?? undefined, description: streamForm.description.trim() || undefined } },
+        { organizationId, payload: { name: streamForm.name.trim(), currency: streamForm.currency, expectedAmount: expectedNum ?? undefined, description: streamForm.description.trim() || undefined, streamDate: streamForm.streamDate } },
         { onSuccess: () => { toast.success("Stream added"); setIsStreamModalOpen(false); }, onError: () => toast.error("Failed to add stream") }
       );
     }
@@ -456,6 +457,10 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
                   <div>
                     <label className="block text-sm font-semibold mb-2" style={{ color: T.soft }}>Description</label>
                     <input type="text" value={streamForm.description} onChange={(e) => setStreamForm((p) => ({ ...p, description: e.target.value }))} placeholder="Notes" className="w-full rounded-xl px-4 py-2.5 bg-white/[0.05] border border-white/[0.1] text-white placeholder-white/40 outline-none focus:border-white/20" />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-semibold mb-2" style={{ color: T.soft }}>Date</label>
+                    <input type="date" value={streamForm.streamDate} onChange={(e) => setStreamForm((p) => ({ ...p, streamDate: e.target.value }))} className="w-full rounded-xl px-4 py-2.5 bg-white/[0.05] border border-white/[0.1] text-white outline-none focus:border-white/20 [color-scheme:dark]" required />
                   </div>
                   <div className="flex gap-3 pt-2">
                     <Btn variant="ghost" className="flex-1" onClick={() => { setIsStreamModalOpen(false); setStreamToEdit(null); }}>Cancel</Btn>

--- a/app/organization/page.tsx
+++ b/app/organization/page.tsx
@@ -54,6 +54,7 @@ export default function OrganizationDashboardPage() {
   const { user } = useAuthStore();
   const router = useRouter();
   const [mobileOrgSwitcherOpen, setMobileOrgSwitcherOpen] = useState(false);
+  const [chartRange, setChartRange] = useState<"week" | "month" | "year">("week");
   const mobileOrgSwitcherRef = useRef<HTMLDivElement>(null);
   const { data: organizations = [], isLoading: isOrgsLoading, isError: isOrgsError, error: orgsError } = useGetAllOrganizations();
 
@@ -100,22 +101,30 @@ export default function OrganizationDashboardPage() {
   const approvalRequestsCount = invoicesForOrg.filter((i) => i.status === "SENT").length;
   const approvalPastDueCount = invoicesForOrg.filter((i) => i.status === "SENT" && new Date(i.dueDate) < new Date()).length;
 
-  const { data: analyticsData, isLoading: isAnalyticsLoading } = useGetOrganizationAnalytics(selectedOrgId);
+  const { data: analyticsData, isLoading: isAnalyticsLoading } = useGetOrganizationAnalytics(selectedOrgId, chartRange);
   const expenseThisMonth = analyticsData?.expenseThisMonth ?? 0;
   const totalPaid = analyticsData?.totalPaid ?? 0;
-  const totalInflow = analyticsData?.totalInflow ?? 0;
-  const byMonth = analyticsData?.inflowOutflowByMonth ?? [];
-  const formatMonthLabel = (monthStr: string) => {
-    const [y, m] = (monthStr || "").split("-");
-    if (!m) return monthStr;
-    const months = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split(" ");
-    return `${months[parseInt(m, 10) - 1]} ${(y || "").slice(-2)}`;
-  };
-  const lineChartData = byMonth.map((m: { month: string; inflow: number; outflow: number }) => ({
-    month: formatMonthLabel(m.month),
-    inflow: m.inflow,
-    outflow: m.outflow,
-  }));
+  const totalInflow = streamsForOrg.reduce((sum, s) => sum + (s.expectedAmount ?? 0), 0);
+  const outflowByPeriod = analyticsData?.outflowByPeriod ?? [];
+
+  // Compute inflow per bucket from streams createdAt (same bucketing logic as backend)
+  const lineChartData = outflowByPeriod.map((bucket) => {
+    const bucketLabel = bucket.month;
+    // Find matching streams: parse the label back to a date range for comparison
+    const inflow = streamsForOrg
+      .filter((s) => {
+        const d = new Date(s.streamDate);
+        if (chartRange === "year") {
+          const label = d.toLocaleDateString("en-US", { month: "short" }) + " " + String(d.getFullYear()).slice(-2);
+          return label === bucketLabel;
+        }
+        // week / month: label is "Mon D" (e.g. "Mar 16")
+        const label = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+        return label === bucketLabel;
+      })
+      .reduce((sum, s) => sum + (s.expectedAmount ?? 0), 0);
+    return { month: bucketLabel, inflow, outflow: bucket.outflow };
+  });
 
   const membersMap = new Map<string, { id: string; name: string | null; image: string | null; email: string | null; orgNames: string[] }>();
   organizations.forEach((org) => {
@@ -467,17 +476,36 @@ export default function OrganizationDashboardPage() {
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                 {/* Chart: two columns */}
                 <Card className="lg:col-span-2 p-4 sm:p-5 min-w-0">
-                  <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-[14px] font-bold" style={{ color: T.bright }}>Inflow vs outflow · last 6 months</h3>
-                    <div className="flex gap-4 text-[11px]" style={{ color: T.muted }}>
-                      <span className="flex items-center gap-1.5">
-                        <span className="w-3 h-0.5 rounded-full" style={{ background: G }} />
-                        Inflow
-                      </span>
-                      <span className="flex items-center gap-1.5">
-                        <span className="w-3 h-0.5 rounded-full" style={{ background: "#F87171" }} />
-                        Outflow
-                      </span>
+                  <div className="flex items-center justify-between mb-4 gap-3 flex-wrap">
+                    <h3 className="text-[14px] font-bold" style={{ color: T.bright }}>Inflow vs outflow</h3>
+                    <div className="flex items-center gap-3">
+                      {/* Range tabs */}
+                      <div className="flex rounded-lg overflow-hidden" style={{ border: "1px solid rgba(255,255,255,0.08)" }}>
+                        {(["week", "month", "year"] as const).map((r) => (
+                          <button
+                            key={r}
+                            onClick={() => setChartRange(r)}
+                            className="px-3 py-1 text-[11px] font-semibold transition-colors capitalize"
+                            style={{
+                              background: chartRange === r ? "rgba(255,255,255,0.1)" : "transparent",
+                              color: chartRange === r ? T.bright : T.muted,
+                            }}
+                          >
+                            {r}
+                          </button>
+                        ))}
+                      </div>
+                      {/* Legend */}
+                      <div className="flex gap-4 text-[11px]" style={{ color: T.muted }}>
+                        <span className="flex items-center gap-1.5">
+                          <span className="w-3 h-0.5 rounded-full" style={{ background: G }} />
+                          Inflow
+                        </span>
+                        <span className="flex items-center gap-1.5">
+                          <span className="w-3 h-0.5 rounded-full" style={{ background: "#F87171" }} />
+                          Outflow
+                        </span>
+                      </div>
                     </div>
                   </div>
                   {lineChartData.length === 0 ? (

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -165,6 +165,26 @@ export default function SettingsPage() {
     }
   };
 
+  // Auto-save currency change immediately (no save button needed for dropdown)
+  const handleCurrencyChange = (newCurrency: string) => {
+    if (!newCurrency || newCurrency === initialPreferredCurrency) return;
+    setPreferredCurrency(newCurrency);
+    updateUser({ currency: newCurrency }, {
+      onSuccess: () => {
+        setInitialPreferredCurrency(newCurrency);
+        if (user) {
+          setUser({ ...user, currency: newCurrency });
+        }
+        toast.success("Currency updated");
+      },
+      onError: (error) => {
+        toast.error("Failed to update currency");
+        console.error("Error updating currency:", error);
+        setPreferredCurrency(initialPreferredCurrency); // revert on error
+      },
+    });
+  };
+
   // Logout handler
   const handleLogout = async () => {
     try {
@@ -344,6 +364,7 @@ export default function SettingsPage() {
     setDisplayName,
     preferredCurrency,
     setPreferredCurrency,
+    onCurrencyChange: handleCurrencyChange,
     hasChanges,
     handleSaveChanges,
     isUpdatatingUser,

--- a/app/settings/settings-page-content.tsx
+++ b/app/settings/settings-page-content.tsx
@@ -24,6 +24,7 @@ export interface SettingsPageContentProps {
   setDisplayName: (v: string) => void;
   preferredCurrency: string;
   setPreferredCurrency: (v: string) => void;
+  onCurrencyChange?: (v: string) => void;
   hasChanges: boolean;
   handleSaveChanges: () => void;
   isUpdatatingUser: boolean;
@@ -305,6 +306,7 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
     setDisplayName,
     preferredCurrency,
     setPreferredCurrency,
+    onCurrencyChange,
     hasChanges: _hasChanges,
     handleSaveChanges,
     isUpdatatingUser,
@@ -628,7 +630,11 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
             <div style={{ minWidth: 220 }}>
               <CurrencyDropdown
                 selectedCurrencies={preferredCurrency ? [preferredCurrency] : []}
-                setSelectedCurrencies={(currencies) => setPreferredCurrency(currencies[0] || "")}
+                setSelectedCurrencies={(currencies) => {
+                  const newCurrency = currencies[0] || "";
+                  setPreferredCurrency(newCurrency);
+                  onCurrencyChange?.(newCurrency);
+                }}
                 mode="single"
                 showFiatCurrencies={true}
                 filterCurrencies={(currency: Currency) => currency.symbol !== "ETH" && currency.symbol !== "USDC"}

--- a/features/business/api/client.ts
+++ b/features/business/api/client.ts
@@ -106,6 +106,7 @@ export const IncomeStreamSchema = z.object({
   currency: z.string(),
   expectedAmount: z.number().nullable(),
   description: z.string().nullable(),
+  streamDate: z.coerce.date(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
 });
@@ -199,13 +200,12 @@ export const getOrganizationActivity = async (organizationId: string) => {
   return OrganizationActivitySchema.array().parse(response);
 };
 
-export const getOrganizationAnalytics = async (organizationId: string) => {
-  const response = await apiClient.get(`/invoices/organization/${organizationId}/analytics`);
+export const getOrganizationAnalytics = async (organizationId: string, range: "week" | "month" | "year" = "week") => {
+  const response = await apiClient.get(`/invoices/organization/${organizationId}/analytics?range=${range}`);
   return response as unknown as {
     expenseThisMonth: number;
     totalPaid: number;
-    totalInflow: number;
-    inflowOutflowByMonth: { month: string; inflow: number; outflow: number }[];
+    outflowByPeriod: { month: string; outflow: number }[];
   };
 };
 
@@ -221,7 +221,7 @@ export const getStreamsByOrganization = async (organizationId: string) => {
 
 export const createStream = async (
   organizationId: string,
-  payload: { name: string; currency?: string; expectedAmount?: number | null; description?: string | null }
+  payload: { name: string; currency?: string; expectedAmount?: number | null; description?: string | null; streamDate?: string }
 ) => {
   const response = await apiClient.post(`/groups/${organizationId}/streams`, payload);
   return IncomeStreamSchema.parse(response);
@@ -230,7 +230,7 @@ export const createStream = async (
 export const updateStream = async (
   organizationId: string,
   streamId: string,
-  payload: { name?: string; currency?: string; expectedAmount?: number | null; description?: string | null }
+  payload: { name?: string; currency?: string; expectedAmount?: number | null; description?: string | null; streamDate?: string }
 ) => {
   const response = await apiClient.put(`/groups/${organizationId}/streams/${streamId}`, payload);
   return IncomeStreamSchema.parse(response);

--- a/features/business/hooks/use-invoices.ts
+++ b/features/business/hooks/use-invoices.ts
@@ -113,10 +113,10 @@ export const useGetOrganizationActivity = (organizationId: string) => {
   });
 };
 
-export const useGetOrganizationAnalytics = (organizationId: string) => {
+export const useGetOrganizationAnalytics = (organizationId: string, range: "week" | "month" | "year" = "week") => {
   return useQuery({
-    queryKey: [QueryKeys.INVOICES, organizationId, "analytics"],
-    queryFn: () => getOrganizationAnalytics(organizationId),
+    queryKey: [QueryKeys.INVOICES, organizationId, "analytics", range],
+    queryFn: () => getOrganizationAnalytics(organizationId, range),
     enabled: !!organizationId,
   });
 };


### PR DESCRIPTION
  Expenses page (organization/[organizationId]/expenses/page.tsx)                                                                               
  - Replaced currency text input with the app's CurrencyDropdown component (single-select, fiat only)                                           
  - Fixed "Missing required fields" API error — backend was reading groupId from request body instead of URL params                             
  - Fixed modal overlay showing space above it — both modals (log expense + delete confirm) now render via createPortal into document.body to   
  escape the layout's stacking context                                                                                                          
  - Fixed date picker icon appearing black — added [color-scheme:dark] to the date input                                                        
                                                                                                                                                
  Settings page (settings/page.tsx + settings-page-content.tsx)                                                                                 
  - Fixed default currency not saving — changing the currency dropdown now auto-saves immediately via API without requiring a "Save Changes"    
  button click (which was in a different card section)                                                                                          
  - Added revert-on-error behaviour — currency reverts to previous value if the API call fails                                                