### PR TITLE
bug fixes

### DIFF
--- a/app/groups/[id]/activity/page.tsx
+++ b/app/groups/[id]/activity/page.tsx
@@ -215,27 +215,6 @@ export default function GroupActivityPage() {
               activityType = "settled";
             }
 
-            let amountColor = T.bright;
-            if (
-              expense.splitType === "SETTLEMENT" &&
-              settlementPayeeName &&
-              settlementPayeeId !== null
-            ) {
-              if (settlementPayeeId === user.id) amountColor = G;
-              else if (isYouPayer) amountColor = "#F87171";
-            } else {
-              if (isYouPayer) amountColor = "#F87171";
-              else {
-                const myPart = expense.expenseParticipants?.find(
-                  (p: { userId: string }) => p.userId === user.id
-                );
-                if (myPart) {
-                  if (myPart.amount < 0) amountColor = "#F87171";
-                  else if (myPart.amount > 0) amountColor = G;
-                }
-              }
-            }
-
             if (
               expense.splitType === "SETTLEMENT" &&
               settlementPayeeName
@@ -274,7 +253,7 @@ export default function GroupActivityPage() {
                     }}
                   >
                     {payerLabel} marked payment to {payeeLabel} as settled{" "}
-                    <span style={{ color: amountColor }}>({amountStr})</span>
+                    <span style={{ color: T.bright }}>({amountStr})</span>
                   </p>
                   <span
                     style={{
@@ -322,7 +301,7 @@ export default function GroupActivityPage() {
                   }}
                 >
                   {payerLabel} added {expense.name}{" "}
-                  <span style={{ color: amountColor }}>({amountStr})</span>
+                  <span style={{ color: T.bright }}>({amountStr})</span>
                 </p>
                 <span
                   style={{

--- a/app/groups/[id]/layout.tsx
+++ b/app/groups/[id]/layout.tsx
@@ -42,6 +42,8 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
   const [isAddExpenseModalOpen, setIsAddExpenseModalOpen] = useState(false);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [settleFriendId, setSettleFriendId] = useState<string | null>(null);
+  const [settleSpecificAmount, setSettleSpecificAmount] = useState<number | undefined>(undefined);
+  const [settleSpecificMemberAmounts, setSettleSpecificMemberAmounts] = useState<Record<string, number> | undefined>(undefined);
   const [groupSettings, setGroupSettings] = useState({
     name: "",
     currency: "ETH",
@@ -174,11 +176,15 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
     openAddMember: () => setIsAddMemberModalOpen(true),
     openAddExpense: () => setIsAddExpenseModalOpen(true),
     openSettings: () => setIsSettingsModalOpen(true),
-    openSettle: (friendId?: string | null) => {
+    openSettle: (friendId?: string | null, specificAmount?: number, specificMemberAmounts?: Record<string, number>) => {
       setSettleFriendId(friendId ?? null);
+      setSettleSpecificAmount(specificAmount);
+      setSettleSpecificMemberAmounts(specificMemberAmounts);
       setIsSettleModalOpen(true);
     },
     settleFriendId,
+    settleSpecificAmount,
+    settleSpecificMemberAmounts,
     getSpecificDebtAmount,
     getSpecificDebtByCurrency,
     handleSettleFriendClick,
@@ -210,6 +216,8 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
           onClose={() => {
             setIsSettleModalOpen(false);
             setSettleFriendId(null);
+            setSettleSpecificAmount(undefined);
+            setSettleSpecificMemberAmounts(undefined);
           }}
           balances={group.groupBalances}
           groupId={groupId}
@@ -217,6 +225,8 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
           defaultCurrency={user?.currency || group.defaultCurrency}
           showIndividualView={false}
           defaultExpandedMemberId={settleFriendId}
+          specificAmount={settleSpecificAmount}
+          specificMemberAmounts={settleSpecificMemberAmounts}
         />
 
         <AddMemberModal
@@ -230,6 +240,7 @@ function GroupLayoutInner({ children }: { children: React.ReactNode }) {
           onClose={() => setIsAddExpenseModalOpen(false)}
           groupId={groupId}
           members={group.groupUsers.map((m) => m.user)}
+          defaultCurrency={user?.currency || group?.defaultCurrency || "USD"}
         />
 
         {isSettingsModalOpen && (

--- a/app/groups/[id]/splits/page.tsx
+++ b/app/groups/[id]/splits/page.tsx
@@ -89,11 +89,13 @@ function ExpenseRow({
 
   const myShare = participants.find((p) => p.userId === currentUserId)?.amount ?? 0;
   const iAmPayer = expense.paidBy === currentUserId;
+  const isInvolved = iAmPayer || participants.some((p) => p.userId === currentUserId);
   const pending = participants.filter((p) => p.amount > 0).reduce((a, p) => a + p.amount, 0);
 
   const categoryStyle = getCategoryStyle(expense.category);
 
   const statusLine = (() => {
+    if (!isInvolved) return null;
     if (myShare > 0 && !iAmPayer) return { text: `you owe ${formatCurrency(myShare, expense.currency)}`, color: "#F87171" };
     if (iAmPayer && pending > 0) return { text: `owed ${formatCurrency(pending, expense.currency)}`, color: G };
     if (iAmPayer && pending === 0) return { text: "all settled ✓", color: G };
@@ -214,25 +216,29 @@ function ExpenseRow({
                       >
                         {formatCurrency(p.amount, expense.currency)}
                       </span>
-                      <Tag color={isSettled ? G : "#F87171"}>
-                        {isSettled ? "settled" : "pending"}
-                      </Tag>
+                      {isInvolved && (
+                        <Tag color={isSettled ? G : "#F87171"}>
+                          {isSettled ? "settled" : "pending"}
+                        </Tag>
+                      )}
                     </div>
                   </div>
                 );
               })}
             </div>
-          <div style={{ display: "flex", gap: 8, paddingTop: 16 }}>
-            <Btn variant="ghost" onClick={onSettle} className="splito-sbtn" style={{ padding: "8px 16px", fontSize: 12 }}>
-              <Icons.check /> Settle
-            </Btn>
-            <Btn variant="ghost" onClick={onNotify} className="splito-abtn" style={{ padding: "8px 16px", fontSize: 12 }}>
-              <Icons.bell /> Notify
-            </Btn>
-            <Btn variant="danger" onClick={onDelete} style={{ padding: "8px 14px", fontSize: 12 }}>
-              <Icons.trash size={14} /> Delete
-            </Btn>
-          </div>
+          {isInvolved && (
+            <div style={{ display: "flex", gap: 8, paddingTop: 16 }}>
+              <Btn variant="ghost" onClick={onSettle} className="splito-sbtn" style={{ padding: "8px 16px", fontSize: 12 }}>
+                <Icons.check /> Settle
+              </Btn>
+              <Btn variant="ghost" onClick={onNotify} className="splito-abtn" style={{ padding: "8px 16px", fontSize: 12 }}>
+                <Icons.bell /> Notify
+              </Btn>
+              <Btn variant="danger" onClick={onDelete} style={{ padding: "8px 14px", fontSize: 12 }}>
+                <Icons.trash size={14} /> Delete
+              </Btn>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/app/organization/[organizationId]/activity/page.tsx
+++ b/app/organization/[organizationId]/activity/page.tsx
@@ -47,7 +47,7 @@ function getActivityText(act: Activity, formatAmt: (amount: number, currency: st
           {act.invoice && (
             <>
               {" "}
-              <span style={{ color: A }}>
+              <span style={{ color: T.bright }}>
                 ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
               {act.invoice.recipient?.name && ` to ${act.invoice.recipient.name}`}
@@ -62,7 +62,7 @@ function getActivityText(act: Activity, formatAmt: (amount: number, currency: st
           {act.invoice && (
             <>
               {" "}
-              <span style={{ color: G }}>
+              <span style={{ color: T.bright }}>
                 ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
             </>
@@ -76,7 +76,7 @@ function getActivityText(act: Activity, formatAmt: (amount: number, currency: st
           {act.invoice && (
             <>
               {" "}
-              <span style={{ color: "#F87171" }}>
+              <span style={{ color: T.bright }}>
                 ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
             </>
@@ -90,7 +90,7 @@ function getActivityText(act: Activity, formatAmt: (amount: number, currency: st
           {act.invoice && (
             <>
               {" "}
-              <span style={{ color: G }}>
+              <span style={{ color: T.bright }}>
                 ({formatAmt(act.invoice.amount, act.invoice.currency)})
               </span>
             </>

--- a/components/add-expense-modal.tsx
+++ b/components/add-expense-modal.tsx
@@ -43,6 +43,7 @@ interface AddExpenseModalProps {
   onClose: () => void;
   members: User[];
   groupId: string;
+  defaultCurrency?: string;
 }
 
 interface ExpenseFormData {
@@ -110,6 +111,7 @@ export function AddExpenseModal({
   onClose,
   members,
   groupId,
+  defaultCurrency = "USD",
 }: AddExpenseModalProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const queryClient = useQueryClient();
@@ -150,7 +152,7 @@ export function AddExpenseModal({
     description: "",
     amount: "",
     splitType: "equal",
-    currency: "USD",
+    currency: defaultCurrency,
     currencyType: "FIAT",
     timeLockIn: false,
     paidBy: user?.id || "",
@@ -167,8 +169,11 @@ export function AddExpenseModal({
   const groupName = groupCtx?.group?.name ?? "Group";
 
   useEffect(() => {
-    if (isOpen) setStep(1);
-  }, [isOpen]);
+    if (isOpen) {
+      setStep(1);
+      setFormData((prev) => ({ ...prev, currency: defaultCurrency, currencyType: "FIAT" }));
+    }
+  }, [isOpen, defaultCurrency]);
 
   const allChainTokenOptions = useAllChainsTokens();
   const [resolver, setResolver] = useState<Option | undefined>(undefined);
@@ -184,7 +189,9 @@ export function AddExpenseModal({
   }, [user, members]);
 
   useEffect(() => {
-    const allMembers = members.map((m) => m.id);
+    const allMembers = members
+      .filter((m) => m.id !== formData.paidBy)
+      .map((m) => m.id);
 
     let newSplits: Split[] = [];
 
@@ -215,33 +222,47 @@ export function AddExpenseModal({
     }
 
     setSplits(newSplits);
-  }, [members, formData.amount, formData.splitType]);
+  }, [members, formData.amount, formData.splitType, formData.paidBy]);
 
   const updateCustomSplit = (id: string, amount: number) => {
-    setSplits((current) =>
-      current.map((split) =>
-        split.address === id ? { ...split, amount } : split
-      )
-    );
+    setSplits((current) => {
+      const total = Number(formData.amount);
+      const others = current.filter(
+        (s) => s.address !== id && s.address !== formData.paidBy
+      );
+      const remaining = total - amount;
+      const perOther = others.length > 0 ? remaining / others.length : 0;
+      return current.map((split) => {
+        if (split.address === id) return { ...split, amount };
+        if (split.address !== formData.paidBy) return { ...split, amount: perOther };
+        return split;
+      });
+    });
   };
 
   const updatePercentage = (id: string, percentage: number) => {
-    setPercentages((current) => ({
-      ...current,
-      [id]: percentage,
-    }));
+    setPercentages((current) => {
+      const otherIds = Object.keys(current).filter((k) => k !== id);
+      const remaining = 100 - percentage;
+      const perOther = otherIds.length > 0 ? remaining / otherIds.length : 0;
+      const updated: { [key: string]: number } = { ...current, [id]: percentage };
+      otherIds.forEach((k) => (updated[k] = perOther));
+      return updated;
+    });
 
-    setSplits((current) =>
-      current.map((split) =>
-        split.address === id
-          ? {
-              ...split,
-              amount: (Number(formData.amount) * percentage) / 100,
-              percentage: percentage,
-            }
-          : split
-      )
-    );
+    setSplits((current) => {
+      const otherSplits = current.filter((s) => s.address !== id && s.address !== formData.paidBy);
+      const remaining = 100 - percentage;
+      const perOther = otherSplits.length > 0 ? remaining / otherSplits.length : 0;
+      return current.map((split) => {
+        if (split.address === id) {
+          return { ...split, amount: (Number(formData.amount) * percentage) / 100, percentage };
+        } else if (split.address !== formData.paidBy) {
+          return { ...split, amount: (Number(formData.amount) * perOther) / 100, percentage: perOther };
+        }
+        return split;
+      });
+    });
   };
 
   const calculateDebts = (splits: Split[], paidBy: string): Debt[] => {
@@ -305,7 +326,7 @@ export function AddExpenseModal({
       currencyType: formData.currencyType,
       timeLockIn: formData.timeLockIn,
       paidBy: formData.paidBy,
-      splitType: formData.splitType.toUpperCase(),
+      splitType: formData.splitType === "custom" ? "EXACT" : formData.splitType.toUpperCase(),
       participants: splits.map((split) => ({
         userId: split.address,
         amount: split.amount,
@@ -366,14 +387,16 @@ export function AddExpenseModal({
   useEffect(() => {
     if (formData.splitType !== "percentage") return;
 
-    const allMembers = members.map((m) => m.id);
+    const allMembers = members
+      .filter((m) => m.id !== formData.paidBy)
+      .map((m) => m.id);
     const equalPercentage = 100 / allMembers.length;
 
     const initialPercentages = Object.fromEntries(
       allMembers.map((id) => [id, equalPercentage])
     );
     setPercentages(initialPercentages);
-  }, [members, formData.splitType]);
+  }, [members, formData.splitType, formData.paidBy]);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -418,6 +441,12 @@ export function AddExpenseModal({
   };
 
   const isCrypto = formData.currencyType === "TOKEN";
+  const isStablecoin = isCrypto && (() => {
+    const id = formData.currency.toUpperCase();
+    const symbol = getCurrencySymbol(formData.currency).toUpperCase();
+    const STABLECOINS = ["USDC", "USDT", "DAI", "BUSD", "TUSD", "FRAX", "USDP", "GUSD", "LUSD", "USDD", "SUSD"];
+    return STABLECOINS.some((s) => id.includes(s) || symbol.includes(s));
+  })();
   const canProceedStep1 = formData.name.trim() !== "";
   const canProceedStep2 = formData.currency !== "";
   const canProceedStep3 =
@@ -790,7 +819,7 @@ export function AddExpenseModal({
                       fontSize: 20,
                       fontWeight: 800,
                       marginRight: 10,
-                      minWidth: 24,
+                      flexShrink: 0,
                     }}
                   >
                     {getCurrencySymbol(formData.currency)}
@@ -1170,7 +1199,7 @@ export function AddExpenseModal({
                   </span>
                 </div>
               )}
-              {isCrypto && (
+              {isCrypto && !isStablecoin && (
                 <div>
                   <TimeLockToggle
                     value={formData.timeLockIn}

--- a/components/create-group-form.tsx
+++ b/components/create-group-form.tsx
@@ -969,45 +969,27 @@ export function CreateGroupForm({ isOpen, onClose }: CreateGroupFormProps) {
                     </p>
                   </div>
                                 </div>
-                <div
-                  style={{
-                    background: "rgba(255,255,255,0.04)",
-                    borderRadius: 16,
-                    padding: "15px 18px",
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                    border: "1px solid rgba(255,255,255,0.07)",
-                  }}
-                >
-                  <div>
-                    <p
-                      style={{
-                        color: T.sub,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        marginBottom: 4,
-                        letterSpacing: "0.05em",
-                      }}
-                    >
-                      DEFAULT SETTLEMENT
-                    </p>
-                    <p
-                      style={{
-                        color: T.bright,
-                        fontSize: 13,
-                        fontWeight: 700,
-                      }}
-                    >
-                      {formData.currency
-                        ? (() => {
-                            const c = allCurrencies?.currencies?.find((x: { id: string; symbol?: string; name?: string }) => x.id === formData.currency);
-                            return c ? `${c.symbol || formData.currency}${formData.currencyType === "TOKEN" ? ` · ${c.name || ""}` : ""}` : formData.currency;
-                          })()
-                        : "USD (Fiat)"}
-                                </p>
-                              </div>
-                            </div>
+                <div>
+                  <p
+                    style={{
+                      color: T.sub,
+                      fontSize: 11,
+                      fontWeight: 700,
+                      marginBottom: 8,
+                      letterSpacing: "0.05em",
+                    }}
+                  >
+                    DEFAULT SETTLEMENT
+                  </p>
+                  <CurrencyDropdown
+                    selectedCurrencies={formData.currency ? [formData.currency] : []}
+                    setSelectedCurrencies={handleCurrencySelect}
+                    showFiatCurrencies={true}
+                    disableChainCurrencies={false}
+                    mode="single"
+                    placeholder="Select currency..."
+                  />
+                </div>
                 <div>
                   <label style={lbl}>Members</label>
                   <div

--- a/components/groups-list-content.tsx
+++ b/components/groups-list-content.tsx
@@ -14,7 +14,7 @@ type GroupItem = {
   name: string;
   groupBalances?: { userId: string; currency: string; amount: number }[];
   groupUsers?: { user: { id: string; name?: string | null } }[];
-  expenses?: { amount: number; currency: string }[];
+  expenses?: { amount: number; currency: string; splitType?: string }[];
   updatedAt: Date;
 };
 
@@ -48,10 +48,12 @@ function GroupBalanceCell({
   const { total: oweTotal, isLoading: loadOwe } = useConvertedBalanceTotal(oweItems, defaultCurrency);
   const { total: owedTotal, isLoading: loadOwed } = useConvertedBalanceTotal(owedItems, defaultCurrency);
 
-  const expenseItems = (group.expenses || []).map((e) => ({
-    amount: Math.abs(e.amount),
-    currency: e.currency,
-  }));
+  const expenseItems = (group.expenses || [])
+    .filter((e) => e.splitType !== "SETTLEMENT")
+    .map((e) => ({
+      amount: Math.abs(e.amount),
+      currency: e.currency,
+    }));
   const { total: totalSpent, isLoading: loadSpent } = useConvertedBalanceTotal(expenseItems, defaultCurrency);
 
   if (loadOwe || loadOwed)

--- a/components/groups-list.tsx
+++ b/components/groups-list.tsx
@@ -51,6 +51,7 @@ export function GroupsList({ searchQuery = "" }: { searchQuery?: string }) {
         byCurrency[b.currency] = (byCurrency[b.currency] ?? 0) + b.amount;
       });
       Object.entries(byCurrency).forEach(([curr, amount]) => {
+        // amount > 0 = you owe, amount < 0 = owed to you
         if (amount > 0) oweItems.push({ amount, currency: curr });
         else if (amount < 0) owedItems.push({ amount: Math.abs(amount), currency: curr });
       });
@@ -80,10 +81,12 @@ export function GroupsList({ searchQuery = "" }: { searchQuery?: string }) {
   const totalSpentItems = useMemo(() => {
     if (!groupsData) return [];
     return groupsData.flatMap((g) =>
-      (Array.isArray((g as { expenses?: { amount: number; currency: string }[] }).expenses)
-        ? (g as { expenses: { amount: number; currency: string }[] }).expenses
+      (Array.isArray((g as { expenses?: { amount: number; currency: string; splitType?: string }[] }).expenses)
+        ? (g as { expenses: { amount: number; currency: string; splitType?: string }[] }).expenses
         : []
-      ).map((e) => ({ amount: e.amount, currency: e.currency }))
+      )
+        .filter((e) => e.splitType !== "SETTLEMENT")
+        .map((e) => ({ amount: e.amount, currency: e.currency }))
     );
   }, [groupsData]);
   const { total: totalSpent } = useConvertedBalanceTotal(totalSpentItems, defaultCurrency);
@@ -202,22 +205,24 @@ export function GroupsList({ searchQuery = "" }: { searchQuery?: string }) {
 
   if (groupsData.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center rounded-2xl sm:rounded-3xl bg-[#101012] p-6 sm:p-12 min-h-[calc(100vh-160px)] sm:min-h-[calc(100vh-180px)]">
-        <div className="text-mobile-lg sm:text-xl text-white/70 mb-3 sm:mb-4">
-          No groups created yet
-        </div>
-        <p className="text-mobile-sm sm:text-base text-white/50 text-center max-w-md mb-6 sm:mb-8">
-          Create a group to start tracking expenses and settle debts with your
-          friends
+      <div style={{ textAlign: "center", padding: "80px 20px" }}>
+        <p style={{ fontSize: 48, marginBottom: 18 }}>👥</p>
+        <p style={{ fontSize: 18, fontWeight: 800, color: T.body, marginBottom: 8 }}>
+          No groups yet
+        </p>
+        <p style={{ fontSize: 14, color: T.sub, marginBottom: 24 }}>
+          Create a group to start tracking expenses and settle debts with your friends
         </p>
         <button
+          type="button"
           onClick={() =>
             document.dispatchEvent(new CustomEvent("open-create-group-modal"))
           }
-          className="flex items-center justify-center gap-2 rounded-full bg-white text-black h-10 sm:h-12 px-4 sm:px-6 text-mobile-base sm:text-base font-medium hover:bg-white/90 transition-all"
+          className="inline-flex items-center gap-2 rounded-xl text-[13px] font-extrabold text-[#0a0a0a] transition-opacity hover:opacity-90"
+          style={{ background: "#22D3EE", padding: "10px 18px" }}
         >
-          <Plus className="h-4 sm:h-5 w-4 sm:w-5" strokeWidth={1.5} />
-          <span>Create Group</span>
+          <Plus className="h-4 w-4" strokeWidth={2.5} />
+          New Group
         </button>
       </div>
     );
@@ -229,7 +234,7 @@ export function GroupsList({ searchQuery = "" }: { searchQuery?: string }) {
     if (netBalance < 0) return `-${formatCurrency(Math.abs(netBalance), defaultCurrency)}`;
     return formatCurrency(0, defaultCurrency);
   })();
-  const netBalanceColor = netBalance > 0 ? G : netBalance < 0 ? "#FF4444" : T.muted;
+  const netBalanceColor = netBalance > 0 ? G : netBalance < 0 ? "#F87171" : T.muted;
 
   return React.createElement(GroupsListContent, {
     filteredGroups,

--- a/components/settle-debts-modal.tsx
+++ b/components/settle-debts-modal.tsx
@@ -11,7 +11,7 @@ import { useSettleDebt } from "@/features/settle/hooks/use-splits";
 import { useMarkAsPaid } from "@/features/groups/hooks/use-create-group";
 import { useHandleEscapeToCloseModal } from "@/hooks/useHandleEscape";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, useQueries } from "@tanstack/react-query";
 import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
 import { useBalances } from "@/features/balances/hooks/use-balances";
@@ -36,6 +36,7 @@ interface SettleDebtsModalProps {
   specificAmount?: number;
   specificDebtByCurrency?: Record<string, number>;
   defaultExpandedMemberId?: string | null;
+  specificMemberAmounts?: Record<string, number>;
 }
 
 export function SettleDebtsModal({
@@ -50,6 +51,7 @@ export function SettleDebtsModal({
   specificAmount,
   specificDebtByCurrency,
   defaultExpandedMemberId,
+  specificMemberAmounts,
 }: SettleDebtsModalProps) {
   const user = useAuthStore((state) => state.user);
   const {
@@ -282,12 +284,12 @@ export function SettleDebtsModal({
     }
   }, [isOpen, groupId, showIndividualView, selectedFriendId, userStellarAddress]);
 
-  // Auto-expand the specified member row when modal opens
+  // Reset expanded row when modal opens
   useEffect(() => {
-    if (isOpen && defaultExpandedMemberId) {
-      setExpandedRowMemberId(defaultExpandedMemberId);
+    if (isOpen) {
+      setExpandedRowMemberId(null);
     }
-  }, [isOpen, defaultExpandedMemberId]);
+  }, [isOpen]);
 
   // Set the selected user based on selectedFriendId prop
   useEffect(() => {
@@ -821,17 +823,34 @@ export function SettleDebtsModal({
   const memberDebtRows = useMemo(() => {
     const palette = ["#A78BFA", "#34D399", "#FB923C", "#22D3EE", "#F472B6", "#FBBF24"];
     const sourceBalances = Array.isArray(balances) ? balances : [];
-    const rows = sourceBalances
-      .filter((b) => b.userId !== user?.id && b.amount < 0)
+    // Track debts per member per currency separately
+    // Only include debts that the current user specifically owes (b.firendId === user?.id)
+    const balanceMap = sourceBalances
+      .filter((b) => b.userId !== user?.id && b.amount < 0 && b.firendId === user?.id)
       .reduce((acc, b) => {
-        const current = acc.get(b.userId) || 0;
-        const rate = balanceRateMap[b.currency] ?? 1;
-        acc.set(b.userId, current + Math.abs(b.amount) * rate);
+        const existing = acc.get(b.userId) || [];
+        const entry = existing.find((e) => e.currency === b.currency);
+        if (entry) {
+          entry.amount += Math.abs(b.amount);
+        } else {
+          existing.push({ currency: b.currency, amount: Math.abs(b.amount) });
+        }
+        acc.set(b.userId, existing);
         return acc;
-      }, new Map<string, number>());
+      }, new Map<string, Array<{ currency: string; amount: number }>>());
 
-    return Array.from(rows.entries())
-      .map(([memberId, amount], index) => {
+    // Also add rows for members in specificMemberAmounts not already covered by balance data
+    // (these are debtors in the payer/creditor view)
+    if (specificMemberAmounts) {
+      Object.entries(specificMemberAmounts).forEach(([memberId, amount]) => {
+        if (amount > 0 && !balanceMap.has(memberId)) {
+          balanceMap.set(memberId, [{ currency: defaultCurrency || "USD", amount }]);
+        }
+      });
+    }
+
+    return Array.from(balanceMap.entries())
+      .map(([memberId, debts], index) => {
         const member = _members.find((m) => m.id === memberId);
         const initials = (member?.name || member?.email || "?")
           .split(" ")
@@ -840,20 +859,55 @@ export function SettleDebtsModal({
           .slice(0, 2)
           .toUpperCase();
         const color = palette[index % palette.length];
+        const primaryDebt = debts[0] ?? { amount: 0, currency: defaultCurrency || "USD" };
         return {
           memberId,
           name: member?.name || member?.email || "Member",
           initials,
           color,
-          amount,
+          debts,
+          amount: primaryDebt.amount,
+          currency: primaryDebt.currency,
         };
       })
       .sort((a, b) => b.amount - a.amount);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [balances, user?.id, _members, balanceRateMap]);
+  }, [balances, user?.id, _members, specificMemberAmounts, defaultCurrency]);
+
+  // Fetch exchange rates for balance currencies that differ from defaultCurrency
+  const uniqueBalanceCurrencies = useMemo(() => {
+    if (!defaultCurrency) return [];
+    return [...new Set(memberDebtRows.map((r) => r.currency))].filter(
+      (c) => c && c !== defaultCurrency
+    );
+  }, [memberDebtRows, defaultCurrency]);
+
+  const balanceRateQueries = useQueries({
+    queries: uniqueBalanceCurrencies.map((from) => ({
+      queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
+      queryFn: () => getExchangeRate(from, defaultCurrency ?? "USD"),
+      staleTime: 1000 * 60 * 5,
+      retry: 1,
+    })),
+  });
+
+  const balanceRates = useMemo(() => {
+    const map: Record<string, number> = {};
+    uniqueBalanceCurrencies.forEach((c, i) => {
+      map[c] = balanceRateQueries[i]?.data?.rate ?? 1;
+    });
+    return map;
+  }, [uniqueBalanceCurrencies, balanceRateQueries]);
+
+  const convertBalanceAmount = (amount: number, fromCurrency: string): number => {
+    if (!fromCurrency || fromCurrency === defaultCurrency) return amount;
+    return amount * (balanceRates[fromCurrency] ?? 1);
+  };
 
   // Calculate the remaining total after currency conversion
-  const remainingTotal = memberDebtRows.reduce((sum, row) => sum + row.amount, 0);
+  const remainingTotal = memberDebtRows.reduce(
+    (sum, row) => sum + row.debts.reduce((s, d) => s + convertBalanceAmount(d.amount, d.currency), 0),
+    0
+  );
 
   const CURRENCY_FLAG: Record<string, string> = {
     USD: "🇺🇸", EUR: "🇪🇺", GBP: "🇬🇧", JPY: "🇯🇵", THB: "🇹🇭",
@@ -873,7 +927,7 @@ export function SettleDebtsModal({
     ? Object.keys(organizedCurrencies.chainGroups)
     : ["stellar", "solana", "aptos", "base"];
 
-  const handleMarkAsPaid = (memberId: string, amount: number) => {
+  const handleMarkAsPaid = (memberId: string, amount: number, currency: string) => {
     if (!user || !groupId) return;
     markAsPaidMutation.mutate(
       {
@@ -882,7 +936,7 @@ export function SettleDebtsModal({
           payerId: memberId,
           payeeId: user.id,
           amount,
-          currency: defaultCurrency || "USD",
+          currency: currency || defaultCurrency || "USD",
           currencyType: "FIAT",
         },
       },
@@ -1014,7 +1068,14 @@ export function SettleDebtsModal({
                                 </p>
                               </div>
                               <p className="text-[#34D399] text-sm font-extrabold tabular-nums flex-shrink-0">
-                                +{formatCurrency(row.amount, defaultCurrency || "USD")}
+                                +{formatCurrency(
+                                  specificMemberAmounts?.[row.memberId] !== undefined
+                                    ? specificMemberAmounts[row.memberId]
+                                    : row.memberId === defaultExpandedMemberId && specificAmount !== undefined
+                                      ? specificAmount
+                                      : row.debts.reduce((sum, d) => sum + convertBalanceAmount(d.amount, d.currency), 0),
+                                  defaultCurrency || "USD"
+                                )}
                               </p>
                               <span className="flex-shrink-0 text-white/40">
                                 {isExpanded ? (
@@ -1250,7 +1311,19 @@ export function SettleDebtsModal({
                                             border: "1.5px solid rgba(52,211,153,0.25)",
                                             color: "#34D399",
                                           }}
-                                          onClick={() => handleMarkAsPaid(row.memberId, row.amount)}
+                                          onClick={() => {
+                                            const displayedAmount =
+                                              specificMemberAmounts?.[row.memberId] !== undefined
+                                                ? specificMemberAmounts[row.memberId]
+                                                : row.memberId === defaultExpandedMemberId && specificAmount !== undefined
+                                                  ? specificAmount
+                                                  : row.debts.reduce((sum, d) => sum + convertBalanceAmount(d.amount, d.currency), 0);
+                                            handleMarkAsPaid(
+                                              row.memberId,
+                                              displayedAmount,
+                                              memberBankCurrencies[row.memberId] || defaultCurrency || row.currency,
+                                            );
+                                          }}
                                         >
                                           {markAsPaidMutation.isPending ? "Marking…" : "✓ Mark as Paid"}
                                         </button>

--- a/components/settle-debts-modal.tsx
+++ b/components/settle-debts-modal.tsx
@@ -11,14 +11,13 @@ import { useSettleDebt } from "@/features/settle/hooks/use-splits";
 import { useMarkAsPaid } from "@/features/groups/hooks/use-create-group";
 import { useHandleEscapeToCloseModal } from "@/hooks/useHandleEscape";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { useQueryClient, useQueries } from "@tanstack/react-query";
+import { useQueryClient, useQuery, useQueries } from "@tanstack/react-query";
 import { useGetFriends } from "@/features/friends/hooks/use-get-friends";
 import { useGetAllGroups } from "@/features/groups/hooks/use-create-group";
 import { useBalances } from "@/features/balances/hooks/use-balances";
 import ResolverSelector, { Option as TokenOption } from "./ResolverSelector";
 import { useOrganizedCurrencies, useGetExchangeRate, CURRENCY_QUERY_KEYS } from "@/features/currencies/hooks/use-currencies";
 import { useAuthStore } from "@/stores/authStore";
-import { useQuery, useQueries } from "@tanstack/react-query";
 import { getExchangeRate } from "@/features/currencies/api/client";
 import { useWallet } from "@/hooks/useWallet";
 import { useUserWallets } from "@/features/wallets/hooks/use-wallets";
@@ -881,7 +880,7 @@ export function SettleDebtsModal({
     );
   }, [memberDebtRows, defaultCurrency]);
 
-  const balanceRateQueries = useQueries({
+  const memberDebtRateQueries = useQueries({
     queries: uniqueBalanceCurrencies.map((from) => ({
       queryKey: [CURRENCY_QUERY_KEYS.EXCHANGE_RATE, from, defaultCurrency],
       queryFn: () => getExchangeRate(from, defaultCurrency ?? "USD"),
@@ -893,10 +892,10 @@ export function SettleDebtsModal({
   const balanceRates = useMemo(() => {
     const map: Record<string, number> = {};
     uniqueBalanceCurrencies.forEach((c, i) => {
-      map[c] = balanceRateQueries[i]?.data?.rate ?? 1;
+      map[c] = memberDebtRateQueries[i]?.data?.rate ?? 1;
     });
     return map;
-  }, [uniqueBalanceCurrencies, balanceRateQueries]);
+  }, [uniqueBalanceCurrencies, memberDebtRateQueries]);
 
   const convertBalanceAmount = (amount: number, fromCurrency: string): number => {
     if (!fromCurrency || fromCurrency === defaultCurrency) return amount;

--- a/contexts/group-layout-context.tsx
+++ b/contexts/group-layout-context.tsx
@@ -11,8 +11,10 @@ export type GroupLayoutContextValue = {
   openAddMember: () => void;
   openAddExpense: () => void;
   openSettings: () => void;
-  openSettle: (friendId?: string | null) => void;
+  openSettle: (friendId?: string | null, specificAmount?: number, specificMemberAmounts?: Record<string, number>) => void;
   settleFriendId: string | null;
+  settleSpecificAmount: number | undefined;
+  settleSpecificMemberAmounts: Record<string, number> | undefined;
   getSpecificDebtAmount: (friendId: string) => number;
   getSpecificDebtByCurrency: (friendId: string) => Record<string, number>;
   handleSettleFriendClick: (friendId: string) => void;


### PR DESCRIPTION
Bug Fixes
  - Fixed balance sign convention in GroupInfoHeader — net balance now correctly shows "You are owed" vs "You owe" using a proper NET
  calculation
  - Fixed settle modal showing inflated amounts by adding b.firendId === user?.id filter to exclude other members' inter-debts
  - Fixed settle modal missing debtors in creditor view by injecting specificMemberAmounts rows
  - Fixed total spent being inflated by settlement expenses (splitType === "SETTLEMENT" now excluded everywhere)
  - Fixed setSettleAsIndividual is not defined runtime error in group layout

  UI / Design
  - Fixed net balance color (#FF4444 → #F87171) to match rest of app
  - Fixed "No groups" empty state to match app design system
  - Fixed DEFAULT SETTLEMENT dropdown in Create Group review step — replaced broken static display with CurrencyDropdown
  - Removed red/green price colors from group activity tab — amounts are now white
  - Removed red/green price colors from organization activity tab — amounts are now white

  Access Control
  - Third-party non-involved users no longer see Settle, Notify, Delete buttons or payment status on expense rows
  - Notify button only shown to the expense payer (backend only allows payer to send reminders)

  Accept Payments Feature
  - Wired up "Accept Payments In" dropdown to actual API (GET/POST/DELETE /users/accepted-tokens)
  - Added Save button to accept payments section (both mobile and desktop) matching app button style
  - Fixed backend $executeRaw → $queryRaw so RETURNING * actually returns saved records
  - Query now always fetches fresh (staleTime: 0) so selections persist across page navigation