### PR TITLE
revisions

### DIFF
--- a/app/groups/[id]/activity/page.tsx
+++ b/app/groups/[id]/activity/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { useAuthStore } from "@/stores/authStore";
 import { formatRelativeTime } from "@/lib/utils";
 import { Card, SectionLabel, T, A, G } from "@/lib/splito-design";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 
 type ExpenseItem = {
   id: string;
@@ -46,7 +49,43 @@ const DOT_COLORS: Record<string, string> = {
 
 export default function GroupActivityPage() {
   const { user } = useAuthStore();
-  const { group, formatCurrency } = useGroupLayout();
+  const { group, formatCurrency, defaultCurrency } = useGroupLayout();
+
+  // Fetch exchange rates for all unique expense currencies that differ from defaultCurrency
+  const expenseCurrencies = useMemo(() => {
+    const currencies = new Set<string>();
+    (group?.expenses ?? []).forEach((e: { currency: string | null }) => {
+      if (e.currency) currencies.add(e.currency);
+    });
+    currencies.delete(defaultCurrency);
+    return [...currencies].filter(Boolean);
+  }, [group, defaultCurrency]);
+
+  const rateQueries = useQueries({
+    queries: expenseCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+
+  const rateMap = useMemo(() => {
+    const map: Record<string, number> = { [defaultCurrency]: 1 };
+    expenseCurrencies.forEach((c, i) => {
+      const rate = rateQueries[i]?.data?.rate;
+      if (rate) map[c] = rate;
+    });
+    return map;
+  }, [expenseCurrencies, rateQueries, defaultCurrency]);
+
+  const convertedFormatCurrency = (amount: number, currency: string | null): string => {
+    const src = currency || defaultCurrency;
+    if (src === defaultCurrency) return formatCurrency(amount, defaultCurrency);
+    const rate = rateMap[src];
+    if (!rate) return formatCurrency(amount, src); // show original while rate loads
+    return formatCurrency(amount * rate, defaultCurrency);
+  };
 
   const activities = useMemo((): ActivityItem[] => {
     if (!group || !user) return [];
@@ -163,10 +202,7 @@ export default function GroupActivityPage() {
             } = item;
             const isYouPayer = expense.paidBy === user.id;
             const payerLabel = isYouPayer ? "You" : paidByName;
-            const amountStr = formatCurrency(
-              expense.amount,
-              expense.currency || "USD"
-            );
+            const amountStr = convertedFormatCurrency(expense.amount, expense.currency);
 
             let activityType: keyof typeof DOT_COLORS = "added";
             if (

--- a/app/groups/[id]/members/page.tsx
+++ b/app/groups/[id]/members/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
 import { Trash2 } from "lucide-react";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { useAuthStore } from "@/stores/authStore";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 import {
   Card,
   SectionLabel,
@@ -35,25 +38,55 @@ export default function GroupMembersPage() {
     handleSendReminder,
     formatCurrency,
     defaultCurrency,
-    getSpecificDebtAmount,
+    getSpecificDebtByCurrency,
   } = useGroupLayout();
+
+  // Collect all unique currencies from expenses and balances that differ from defaultCurrency
+  const allCurrencies = useMemo(() => {
+    const currencies = new Set<string>();
+    (group?.expenses ?? []).forEach((e: { currency: string }) => currencies.add(e.currency));
+    (group?.groupBalances ?? []).forEach((b: { currency: string }) => currencies.add(b.currency));
+    currencies.delete(defaultCurrency);
+    return [...currencies].filter(Boolean);
+  }, [group, defaultCurrency]);
+
+  const rateQueries = useQueries({
+    queries: allCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+
+  const rateMap = useMemo(() => {
+    const map: Record<string, number> = { [defaultCurrency]: 1 };
+    allCurrencies.forEach((c, i) => {
+      const rate = rateQueries[i]?.data?.rate;
+      if (rate) map[c] = rate;
+    });
+    return map;
+  }, [allCurrencies, rateQueries, defaultCurrency]);
+
+  const convert = (amount: number, currency: string) =>
+    amount * (rateMap[currency] ?? 1);
 
   const { totalSpent, youAreOwed, expenseCount } = useMemo(() => {
     if (!group || !user) return { totalSpent: 0, youAreOwed: 0, expenseCount: 0 };
     const totalSpent = (group.expenses ?? [])
       .filter((e: { splitType?: string }) => e.splitType !== "SETTLEMENT")
-      .reduce((a: number, e: { amount: number }) => a + e.amount, 0);
+      .reduce((a: number, e: { amount: number; currency: string }) => a + convert(e.amount, e.currency), 0);
     const youAreOwed = (group.groupBalances ?? [])
       .filter(
-        (b: { userId: string; firendId: string; amount: number }) =>
-          b.userId === user.id && b.amount > 0
+        (b: { userId: string; amount: number }) => b.userId === user.id && b.amount > 0
       )
-      .reduce((a: number, b: { amount: number }) => a + b.amount, 0);
+      .reduce((a: number, b: { amount: number; currency: string }) => a + convert(b.amount, b.currency), 0);
     const expenseCount = (group.expenses ?? []).filter(
       (e: { splitType?: string }) => e.splitType !== "SETTLEMENT"
     ).length;
     return { totalSpent, youAreOwed, expenseCount };
-  }, [group, user]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [group, user, rateMap]);
 
   const formatAmount = (amount: number) =>
     formatCurrency(amount, defaultCurrency || "USD");
@@ -71,8 +104,12 @@ export default function GroupMembersPage() {
               (e: { paidBy: string; splitType?: string }) =>
                 e.paidBy === member.user.id && e.splitType !== "SETTLEMENT"
             )
-            .reduce((a: number, e: { amount: number }) => a + e.amount, 0);
-          const owes = getSpecificDebtAmount(member.user.id);
+            .reduce((a: number, e: { amount: number; currency: string }) => a + convert(e.amount, e.currency), 0);
+          const debtByCurrency = getSpecificDebtByCurrency(member.user.id);
+          const owes = Object.entries(debtByCurrency).reduce(
+            (sum, [currency, amount]) => sum + convert(amount, currency),
+            0
+          );
           const owesDisplay =
             owes > 0
               ? { text: `owes ${formatAmount(owes)}`, color: "#F87171" }

--- a/app/groups/[id]/splits/page.tsx
+++ b/app/groups/[id]/splits/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useGroupLayout } from "@/contexts/group-layout-context";
 import { useAuthStore } from "@/stores/authStore";
 import { useDeleteExpense } from "@/features/expenses/hooks/use-create-expense";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 import {
   Card,
   SectionLabel,
@@ -242,6 +245,7 @@ export default function GroupSplitsPage() {
   const {
     group,
     formatCurrency,
+    defaultCurrency,
     openSettle,
     handleSendReminder,
     openAddExpense,
@@ -253,6 +257,36 @@ export default function GroupSplitsPage() {
     () => expenses.filter((e) => e.splitType !== "SETTLEMENT"),
     [expenses]
   );
+
+  // Fetch exchange rates for all unique expense currencies that differ from defaultCurrency
+  const expenseCurrencies = useMemo(
+    () => [...new Set(nonSettlement.map((e) => e.currency).filter((c) => c && c !== defaultCurrency))],
+    [nonSettlement, defaultCurrency]
+  );
+  const rateQueries = useQueries({
+    queries: expenseCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+  const rateMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    expenseCurrencies.forEach((c, i) => {
+      const rate = rateQueries[i]?.data?.rate;
+      if (rate) map[c] = rate;
+    });
+    return map;
+  }, [expenseCurrencies, rateQueries]);
+
+  // Converts an amount from its expense currency to defaultCurrency, then formats
+  const convertedFormatCurrency = (amount: number, currency: string): string => {
+    if (!defaultCurrency || currency === defaultCurrency) return formatCurrency(amount, currency);
+    const rate = rateMap[currency];
+    if (!rate) return formatCurrency(amount, currency); // fall back to original if rate not loaded
+    return formatCurrency(amount * rate, defaultCurrency);
+  };
 
   const byDate = useMemo(() => {
     const map = new Map<string, ExpenseWithParticipants[]>();
@@ -306,7 +340,7 @@ export default function GroupSplitsPage() {
             groupUsers={group.groupUsers}
             currentUserId={user.id}
             currentUserName={user.name ?? null}
-                  formatCurrency={formatCurrency}
+                  formatCurrency={convertedFormatCurrency}
                   isLast={idx === dateExpenses.length - 1}
                   onNotify={() => {
                     const firstOwer = expense.expenseParticipants?.find((p) => p.amount > 0);

--- a/app/organization/[organizationId]/activity/page.tsx
+++ b/app/organization/[organizationId]/activity/page.tsx
@@ -4,10 +4,14 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useGetOrganizationActivity } from "@/features/business/hooks/use-invoices";
 import { useOrganizationOrg } from "@/contexts/organization-org-context";
+import { useAuthStore } from "@/stores/authStore";
 import { Loader2 } from "lucide-react";
 import { formatCurrency } from "@/utils/formatters";
 import { formatRelativeTime } from "@/lib/utils";
 import { Card, SectionLabel, T, G, A } from "@/lib/splito-design";
+import { useQueries } from "@tanstack/react-query";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 
 type Activity = {
   id: string;
@@ -32,7 +36,7 @@ function getDotColor(type: string): string {
   return DOT_COLORS[type] ?? T.muted;
 }
 
-function getActivityText(act: Activity): React.ReactNode {
+function getActivityText(act: Activity, formatAmt: (amount: number, currency: string) => string): React.ReactNode {
   const userName = act.user?.name || act.user?.email || "Someone";
 
   switch (act.type) {
@@ -44,7 +48,7 @@ function getActivityText(act: Activity): React.ReactNode {
             <>
               {" "}
               <span style={{ color: A }}>
-                ({formatCurrency(act.invoice.amount, act.invoice.currency)})
+                ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
               {act.invoice.recipient?.name && ` to ${act.invoice.recipient.name}`}
             </>
@@ -59,7 +63,7 @@ function getActivityText(act: Activity): React.ReactNode {
             <>
               {" "}
               <span style={{ color: G }}>
-                ({formatCurrency(act.invoice.amount, act.invoice.currency)})
+                ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
             </>
           )}
@@ -73,7 +77,7 @@ function getActivityText(act: Activity): React.ReactNode {
             <>
               {" "}
               <span style={{ color: "#F87171" }}>
-                ({formatCurrency(act.invoice.amount, act.invoice.currency)})
+                ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
             </>
           )}
@@ -87,7 +91,7 @@ function getActivityText(act: Activity): React.ReactNode {
             <>
               {" "}
               <span style={{ color: G }}>
-                ({formatCurrency(act.invoice.amount, act.invoice.currency)})
+                ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
             </>
           )}
@@ -131,7 +135,34 @@ export default function OrganizationActivityPage() {
   const router = useRouter();
   const organizationId = params?.organizationId as string;
   const { isAdmin } = useOrganizationOrg();
+  const { user } = useAuthStore();
   const { data: activities = [], isLoading } = useGetOrganizationActivity(organizationId);
+
+  const defaultCurrency = user?.currency || "USD";
+  const activityList = activities as unknown as Activity[];
+  const uniqueCurrencies = Array.from(
+    new Set(
+      activityList
+        .filter((a) => a.invoice?.currency)
+        .map((a) => a.invoice!.currency)
+    )
+  ).filter((c) => c !== defaultCurrency);
+  const rateQueries = useQueries({
+    queries: uniqueCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+  const rateMap: Record<string, number> = { [defaultCurrency]: 1 };
+  uniqueCurrencies.forEach((c, i) => {
+    const rate = rateQueries[i]?.data?.rate;
+    if (rate != null) rateMap[c] = rate;
+  });
+  const convert = (amount: number, currency: string) => amount * (rateMap[currency] ?? 1);
+  const formatAmt = (amount: number, currency: string) =>
+    formatCurrency(convert(amount, currency), defaultCurrency);
 
   useEffect(() => {
     if (isAdmin === false) {
@@ -146,8 +177,6 @@ export default function OrganizationActivityPage() {
       </div>
     );
   }
-
-  const activityList = activities as unknown as Activity[];
 
   return (
     <div style={{ padding: "0 0 24px" }}>
@@ -192,7 +221,7 @@ export default function OrganizationActivityPage() {
                   fontWeight: 500,
                 }}
               >
-                {getActivityText(act)}
+                {getActivityText(act, formatAmt)}
                 {act.note && (
                   <span style={{ color: T.dim }}> &mdash; &ldquo;{act.note}&rdquo;</span>
                 )}

--- a/app/organization/[organizationId]/contracts/page.tsx
+++ b/app/organization/[organizationId]/contracts/page.tsx
@@ -17,6 +17,9 @@ import { ContractGateModal } from "@/components/contract-gate-modal";
 import { Contract } from "@/features/business/api/client";
 import { motion, AnimatePresence } from "framer-motion";
 import { useAuthStore } from "@/stores/authStore";
+import { useQueries } from "@tanstack/react-query";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 import { Card, SectionLabel, T, A, G } from "@/lib/splito-design";
 import { cn } from "@/lib/utils";
 
@@ -50,6 +53,25 @@ export default function OrganizationContractsPage() {
   const { isAdmin, openCreateContract } = useOrganizationOrg();
   const { user } = useAuthStore();
   const { data: contracts = [], isLoading: isContractsLoading } = useGetContractsByOrganization(organizationId);
+
+  const defaultCurrency = user?.currency || "USD";
+  const uniqueCurrencies = Array.from(
+    new Set(contracts.map((c) => c.compensationCurrency ?? defaultCurrency))
+  ).filter((c) => c !== defaultCurrency);
+  const rateQueries = useQueries({
+    queries: uniqueCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+  const rateMap: Record<string, number> = { [defaultCurrency]: 1 };
+  uniqueCurrencies.forEach((c, i) => {
+    const rate = rateQueries[i]?.data?.rate;
+    if (rate != null) rateMap[c] = rate;
+  });
+  const convert = (amount: number, currency: string) => amount * (rateMap[currency] ?? 1);
   const revokeContractMutation = useRevokeContract();
   const [contractToEdit, setContractToEdit] = useState<Contract | null>(null);
   const [contractToRevoke, setContractToRevoke] = useState<Contract | null>(null);
@@ -195,7 +217,7 @@ export default function OrganizationContractsPage() {
                         : `From ${c.organization?.name ?? "organization"}`}
                       {c.compensationAmount != null && (
                         <> · <span className="font-mono font-semibold" style={{ color: T.body }}>
-                          {formatCurrency(c.compensationAmount, c.compensationCurrency ?? "USD")}
+                          {formatCurrency(convert(c.compensationAmount, c.compensationCurrency ?? defaultCurrency), defaultCurrency)}
                           {c.paymentFrequency && `/${c.paymentFrequency.toLowerCase()}`}
                         </span></>
                       )}

--- a/app/organization/[organizationId]/expenses/page.tsx
+++ b/app/organization/[organizationId]/expenses/page.tsx
@@ -12,6 +12,9 @@ import { Card, SectionLabel, T, A } from "@/lib/splito-design";
 import { motion, AnimatePresence } from "framer-motion";
 import CurrencyDropdown from "@/components/currency-dropdown";
 import type { Currency } from "@/features/currencies/api/client";
+import { useQueries } from "@tanstack/react-query";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 
 type Expense = {
   id: string;
@@ -64,18 +67,38 @@ export default function OrganizationExpensesPage() {
   const [form, setForm] = useState({
     name: "",
     amount: "",
-    currency: "USD",
+    currency: user?.currency || "USD",
     category: "Business",
     expenseDate: new Date().toISOString().slice(0, 10),
   });
 
+  // ── Currency conversion ───────────────────────────────────────
+  const defaultCurrency = user?.currency || "USD";
+  const uniqueCurrencies = Array.from(new Set(expenses.map((e) => e.currency))).filter(
+    (c) => c !== defaultCurrency
+  );
+  const rateQueries = useQueries({
+    queries: uniqueCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+  const rateMap: Record<string, number> = { [defaultCurrency]: 1 };
+  uniqueCurrencies.forEach((c, i) => {
+    const rate = rateQueries[i]?.data?.rate;
+    if (rate != null) rateMap[c] = rate;
+  });
+  const convert = (amount: number, currency: string) => amount * (rateMap[currency] ?? 1);
+
   // ── Aggregates ──────────────────────────────────────────────
   const now = new Date();
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-  const totalExpenses = expenses.reduce((sum, e) => sum + e.amount, 0);
+  const totalExpenses = expenses.reduce((sum, e) => sum + convert(e.amount, e.currency), 0);
   const thisMonthExpenses = expenses
     .filter((e) => new Date(e.expenseDate) >= startOfMonth)
-    .reduce((sum, e) => sum + e.amount, 0);
+    .reduce((sum, e) => sum + convert(e.amount, e.currency), 0);
 
   // ── Handlers ─────────────────────────────────────────────────
   const closeForm = () => {
@@ -83,7 +106,7 @@ export default function OrganizationExpensesPage() {
     setForm({
       name: "",
       amount: "",
-      currency: "USD",
+      currency: user?.currency || "USD",
       category: "Business",
       expenseDate: new Date().toISOString().slice(0, 10),
     });
@@ -221,7 +244,7 @@ export default function OrganizationExpensesPage() {
                   className="text-[22px] sm:text-[24px] font-extrabold font-mono"
                   style={{ color: "#F87171" }}
                 >
-                  {formatCurrency(totalExpenses, "USD")}
+                  {formatCurrency(totalExpenses, defaultCurrency)}
                 </p>
               </div>
               <div className="min-w-0 pl-4 sm:pl-6">
@@ -235,7 +258,7 @@ export default function OrganizationExpensesPage() {
                   className="text-[22px] sm:text-[24px] font-extrabold font-mono"
                   style={{ color: "#22D3EE" }}
                 >
-                  {formatCurrency(thisMonthExpenses, "USD")}
+                  {formatCurrency(thisMonthExpenses, defaultCurrency)}
                 </p>
               </div>
             </div>
@@ -289,7 +312,7 @@ export default function OrganizationExpensesPage() {
                     className="text-[15px] font-extrabold font-mono flex-shrink-0"
                     style={{ color: "#F87171" }}
                   >
-                    {formatCurrency(exp.amount, exp.currency)}
+                    {formatCurrency(convert(exp.amount, exp.currency), defaultCurrency)}
                   </p>
 
                   {/* Delete */}

--- a/app/organization/[organizationId]/invoices/page.tsx
+++ b/app/organization/[organizationId]/invoices/page.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { useParams } from "next/navigation";
 import Image from "next/image";
 import { useAuthStore } from "@/stores/authStore";
+import { useQueries } from "@tanstack/react-query";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 import {
   useGetInvoicesByOrganization,
   useUpdateInvoice,
@@ -61,6 +64,7 @@ function InvoiceRow({
   isDeleting,
   isClearing,
   setExpandedImage,
+  formatAmt,
 }: {
   inv: Invoice;
   isAdmin: boolean;
@@ -74,16 +78,18 @@ function InvoiceRow({
   isDeleting?: boolean;
   isClearing?: boolean;
   setExpandedImage?: (v: { url: string; description: string }) => void;
+  formatAmt?: (amount: number, currency: string) => string;
 }) {
   const isPastDue = inv.dueDate && new Date(inv.dueDate) < new Date();
   const isIssuer = inv.issuerId === userId;
+  const displayAmt = formatAmt ?? ((amount: number, currency: string) => formatCurrency(amount, currency));
 
   return (
     <div className="w-full flex items-center gap-3 sm:gap-6 px-4 sm:px-6 py-4 border-b border-white/[0.06] last:border-b-0 hover:bg-white/[0.015] transition-colors">
       {/* Receipt image thumbnail */}
       {inv.imageUrl ? (
         <button type="button"
-          onClick={() => setExpandedImage?.({ url: inv.imageUrl!, description: inv.description || `Invoice — ${formatCurrency(inv.amount, inv.currency)}` })}
+          onClick={() => setExpandedImage?.({ url: inv.imageUrl!, description: inv.description || `Invoice — ${displayAmt(inv.amount, inv.currency)}` })}
           className="relative h-12 w-14 flex-shrink-0 rounded-xl overflow-hidden border border-white/[0.08] cursor-pointer hover:border-white/20 transition-colors">
           <Image src={inv.imageUrl} alt="Invoice" fill className="object-cover" sizes="56px" />
         </button>
@@ -109,7 +115,7 @@ function InvoiceRow({
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
             <p className="text-[16px] font-extrabold font-mono" style={{ color: T.bright }}>
-              {formatCurrency(inv.amount, inv.currency)}
+              {displayAmt(inv.amount, inv.currency)}
             </p>
             <StatusPill status={inv.status} />
           </div>
@@ -174,21 +180,37 @@ export default function OrganizationInvoicesPage() {
   const [invoiceToReview, setInvoiceToReview] = useState<Invoice | null>(null);
   const [showPreviousInvoices, setShowPreviousInvoices] = useState(false);
 
-  const formatCurrencyLocal = (amount: number, currency: string) => formatCurrency(amount, currency);
+  const defaultCurrency = user?.currency || "USD";
+  const uniqueCurrencies = Array.from(new Set(invoices.map((i) => i.currency))).filter(
+    (c) => c !== defaultCurrency
+  );
+  const rateQueries = useQueries({
+    queries: uniqueCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+  const rateMap: Record<string, number> = { [defaultCurrency]: 1 };
+  uniqueCurrencies.forEach((c, i) => {
+    const rate = rateQueries[i]?.data?.rate;
+    if (rate != null) rateMap[c] = rate;
+  });
+  const convert = (amount: number, currency: string) => amount * (rateMap[currency] ?? 1);
 
   const pendingToPay = invoices.filter((i) => PAYABLE_STATUSES.includes(i.status as typeof PAYABLE_STATUSES[number]));
   const approvalRequests = invoices.filter((i) => i.status === APPROVAL_STATUS);
   const previousInvoices = invoices.filter((i) => PREVIOUS_STATUSES.includes(i.status as typeof PREVIOUS_STATUSES[number]));
 
-  const pendingTotal = pendingToPay.reduce((sum, i) => sum + i.amount, 0);
-  const currencyFirst = pendingToPay[0]?.currency ?? invoices[0]?.currency ?? "USD";
+  const pendingTotal = pendingToPay.reduce((sum, i) => sum + convert(i.amount, i.currency), 0);
 
   const handlePayAll = () => {
     const approvedOnly = pendingToPay.filter((i) => i.status === "APPROVED");
     if (approvedOnly.length === 0) { toast.error("No approved invoices to pay"); return; }
     approvedOnly.forEach((inv) => {
       markPaidMutation.mutate(inv.id, {
-        onSuccess: () => toast.success(`Marked as paid: ${formatCurrencyLocal(inv.amount, inv.currency)}`),
+        onSuccess: () => toast.success(`Marked as paid: ${formatCurrency(convert(inv.amount, inv.currency), defaultCurrency)}`),
         onError: () => toast.error(`Failed to mark invoice as paid`),
       });
     });
@@ -253,7 +275,7 @@ export default function OrganizationInvoicesPage() {
             <div>
               <p className="text-[11px] font-bold tracking-[0.08em] uppercase mb-1" style={{ color: T.muted }}>Outstanding</p>
               <p className="text-[32px] font-black font-mono tracking-[-0.02em]" style={{ color: paymentsOverdueCount > 0 ? "#F87171" : T.bright }}>
-                {formatCurrencyLocal(pendingTotal, currencyFirst)}
+                {formatCurrency(pendingTotal, defaultCurrency)}
               </p>
               <p className="text-[12px] font-medium mt-1" style={{ color: T.muted }}>
                 {pendingToPay.length} pending · {paymentsOverdueCount} overdue
@@ -288,6 +310,7 @@ export default function OrganizationInvoicesPage() {
                 isPaying={markPaidMutation.isPending}
                 isDeleting={deleteInvoiceMutation.isPending}
                 setExpandedImage={setExpandedImage}
+                formatAmt={(amount, currency) => formatCurrency(convert(amount, currency), defaultCurrency)}
               />
             ))}
           </Card>
@@ -307,6 +330,7 @@ export default function OrganizationInvoicesPage() {
                 userId={user?.id}
                 onReview={() => setInvoiceToReview(inv)}
                 setExpandedImage={setExpandedImage}
+                formatAmt={(amount, currency) => formatCurrency(convert(amount, currency), defaultCurrency)}
               />
             ))}
           </Card>
@@ -342,6 +366,7 @@ export default function OrganizationInvoicesPage() {
                       onClear={() => clearInvoiceMutation.mutate(inv.id, { onSuccess: () => toast.success("Cleared"), onError: () => toast.error("Failed to clear") })}
                       isClearing={clearInvoiceMutation.isPending}
                       setExpandedImage={setExpandedImage}
+                      formatAmt={(amount, currency) => formatCurrency(convert(amount, currency), defaultCurrency)}
                     />
                   ))}
                 </Card>

--- a/app/organization/[organizationId]/layout.tsx
+++ b/app/organization/[organizationId]/layout.tsx
@@ -62,7 +62,7 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [declineInvoiceId, setDeclineInvoiceId] = useState<string | null>(null);
   const [declineNote, setDeclineNote] = useState("");
-  const [groupSettings, setGroupSettings] = useState({ name: "", currency: "USD" });
+  const [groupSettings, setGroupSettings] = useState({ name: "", currency: user?.currency || "USD" });
   const [expandedImage, setExpandedImage] = useState<{ url: string; description: string } | null>(null);
   const [invoiceToEdit, setInvoiceToEdit] = useState<InvoiceForEdit | null>(null);
   const [isStreamModalOpen, setIsStreamModalOpen] = useState(false);
@@ -79,7 +79,7 @@ function OrganizationLayoutInner({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (group) {
-      setGroupSettings((prev) => ({ ...prev, name: group.name, currency: group.defaultCurrency || "USD" }));
+      setGroupSettings((prev) => ({ ...prev, name: group.name, currency: user?.currency || group.defaultCurrency || "USD" }));
     }
   }, [group]);
 

--- a/app/organization/[organizationId]/streams/page.tsx
+++ b/app/organization/[organizationId]/streams/page.tsx
@@ -12,6 +12,10 @@ import { toast } from "sonner";
 import { formatCurrency } from "@/utils/formatters";
 import { Card, SectionLabel, T, A, G } from "@/lib/splito-design";
 import { motion, AnimatePresence } from "framer-motion";
+import { useAuthStore } from "@/stores/authStore";
+import { useQueries } from "@tanstack/react-query";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 
 type Stream = { id: string; name: string; expectedAmount?: number | null; currency: string; description?: string | null };
 
@@ -20,9 +24,29 @@ export default function OrganizationStreamsPage() {
   const router = useRouter();
   const organizationId = params?.organizationId as string;
   const { isAdmin, openStreamModal, openEditStream } = useOrganizationOrg();
+  const { user } = useAuthStore();
   const { data: streams = [], isLoading: isStreamsLoading } = useGetStreamsByOrganization(organizationId, { enabled: !!isAdmin });
   const deleteStreamMutation = useDeleteStream();
   const [streamToDelete, setStreamToDelete] = useState<Stream | null>(null);
+
+  const defaultCurrency = user?.currency || "USD";
+  const uniqueCurrencies = Array.from(
+    new Set((streams as Stream[]).map((s) => s.currency))
+  ).filter((c) => c !== defaultCurrency);
+  const rateQueries = useQueries({
+    queries: uniqueCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+  const rateMap: Record<string, number> = { [defaultCurrency]: 1 };
+  uniqueCurrencies.forEach((c, i) => {
+    const rate = rateQueries[i]?.data?.rate;
+    if (rate != null) rateMap[c] = rate;
+  });
+  const convert = (amount: number, currency: string) => amount * (rateMap[currency] ?? 1);
 
   useEffect(() => {
     if (isAdmin === false && organizationId) {
@@ -115,7 +139,7 @@ export default function OrganizationStreamsPage() {
                 <div className="flex items-center gap-3 sm:gap-4 flex-shrink-0">
                   {stream.expectedAmount != null && (
                     <p className="text-[15px] sm:text-[16px] font-extrabold font-mono" style={{ color: G }}>
-                      {formatCurrency(stream.expectedAmount, stream.currency)}
+                      {formatCurrency(convert(stream.expectedAmount, stream.currency), defaultCurrency)}
                     </p>
                   )}
                   <div className="flex items-center gap-2">
@@ -163,7 +187,7 @@ export default function OrganizationStreamsPage() {
               </div>
               <p className="text-[13px] mb-5" style={{ color: T.body }}>
                 <span className="font-semibold" style={{ color: T.bright }}>&ldquo;{streamToDelete.name}&rdquo;</span>
-                {streamToDelete.expectedAmount != null && ` (${formatCurrency(streamToDelete.expectedAmount, streamToDelete.currency)})`}
+                {streamToDelete.expectedAmount != null && ` (${formatCurrency(convert(streamToDelete.expectedAmount, streamToDelete.currency), defaultCurrency)})`}
                 {" "}will be permanently removed from your income streams.
               </p>
               <div className="flex gap-3">

--- a/app/organization/page.tsx
+++ b/app/organization/page.tsx
@@ -11,6 +11,9 @@ import { useGetContractsByOrganization, useGetMyContracts } from "@/features/bus
 import { useGetStreamsByOrganization } from "@/features/business/hooks/use-streams";
 import { Loader2, FileText, TrendingUp, ChevronsUpDown, Plus, Clock, AlertCircle, ChevronRight } from "lucide-react";
 import { formatCurrency } from "@/utils/formatters";
+import { useQueries } from "@tanstack/react-query";
+import { getExchangeRate } from "@/features/currencies/api/client";
+import { CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 import { OrganizationConnectionError } from "@/components/organization-connection-error";
 import { Card, SectionLabel, T, A, G, Avatar, getUserColor } from "@/lib/splito-design";
 import { cn } from "@/lib/utils";
@@ -83,6 +86,33 @@ export default function OrganizationDashboardPage() {
     enabled: !!selectedOrgId && isAdminOfSelectedOrg,
   });
 
+  // User's personal currency takes priority; analytics data is in the org's own currency
+  const orgCurrency = user?.currency || selectedOrg?.defaultCurrency || "USD";
+  const analyticsCurrency = selectedOrg?.defaultCurrency || "USD";
+
+  const uniqueCurrenciesOrg = Array.from(
+    new Set([
+      ...invoicesForOrg.map((i) => i.currency),
+      ...memberInvoices.map((i) => i.currency),
+      ...streamsForOrg.map((s) => s.currency),
+      analyticsCurrency, // ensure analytics currency has an exchange rate
+    ])
+  ).filter((c) => c !== orgCurrency);
+  const rateQueriesOrg = useQueries({
+    queries: uniqueCurrenciesOrg.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, orgCurrency],
+      queryFn: () => getExchangeRate(from, orgCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!orgCurrency && !!from,
+    })),
+  });
+  const rateMapOrg: Record<string, number> = { [orgCurrency]: 1 };
+  uniqueCurrenciesOrg.forEach((c, i) => {
+    const rate = rateQueriesOrg[i]?.data?.rate;
+    if (rate != null) rateMapOrg[c] = rate;
+  });
+  const convert = (amount: number, currency: string) => amount * (rateMapOrg[currency] ?? 1);
+
   const memberCountForOrg = selectedOrg ? (selectedOrg.groupUsers?.length ?? 0) : 0;
   const totalStreamsCount = streamsForOrg.length;
   const expectedUsd = streamsForOrg
@@ -91,8 +121,7 @@ export default function OrganizationDashboardPage() {
 
   const totalOutstanding = invoicesForOrg
     .filter((i) => i.status === "SENT" || i.status === "OVERDUE" || i.status === "APPROVED")
-    .reduce((sum, i) => sum + i.amount, 0);
-  const currencyFirst = invoicesForOrg[0]?.currency ?? "USD";
+    .reduce((sum, i) => sum + convert(i.amount, i.currency), 0);
   const pendingCount = invoicesForOrg.filter(
     (i) => i.status === "DRAFT" || i.status === "SENT" || i.status === "OVERDUE" || i.status === "APPROVED"
   ).length;
@@ -102,9 +131,9 @@ export default function OrganizationDashboardPage() {
   const approvalPastDueCount = invoicesForOrg.filter((i) => i.status === "SENT" && new Date(i.dueDate) < new Date()).length;
 
   const { data: analyticsData, isLoading: isAnalyticsLoading } = useGetOrganizationAnalytics(selectedOrgId, chartRange);
-  const expenseThisMonth = analyticsData?.expenseThisMonth ?? 0;
-  const totalPaid = analyticsData?.totalPaid ?? 0;
-  const totalInflow = streamsForOrg.reduce((sum, s) => sum + (s.expectedAmount ?? 0), 0);
+  const expenseThisMonth = convert(analyticsData?.expenseThisMonth ?? 0, analyticsCurrency);
+  const totalPaid = convert(analyticsData?.totalPaid ?? 0, analyticsCurrency);
+  const totalInflow = streamsForOrg.reduce((sum, s) => sum + convert(s.expectedAmount ?? 0, s.currency), 0);
   const outflowByPeriod = analyticsData?.outflowByPeriod ?? [];
 
   // Compute inflow per bucket from streams createdAt (same bucketing logic as backend)
@@ -122,8 +151,8 @@ export default function OrganizationDashboardPage() {
         const label = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
         return label === bucketLabel;
       })
-      .reduce((sum, s) => sum + (s.expectedAmount ?? 0), 0);
-    return { month: bucketLabel, inflow, outflow: bucket.outflow };
+      .reduce((sum, s) => sum + convert(s.expectedAmount ?? 0, s.currency), 0);
+    return { month: bucketLabel, inflow, outflow: convert(bucket.outflow, analyticsCurrency) };
   });
 
   const membersMap = new Map<string, { id: string; name: string | null; image: string | null; email: string | null; orgNames: string[] }>();
@@ -313,7 +342,7 @@ export default function OrganizationDashboardPage() {
                         </div>
                         <div>
                           <p className="text-[14px] font-bold text-red-400">{paymentsOverdue} overdue payment{paymentsOverdue !== 1 ? "s" : ""}</p>
-                          <p className="text-[12px] font-medium mt-0.5" style={{ color: T.muted }}>{formatCurrency(totalOutstanding, currencyFirst)} outstanding</p>
+                          <p className="text-[12px] font-medium mt-0.5" style={{ color: T.muted }}>{formatCurrency(totalOutstanding, orgCurrency)} outstanding</p>
                         </div>
                       </div>
                       <span className="text-[12px] font-extrabold px-3 py-1.5 rounded-lg shrink-0" style={{ background: "#F87171", color: "#0a0a0a" }}>Pay now</span>
@@ -402,7 +431,7 @@ export default function OrganizationDashboardPage() {
                         </div>
                         <div className="flex-1 min-w-0">
                           <p className="text-[13px] font-semibold truncate" style={{ color: T.bright }}>
-                            {formatCurrency(inv.amount, inv.currency)}
+                            {formatCurrency(convert(inv.amount, inv.currency), orgCurrency)}
                           </p>
                           <p className="text-[11px] mt-0.5" style={{ color: T.muted }}>
                             Due {new Date(inv.dueDate).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
@@ -446,7 +475,7 @@ export default function OrganizationDashboardPage() {
                           </p>
                           {contract.compensationAmount != null && (
                             <p className="text-[11px] mt-0.5" style={{ color: T.muted }}>
-                              {formatCurrency(contract.compensationAmount, contract.compensationCurrency ?? "USD")}
+                              {formatCurrency(contract.compensationAmount, contract.compensationCurrency ?? orgCurrency)}
                             </p>
                           )}
                         </div>
@@ -524,7 +553,7 @@ export default function OrganizationDashboardPage() {
                             tickLine={{ stroke: "rgba(255,255,255,0.06)" }}
                           />
                           <YAxis
-                            tickFormatter={(v: number) => formatCurrency(v, "USD")}
+                            tickFormatter={(v: number) => formatCurrency(v, orgCurrency)}
                             tick={{ fontSize: 10, fill: T.dim }}
                             axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
                             tickLine={{ stroke: "rgba(255,255,255,0.06)" }}
@@ -537,7 +566,7 @@ export default function OrganizationDashboardPage() {
                               borderRadius: "12px",
                             }}
                             labelStyle={{ color: T.bright }}
-                            formatter={(value: number, name: string) => [formatCurrency(value, "USD"), name]}
+                            formatter={(value: number, name: string) => [formatCurrency(value, orgCurrency), name]}
                             labelFormatter={(label: string) => label}
                           />
                           <Line
@@ -567,9 +596,9 @@ export default function OrganizationDashboardPage() {
                 {/* Stats: third column */}
                 <div className="flex flex-col gap-3">
                   {[
-                    { label: "Expense this month", value: formatCurrency(expenseThisMonth, "USD"), icon: Clock, iconColor: "#F87171", bg: "rgba(248,113,113,0.08)", border: "rgba(248,113,113,0.15)", sub: "From approved/paid invoices" },
-                    { label: "Total paid", value: formatCurrency(totalPaid, "USD"), icon: FileText, iconColor: T.muted, bg: "rgba(255,255,255,0.04)", border: "rgba(255,255,255,0.08)", sub: "All time (invoices)" },
-                    { label: "Expected inflow", value: formatCurrency(totalInflow, "USD"), icon: TrendingUp, iconColor: "#34D399", bg: "rgba(52,211,153,0.10)", border: "rgba(52,211,153,0.25)", sub: "From income streams" },
+                    { label: "Expense this month", value: formatCurrency(expenseThisMonth, orgCurrency), icon: Clock, iconColor: "#F87171", bg: "rgba(248,113,113,0.08)", border: "rgba(248,113,113,0.15)", sub: "From approved/paid invoices" },
+                    { label: "Total paid", value: formatCurrency(totalPaid, orgCurrency), icon: FileText, iconColor: T.muted, bg: "rgba(255,255,255,0.04)", border: "rgba(255,255,255,0.08)", sub: "All time (invoices)" },
+                    { label: "Expected inflow", value: formatCurrency(totalInflow, orgCurrency), icon: TrendingUp, iconColor: "#34D399", bg: "rgba(52,211,153,0.10)", border: "rgba(52,211,153,0.25)", sub: "From income streams" },
                   ].map((stat) => (
                     <div key={stat.label} className="rounded-2xl p-4 flex-1 min-h-0"
                       style={{ background: stat.bg, border: `1px solid ${stat.border}` }}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ import {
   DollarSign,
   Settings,
 } from "lucide-react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, useQueries } from "@tanstack/react-query";
 import { QueryKeys } from "@/lib/constants";
 import { useAuthStore } from "@/stores/authStore";
 import Link from "next/link";
@@ -30,7 +30,8 @@ import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { toast } from "sonner";
 import { formatCurrency } from "@/utils/formatters";
 import { formatRelativeTime } from "@/lib/utils";
-import { useConvertedBalanceTotal } from "@/features/currencies/hooks/use-currencies";
+import { useConvertedBalanceTotal, CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
+import { getExchangeRate } from "@/features/currencies/api/client";
 import {
   A,
   Card,
@@ -201,7 +202,7 @@ function GroupBalanceShort({
   const { total: owedTotal, isLoading: loadOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
   if (loadOwe || loadOwed) return <span className="text-white/60">…</span>;
   const net = (owedTotal ?? 0) - (oweTotal ?? 0);
-  if (net === 0) return <span style={{ color: G, fontSize: 13, fontWeight: 800, fontFamily: "monospace" }}>+$0</span>;
+  if (net === 0) return <span style={{ color: G, fontSize: 13, fontWeight: 800, fontFamily: "monospace" }}>+{formatCurrency(0, defaultCurrency)}</span>;
   if (net > 0)
     return (
       <span
@@ -404,19 +405,20 @@ export default function Page() {
   const owedThisMonth = Number(analyticsData?.owed) || 0;
   const lentThisMonth = Number(analyticsData?.lent) || 0;
   const settledThisMonth = Number(analyticsData?.settled) || 0;
+  const analyticsCurrency = analyticsData?.currency || defaultCurrency;
   const { total: owedConverted, isLoading: owedConvLoading } =
     useConvertedBalanceTotal(
-      owedThisMonth ? [{ amount: owedThisMonth, currency: "USD" }] : [],
+      owedThisMonth ? [{ amount: owedThisMonth, currency: analyticsCurrency }] : [],
       defaultCurrency
     );
   const { total: lentConverted, isLoading: lentConvLoading } =
     useConvertedBalanceTotal(
-      lentThisMonth ? [{ amount: lentThisMonth, currency: "USD" }] : [],
+      lentThisMonth ? [{ amount: lentThisMonth, currency: analyticsCurrency }] : [],
       defaultCurrency
     );
   const { total: settledConverted, isLoading: settledConvLoading } =
     useConvertedBalanceTotal(
-      settledThisMonth ? [{ amount: settledThisMonth, currency: "USD" }] : [],
+      settledThisMonth ? [{ amount: settledThisMonth, currency: analyticsCurrency }] : [],
       defaultCurrency
     );
   const queryClient = useQueryClient();
@@ -459,6 +461,36 @@ export default function Page() {
 
   const netOwed = (overallGetLoading || overallOweLoading) ? 0 : overallGetTotal - overallOweTotal;
 
+  // Collect all unique expense currencies across groups for the activity card
+  const activityCurrencies = useMemo(() => {
+    if (!groups?.length) return [];
+    const currencies = new Set<string>();
+    for (const group of groups) {
+      const expenses = (group as { expenses?: { currency: string }[] }).expenses ?? [];
+      expenses.forEach((e) => { if (e.currency) currencies.add(e.currency); });
+    }
+    currencies.delete(defaultCurrency);
+    return [...currencies].filter(Boolean);
+  }, [groups, defaultCurrency]);
+
+  const activityRateQueries = useQueries({
+    queries: activityCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+
+  const activityRateMap = useMemo(() => {
+    const map: Record<string, number> = { [defaultCurrency]: 1 };
+    activityCurrencies.forEach((c, i) => {
+      const rate = activityRateQueries[i]?.data?.rate;
+      if (rate) map[c] = rate;
+    });
+    return map;
+  }, [activityCurrencies, activityRateQueries, defaultCurrency]);
+
   /** Recent activity from all groups (expenses + settlements) for Dashboard card */
   const recentActivityFromGroups = useMemo(() => {
     if (!user || !groups?.length) return [];
@@ -470,7 +502,9 @@ export default function Page() {
         userId === user.id ? "You" : (groupUsers.find((gu) => gu.user.id === userId)?.user?.name ?? "Someone");
       for (const exp of expenses) {
         const date = exp.createdAt instanceof Date ? exp.createdAt : new Date(exp.createdAt);
-        const amountStr = formatCurrency(Math.abs(exp.amount), exp.currency || defaultCurrency);
+        const src = exp.currency || defaultCurrency;
+        const rate = activityRateMap[src] ?? 1;
+        const amountStr = formatCurrency(Math.abs(exp.amount) * rate, defaultCurrency);
         const timeAgo = formatRelativeTime(date);
         const subtext = `${timeAgo} · ${group.name}`;
         if (exp.splitType === "SETTLEMENT") {
@@ -494,7 +528,7 @@ export default function Page() {
     }
     items.sort((a, b) => b.date.getTime() - a.date.getTime());
     return items.slice(0, 5);
-  }, [groups, user?.id, defaultCurrency]);
+  }, [groups, user?.id, defaultCurrency, activityRateMap]);
 
   const groupAvatarItems = (g: { groupUsers?: { user: { name: string | null; id: string } }[] }) =>
     (g.groupUsers ?? [])
@@ -639,7 +673,7 @@ export default function Page() {
               {[
                 ["You owed this month", isAnalyticsLoading || owedConvLoading ? "…" : formatCurrency(owedConverted, defaultCurrency)],
                 ["You lent this month", isAnalyticsLoading || lentConvLoading ? "…" : formatCurrency(lentConverted, defaultCurrency)],
-                ["You settled this month", isAnalyticsLoading || settledConvLoading ? "…" : settledThisMonth === 0 ? "$0.00" : formatCurrency(settledConverted, defaultCurrency)],
+                ["You settled this month", isAnalyticsLoading || settledConvLoading ? "…" : formatCurrency(settledThisMonth === 0 ? 0 : settledConverted, defaultCurrency)],
               ].map(([label, value], i, arr) => (
                 <div
                   key={String(label)}

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -3,18 +3,28 @@
 import { useEffect } from "react";
 import { useAuthStore } from "@/stores/authStore";
 import { useGetUser } from "@/features/user/hooks/use-update-profile";
-import { useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
+import { Loader2 } from "lucide-react";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const setUser = useAuthStore((state) => state.setUser);
-  const { data: user } = useGetUser();
-  const router = useRouter();
+  const { data: user, isPending } = useGetUser();
+  const pathname = usePathname();
+  const isAuthPage = pathname?.match(/^\/login|^\/signup/);
 
   useEffect(() => {
     if (user) {
       setUser(user);
     }
-  }, [user, setUser, router]);
+  }, [user, setUser]);
+
+  if (!isAuthPage && isPending) {
+    return (
+      <div className="min-h-screen bg-[#0b0b0b] flex items-center justify-center">
+        <Loader2 className="h-10 w-10 animate-spin text-white/50" />
+      </div>
+    );
+  }
 
   return <>{children}</>;
 }

--- a/components/group-info-header.tsx
+++ b/components/group-info-header.tsx
@@ -60,6 +60,8 @@ export function GroupInfoHeader({
     }
   });
 
+  // owed = positive balances = amounts the current user OWES (debts)
+  // owe  = negative balances (abs) = amounts the current user IS OWED (credits)
   const { total: totalOwedToUser, isLoading: loadingOwe } = useConvertedBalanceTotal(
     owe,
     defaultCurrency
@@ -101,15 +103,20 @@ export function GroupInfoHeader({
   ];
 
   const memberCount = group.groupUsers?.length ?? 0;
-  const isOwedToUser = owed.length > 0;
-  const isUserOwes = owe.length > 0;
+  // net = credits (owed to user) - debts (user owes) — same formula as GroupBalanceShort on dashboard
+  const net = converting ? null : totalOwedToUser - totalUserOwes;
+  const isOwedToUser = net !== null && net > 0;
+  const isUserOwes = net !== null && net < 0;
+  const netAmount = net !== null ? Math.abs(net) : 0;
   const balanceLabel = isOwedToUser ? "owed to you" : isUserOwes ? "you owe" : "all settled";
 
-  const desktopSubtitle = isOwedToUser
-    ? <>You are owed <span className="font-bold text-[#34D399]">{converting ? "…" : formatCurrency(totalOwedToUser, defaultCurrency)}</span></>
-    : isUserOwes
-      ? <>You owe <span className="font-bold text-[#F87171]">{converting ? "…" : formatCurrency(totalUserOwes, defaultCurrency)}</span></>
-      : <span className="font-bold text-[#34D399]">All settled ✓</span>;
+  const desktopSubtitle = converting
+    ? <span style={{ color: "rgba(255,255,255,0.4)" }}>…</span>
+    : isOwedToUser
+      ? <>You are owed <span className="font-bold text-[#34D399]">{formatCurrency(netAmount, defaultCurrency)}</span></>
+      : isUserOwes
+        ? <>You owe <span className="font-bold text-[#F87171]">{formatCurrency(netAmount, defaultCurrency)}</span></>
+        : <span className="font-bold text-[#34D399]">All settled ✓</span>;
 
   return (
     <div

--- a/components/settle-debts-modal.tsx
+++ b/components/settle-debts-modal.tsx
@@ -16,9 +16,10 @@ import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
 import { useBalances } from "@/features/balances/hooks/use-balances";
 import ResolverSelector, { Option as TokenOption } from "./ResolverSelector";
-import { useOrganizedCurrencies, useGetExchangeRate } from "@/features/currencies/hooks/use-currencies";
+import { useOrganizedCurrencies, useGetExchangeRate, CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 import { useAuthStore } from "@/stores/authStore";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueries } from "@tanstack/react-query";
+import { getExchangeRate } from "@/features/currencies/api/client";
 import { useWallet } from "@/hooks/useWallet";
 import { useUserWallets } from "@/features/wallets/hooks/use-wallets";
 import { WalletSelector as ShadcnWalletSelector } from "@/components/WalletSelector";
@@ -92,6 +93,34 @@ export function SettleDebtsModal({
   const stellarWallet = wallets.find(w => w.chainId === "stellar");
   const userStellarAddress = stellarWallet?.address || null;
   useHandleEscapeToCloseModal(isOpen, onClose);
+
+  // Exchange rate conversion for balance currencies
+  const balanceCurrencies = useMemo(() => {
+    const currencies = new Set<string>();
+    const sourceBalances = Array.isArray(balances) ? balances : [];
+    sourceBalances.forEach((b) => {
+      if (b.currency && b.currency !== (defaultCurrency || "USD")) currencies.add(b.currency);
+    });
+    return [...currencies].filter(Boolean);
+  }, [balances, defaultCurrency]);
+
+  const balanceRateQueries = useQueries({
+    queries: balanceCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency || "USD"],
+      queryFn: () => getExchangeRate(from, defaultCurrency || "USD"),
+      staleTime: 1000 * 60 * 5,
+      enabled: !!defaultCurrency && !!from,
+    })),
+  });
+
+  const balanceRateMap = useMemo(() => {
+    const map: Record<string, number> = { [defaultCurrency || "USD"]: 1 };
+    balanceCurrencies.forEach((c, i) => {
+      const rate = balanceRateQueries[i]?.data?.rate;
+      if (rate) map[c] = rate;
+    });
+    return map;
+  }, [balanceCurrencies, balanceRateQueries, defaultCurrency]);
 
   // Helper functions for debt calculations
   const transformGroupBalancesToCurrencyMap = (groupBalances: GroupBalance[], userId: string): Record<string, number> => {
@@ -783,8 +812,6 @@ export function SettleDebtsModal({
   // Check if there are any debts to settle for the selected user
   const _hasDebtsToSettle = Object.values(selectedUserDebtByCurrency).some(amount => amount !== 0);
 
-  // Calculate the remaining total after exclusions
-  const remainingTotal = calculateRemainingTotal();
   const displayGroupName = useMemo(() => {
     if (!groupId) return "Group";
     const groupMatch = _groups?.find((g: { id: string; name: string }) => g.id === groupId);
@@ -798,7 +825,8 @@ export function SettleDebtsModal({
       .filter((b) => b.userId !== user?.id && b.amount < 0)
       .reduce((acc, b) => {
         const current = acc.get(b.userId) || 0;
-        acc.set(b.userId, current + Math.abs(b.amount));
+        const rate = balanceRateMap[b.currency] ?? 1;
+        acc.set(b.userId, current + Math.abs(b.amount) * rate);
         return acc;
       }, new Map<string, number>());
 
@@ -821,7 +849,11 @@ export function SettleDebtsModal({
         };
       })
       .sort((a, b) => b.amount - a.amount);
-  }, [balances, user?.id, _members]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [balances, user?.id, _members, balanceRateMap]);
+
+  // Calculate the remaining total after currency conversion
+  const remainingTotal = memberDebtRows.reduce((sum, row) => sum + row.amount, 0);
 
   const CURRENCY_FLAG: Record<string, string> = {
     USD: "🇺🇸", EUR: "🇪🇺", GBP: "🇬🇧", JPY: "🇯🇵", THB: "🇹🇭",

--- a/features/analytics/api/client.ts
+++ b/features/analytics/api/client.ts
@@ -4,6 +4,7 @@ export interface AnalyticsData {
   owed: string | number;
   lent: string | number;
   settled: string | number;
+  currency?: string;
 }
 
 export const getAnalytics = async (): Promise<AnalyticsData> => {
@@ -20,7 +21,8 @@ export const getAnalytics = async (): Promise<AnalyticsData> => {
     return {
       owed: data.owed,
       lent: data.lent,
-      settled: data.settled
+      settled: data.settled,
+      currency: data.currency,
     };
   } catch (error) {
     console.error("Analytics API Error:", error);


### PR DESCRIPTION
  Auth / Loading                                                                                                                                
  - Global auth loader: AuthProvider now shows a full-screen spinner while the user session is loading (on non-auth pages), preventing flash of
  unauthenticated content                                                                                                                       
                                                            
  Group pages (/app/groups/)                                                                                                                    
  - Splits: Expense amounts convert to the group's default currency using live exchange rates
  - Members: Total spent, "you are owed", and per-member debt amounts all convert to default currency                                           
  - Activity: Expense amounts in the activity feed convert to default currency                       
  - Group header balance: Fixed net balance calculation (was using raw owed/owe arrays instead of converted totals); desktop subtitle now shows 
  a loading … state while rates are fetching                                                                                                    
                                                                                                                                                
  Organization pages (/app/organization/)                                                                                                       
  - Dashboard: Stats (expenseThisMonth, totalPaid), chart inflow/outflow, invoice totals, and stream amounts all convert to user's default      
  currency; orgCurrency now prioritizes user?.currency                                                                                          
  - Expenses: Total/monthly stats and individual rows convert to user's default currency; form defaults to user's currency
  - Invoices: Pending total and all invoice rows display in user's default currency                                                             
  - Contracts: Compensation amounts convert to user's default currency                                                                          
  - Streams: Stream amounts convert to user's default currency                                                                                  
  - Activity: Invoice amounts in the activity feed convert to user's default currency                                                           
  - Org Settings modal: "Default Currency" field pre-populates with user's personal currency (INR) instead of hardcoded USD                     
                                                                                                                                                
  Settle modal                                                                                                                                  
  - Balance amounts convert to user's default currency using live exchange rates; fixed remainingTotal always being 0                           
                                                                                                                                                
  Analytics API                                                                                                                                 
  - AnalyticsData type now includes currency field passed through from the backend response    