### PR TITLE
organization view bug fixes

### DIFF
--- a/app/groups/[id]/splits/page.tsx
+++ b/app/groups/[id]/splits/page.tsx
@@ -231,9 +231,11 @@ function ExpenseRow({
               <Btn variant="ghost" onClick={onSettle} className="splito-sbtn" style={{ padding: "8px 16px", fontSize: 12 }}>
                 <Icons.check /> Settle
               </Btn>
-              <Btn variant="ghost" onClick={onNotify} className="splito-abtn" style={{ padding: "8px 16px", fontSize: 12 }}>
-                <Icons.bell /> Notify
-              </Btn>
+              {iAmPayer && (
+                <Btn variant="ghost" onClick={onNotify} className="splito-abtn" style={{ padding: "8px 16px", fontSize: 12 }}>
+                  <Icons.bell /> Notify
+                </Btn>
+              )}
               <Btn variant="danger" onClick={onDelete} style={{ padding: "8px 14px", fontSize: 12 }}>
                 <Icons.trash size={14} /> Delete
               </Btn>

--- a/app/organization/[organizationId]/invoices/page.tsx
+++ b/app/organization/[organizationId]/invoices/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState } from "react";
 import { useParams } from "next/navigation";
 import Image from "next/image";
 import { useAuthStore } from "@/stores/authStore";
@@ -60,9 +60,13 @@ function InvoiceRow({
   onDelete,
   onReview,
   onClear,
+  onMarkPaid,
+  onReject,
   isPaying,
   isDeleting,
   isClearing,
+  isMarkingPaid,
+  isRejecting,
   setExpandedImage,
   formatAmt,
 }: {
@@ -74,9 +78,13 @@ function InvoiceRow({
   onDelete?: () => void;
   onReview?: () => void;
   onClear?: () => void;
+  onMarkPaid?: () => void;
+  onReject?: () => void;
   isPaying?: boolean;
   isDeleting?: boolean;
   isClearing?: boolean;
+  isMarkingPaid?: boolean;
+  isRejecting?: boolean;
   setExpandedImage?: (v: { url: string; description: string }) => void;
   formatAmt?: (amount: number, currency: string) => string;
 }) {
@@ -117,7 +125,7 @@ function InvoiceRow({
             <p className="text-[16px] font-extrabold font-mono" style={{ color: T.bright }}>
               {displayAmt(inv.amount, inv.currency)}
             </p>
-            <StatusPill status={inv.status} />
+            {inv.status !== "DRAFT" && <StatusPill status={inv.status} />}
           </div>
         </div>
 
@@ -152,7 +160,22 @@ function InvoiceRow({
               {isDeleting ? <Loader2 className="h-3 w-3 animate-spin" /> : "Delete"}
             </button>
           )}
-          {isAdmin && onClear && (inv.status === "PAID" || inv.status === "APPROVED" || inv.status === "DECLINED") && (
+          {isAdmin && onMarkPaid && inv.status !== "PAID" && inv.status !== "CLEARED" && (
+            <button onClick={onMarkPaid} disabled={isMarkingPaid}
+              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-bold transition-all hover:opacity-80 disabled:opacity-50"
+              style={{ background: "rgba(52,211,153,0.15)", color: "#34D399" }}>
+              {isMarkingPaid ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle2 className="h-3 w-3" />}
+              Mark paid
+            </button>
+          )}
+          {isAdmin && onReject && inv.status !== "DECLINED" && inv.status !== "PAID" && inv.status !== "CLEARED" && (
+            <button onClick={onReject} disabled={isRejecting}
+              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-bold transition-all hover:opacity-80 disabled:opacity-50"
+              style={{ background: "rgba(248,113,113,0.15)", color: "#F87171" }}>
+              {isRejecting ? <Loader2 className="h-3 w-3 animate-spin" /> : "Reject"}
+            </button>
+          )}
+          {isAdmin && onClear && (inv.status === "DRAFT" || inv.status === "PAID" || inv.status === "APPROVED" || inv.status === "DECLINED") && (
             <button onClick={onClear} disabled={isClearing}
               className="rounded-lg px-3 py-1.5 text-[12px] font-semibold border transition-all hover:bg-white/5 disabled:opacity-50"
               style={{ borderColor: "rgba(255,255,255,0.1)", color: T.muted }}>
@@ -174,6 +197,9 @@ export default function OrganizationInvoicesPage() {
   const approveInvoiceMutation = useApproveInvoice();
   const declineInvoiceMutation = useDeclineInvoice();
   const clearInvoiceMutation = useClearInvoice();
+  const [clearingInvoiceId, setClearingInvoiceId] = React.useState<string | null>(null);
+  const [markingPaidInvoiceId, setMarkingPaidInvoiceId] = React.useState<string | null>(null);
+  const [rejectingInvoiceId, setRejectingInvoiceId] = React.useState<string | null>(null);
   const markPaidMutation = useMarkInvoiceAsPaid();
   const updateInvoiceMutation = useUpdateInvoice();
   const deleteInvoiceMutation = useDeleteInvoice();
@@ -307,8 +333,14 @@ export default function OrganizationInvoicesPage() {
                 onPay={() => markPaidMutation.mutate(inv.id, { onSuccess: () => toast.success("Marked as paid"), onError: () => toast.error("Failed") })}
                 onEdit={() => setInvoiceToEdit({ id: inv.id, amount: inv.amount, currency: inv.currency, dueDate: inv.dueDate, description: inv.description ?? null, imageUrl: inv.imageUrl ?? null })}
                 onDelete={() => deleteInvoiceMutation.mutate(inv.id, { onSuccess: () => toast.success("Deleted"), onError: () => toast.error("Failed to delete") })}
+                onClear={() => { setClearingInvoiceId(inv.id); clearInvoiceMutation.mutate(inv.id, { onSuccess: () => { setClearingInvoiceId(null); toast.success("Cleared"); }, onError: () => { setClearingInvoiceId(null); toast.error("Failed to clear"); } }); }}
+                onMarkPaid={() => { setMarkingPaidInvoiceId(inv.id); markPaidMutation.mutate(inv.id, { onSuccess: () => { setMarkingPaidInvoiceId(null); toast.success("Marked as paid"); }, onError: () => { setMarkingPaidInvoiceId(null); toast.error("Failed to mark as paid"); } }); }}
+                onReject={() => { setRejectingInvoiceId(inv.id); declineInvoiceMutation.mutate({ invoiceId: inv.id }, { onSuccess: () => { setRejectingInvoiceId(null); toast.success("Rejected"); }, onError: () => { setRejectingInvoiceId(null); toast.error("Failed to reject"); } }); }}
                 isPaying={markPaidMutation.isPending}
                 isDeleting={deleteInvoiceMutation.isPending}
+                isClearing={clearingInvoiceId === inv.id}
+                isMarkingPaid={markingPaidInvoiceId === inv.id}
+                isRejecting={rejectingInvoiceId === inv.id}
                 setExpandedImage={setExpandedImage}
                 formatAmt={(amount, currency) => formatCurrency(convert(amount, currency), defaultCurrency)}
               />
@@ -329,6 +361,12 @@ export default function OrganizationInvoicesPage() {
                 isAdmin={!!isAdmin}
                 userId={user?.id}
                 onReview={() => setInvoiceToReview(inv)}
+                onClear={() => { setClearingInvoiceId(inv.id); clearInvoiceMutation.mutate(inv.id, { onSuccess: () => { setClearingInvoiceId(null); toast.success("Cleared"); }, onError: () => { setClearingInvoiceId(null); toast.error("Failed to clear"); } }); }}
+                onMarkPaid={() => { setMarkingPaidInvoiceId(inv.id); markPaidMutation.mutate(inv.id, { onSuccess: () => { setMarkingPaidInvoiceId(null); toast.success("Marked as paid"); }, onError: () => { setMarkingPaidInvoiceId(null); toast.error("Failed to mark as paid"); } }); }}
+                onReject={() => { setRejectingInvoiceId(inv.id); declineInvoiceMutation.mutate({ invoiceId: inv.id }, { onSuccess: () => { setRejectingInvoiceId(null); toast.success("Rejected"); }, onError: () => { setRejectingInvoiceId(null); toast.error("Failed to reject"); } }); }}
+                isClearing={clearingInvoiceId === inv.id}
+                isMarkingPaid={markingPaidInvoiceId === inv.id}
+                isRejecting={rejectingInvoiceId === inv.id}
                 setExpandedImage={setExpandedImage}
                 formatAmt={(amount, currency) => formatCurrency(convert(amount, currency), defaultCurrency)}
               />
@@ -363,8 +401,8 @@ export default function OrganizationInvoicesPage() {
                       inv={inv}
                       isAdmin={!!isAdmin}
                       userId={user?.id}
-                      onClear={() => clearInvoiceMutation.mutate(inv.id, { onSuccess: () => toast.success("Cleared"), onError: () => toast.error("Failed to clear") })}
-                      isClearing={clearInvoiceMutation.isPending}
+                      onClear={() => { setClearingInvoiceId(inv.id); clearInvoiceMutation.mutate(inv.id, { onSuccess: () => { setClearingInvoiceId(null); toast.success("Cleared"); }, onError: () => { setClearingInvoiceId(null); toast.error("Failed to clear"); } }); }}
+                      isClearing={clearingInvoiceId === inv.id}
                       setExpandedImage={setExpandedImage}
                       formatAmt={(amount, currency) => formatCurrency(convert(amount, currency), defaultCurrency)}
                     />

--- a/app/organization/page.tsx
+++ b/app/organization/page.tsx
@@ -127,6 +127,7 @@ export default function OrganizationDashboardPage() {
   ).length;
   const totalInvoicesForOrg = invoicesForOrg.length;
   const paymentsOverdue = invoicesForOrg.filter((i) => i.status === "OVERDUE" || i.status === "APPROVED").length;
+  const memberActiveInvoices = memberInvoices.filter((i) => i.status !== "PAID" && i.status !== "CLEARED" && i.status !== "DECLINED").length;
   const approvalRequestsCount = invoicesForOrg.filter((i) => i.status === "SENT").length;
   const approvalPastDueCount = invoicesForOrg.filter((i) => i.status === "SENT" && new Date(i.dueDate) < new Date()).length;
 
@@ -292,36 +293,45 @@ export default function OrganizationDashboardPage() {
               </div>
             </div>
             <div className="h-px mb-5" style={{ background: "rgba(255,255,255,0.07)" }} />
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-0">
-              {[
-                { label: "Members", value: String(memberCountForOrg), accent: T.bright },
-                { label: "Invoices", value: String(totalInvoicesForOrg), accent: paymentsOverdue > 0 ? "#F87171" : T.bright },
-                { label: "Streams", value: String(totalStreamsCount), accent: "#34D399" },
-                { label: "Contracts", value: String(contractsForOrg.length), accent: A },
-              ].flatMap((s, i) => {
-                const el = (
-                  <div
-                    key={s.label}
-                    className={cn(
-                      "min-w-0",
+            {isAdminOfSelectedOrg ? (
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-0">
+                {[
+                  { label: "Members", value: String(memberCountForOrg), accent: T.bright },
+                  { label: "Invoices", value: String(totalInvoicesForOrg), accent: paymentsOverdue > 0 ? "#F87171" : T.bright },
+                  { label: "Streams", value: String(totalStreamsCount), accent: "#34D399" },
+                  { label: "Contracts", value: String(contractsForOrg.length), accent: A },
+                ].flatMap((s, i) => {
+                  const el = (
+                    <div key={s.label} className={cn("min-w-0",
                       (i === 1 || i === 3) ? "pl-4 sm:pl-6 border-l border-white/[0.07]" : "",
                       i === 2 ? "sm:pl-6 sm:border-l sm:border-white/[0.07]" : "",
                       (i === 0 || i === 2) ? "pr-4 sm:pr-6" : "",
-                    )}
-                  >
+                    )}>
+                      <p className="text-[10px] font-semibold tracking-[0.06em] uppercase mb-1.5" style={{ color: T.dim }}>{s.label}</p>
+                      <p className="text-[22px] sm:text-[24px] font-extrabold font-mono" style={{ color: s.accent }}>{s.value}</p>
+                    </div>
+                  );
+                  if (i === 2) return [(<div key="row-sep" className="col-span-2 sm:hidden h-px my-4" style={{ background: "rgba(255,255,255,0.07)" }} />), el];
+                  return [el];
+                })}
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-0">
+                {[
+                  { label: "Members", value: String(memberCountForOrg), accent: T.bright },
+                  { label: "Active Invoices", value: String(memberActiveInvoices), accent: memberActiveInvoices > 0 ? "#F87171" : T.bright },
+                  { label: "Contracts", value: String(myOrgContracts.length), accent: A },
+                ].map((s, i) => (
+                  <div key={s.label} className={cn("min-w-0",
+                    i > 0 ? "pl-4 sm:pl-6 border-l border-white/[0.07]" : "",
+                    i < 2 ? "pr-4 sm:pr-6" : "",
+                  )}>
                     <p className="text-[10px] font-semibold tracking-[0.06em] uppercase mb-1.5" style={{ color: T.dim }}>{s.label}</p>
                     <p className="text-[22px] sm:text-[24px] font-extrabold font-mono" style={{ color: s.accent }}>{s.value}</p>
                   </div>
-                );
-                if (i === 2) {
-                  return [
-                    <div key="row-sep" className="col-span-2 sm:hidden h-px my-4" style={{ background: "rgba(255,255,255,0.07)" }} />,
-                    el,
-                  ];
-                }
-                return [el];
-              })}
-            </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { signOut } from "@/lib/auth";
-import { useUpdateUser } from "@/features/user/hooks/use-update-profile";
+import { useUpdateUser, useGetUserAcceptedTokens, useAddUserAcceptedToken, useRemoveUserAcceptedToken } from "@/features/user/hooks/use-update-profile";
 import { asEnhancedUser } from "@/types/user";
 import { useGetAllCurrencies } from "@/features/currencies/hooks/use-currencies";
 import {
@@ -41,6 +41,9 @@ export default function SettingsPage() {
   const [initialPreferredCurrency, setInitialPreferredCurrency] =
     useState<string>("");
 
+  const { data: acceptedTokensData } = useGetUserAcceptedTokens();
+  const { mutate: addAcceptedToken } = useAddUserAcceptedToken();
+  const { mutate: removeAcceptedToken } = useRemoveUserAcceptedToken();
   const [selectedCurrencies, setSelectedCurrencies] = useState<string[]>([]);
 
   // State for wallets
@@ -100,6 +103,13 @@ export default function SettingsPage() {
       return "USD";
     }
   };
+
+  // Populate selectedCurrencies from loaded accepted tokens
+  useEffect(() => {
+    if (acceptedTokensData) {
+      setSelectedCurrencies(acceptedTokensData.map((t) => t.tokenId));
+    }
+  }, [acceptedTokensData]);
 
   // Load user data when available; use platform default currency when user has none set
   useEffect(() => {
@@ -385,6 +395,41 @@ export default function SettingsPage() {
     handleImageUpload,
     selectedCurrencies,
     setSelectedCurrencies,
+    onSaveAcceptedTokens: () => {
+      const saved = acceptedTokensData?.map((t) => t.tokenId) ?? [];
+      const added = selectedCurrencies.filter((id) => !saved.includes(id));
+      const removed = saved.filter((id) => !selectedCurrencies.includes(id));
+
+      const addPromises = added.map((tokenId) => {
+        const currency = allCurrencies.find((c) => c.id === tokenId);
+        if (!currency?.chainId) return Promise.resolve();
+        return new Promise<void>((resolve, reject) =>
+          addAcceptedToken({ tokenId, chainId: currency.chainId! }, {
+            onSuccess: () => resolve(),
+            onError: (e) => reject(e),
+          })
+        );
+      });
+
+      const removePromises = removed.map((tokenId) => {
+        const existing = acceptedTokensData?.find((t) => t.tokenId === tokenId);
+        if (!existing) return Promise.resolve();
+        return new Promise<void>((resolve, reject) =>
+          removeAcceptedToken(existing.id, {
+            onSuccess: () => resolve(),
+            onError: (e) => reject(e),
+          })
+        );
+      });
+
+      Promise.all([...addPromises, ...removePromises])
+        .then(() => {
+          if (added.length > 0 || removed.length > 0) {
+            toast.success("Payment preferences saved");
+          }
+        })
+        .catch((e) => toast.error(e?.message || "Failed to save payment preferences"));
+    },
     isLoadingWallets,
     onLogout: handleLogout,
     isLoggingOut: isLoggingOut,

--- a/app/settings/settings-page-content.tsx
+++ b/app/settings/settings-page-content.tsx
@@ -45,6 +45,7 @@ export interface SettingsPageContentProps {
   handleImageUpload: (file: File) => void;
   selectedCurrencies: string[];
   setSelectedCurrencies: (v: string[]) => void;
+  onSaveAcceptedTokens: () => void;
   isLoadingWallets: boolean;
   onLogout?: () => void;
   isLoggingOut?: boolean;
@@ -327,6 +328,7 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
     handleImageUpload,
     selectedCurrencies,
     setSelectedCurrencies,
+    onSaveAcceptedTokens,
     isLoadingWallets,
     onLogout,
     isLoggingOut = false,
@@ -470,6 +472,7 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
               <CurrencyDropdown
                 selectedCurrencies={selectedCurrencies}
                 setSelectedCurrencies={setSelectedCurrencies}
+                mode="single"
                 filterCurrencies={(currency: Currency) =>
                   currency.symbol !== "ETH" &&
                   currency.symbol !== "USDC" &&
@@ -477,6 +480,17 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
                 }
                 showFiatCurrencies={false}
               />
+              <button
+                onClick={onSaveAcceptedTokens}
+                style={{
+                  marginTop: 12, width: "100%", padding: "10px 0",
+                  background: A, border: "none",
+                  borderRadius: 12, color: "#0a0a0a", fontSize: 13, fontWeight: 800,
+                  cursor: "pointer", fontFamily: "inherit",
+                }}
+              >
+                Save
+              </button>
             </MobileCard>
           </>
         )}
@@ -659,6 +673,7 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
               <CurrencyDropdown
                 selectedCurrencies={selectedCurrencies}
                 setSelectedCurrencies={setSelectedCurrencies}
+                mode="single"
                 filterCurrencies={(currency: Currency) =>
                   currency.symbol !== "ETH" &&
                   currency.symbol !== "USDC" &&
@@ -666,6 +681,14 @@ export function SettingsPageContent(props: SettingsPageContentProps) {
                 }
                 showFiatCurrencies={false}
               />
+              <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 14 }}>
+                <button
+                  onClick={onSaveAcceptedTokens}
+                  style={{ background: A, border: "none", borderRadius: 12, padding: "10px 22px", color: "#0a0a0a", fontWeight: 800, fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}
+                >
+                  Save
+                </button>
+              </div>
             </Card>
           </>
         )}

--- a/features/user/api/client.ts
+++ b/features/user/api/client.ts
@@ -46,3 +46,25 @@ export const getUser = async () => {
   const response = await apiClient.get("/users/me");
   return UserSchema.parse(response);
 };
+
+export type UserAcceptedToken = {
+  id: string;
+  tokenId: string;
+  chainId: string;
+  symbol: string;
+  isDefault: boolean;
+};
+
+export const getUserAcceptedTokens = async (): Promise<UserAcceptedToken[]> => {
+  const response = await apiClient.get("/users/accepted-tokens");
+  return response as UserAcceptedToken[];
+};
+
+export const addUserAcceptedToken = async (payload: { tokenId: string; chainId: string }): Promise<UserAcceptedToken> => {
+  const response = await apiClient.post("/users/accepted-tokens", payload);
+  return response as UserAcceptedToken;
+};
+
+export const removeUserAcceptedToken = async (id: string): Promise<void> => {
+  await apiClient.delete(`/users/accepted-tokens/${id}`);
+};

--- a/features/user/api/client.ts
+++ b/features/user/api/client.ts
@@ -57,12 +57,12 @@ export type UserAcceptedToken = {
 
 export const getUserAcceptedTokens = async (): Promise<UserAcceptedToken[]> => {
   const response = await apiClient.get("/users/accepted-tokens");
-  return response as UserAcceptedToken[];
+  return response as unknown as UserAcceptedToken[];
 };
 
 export const addUserAcceptedToken = async (payload: { tokenId: string; chainId: string }): Promise<UserAcceptedToken> => {
   const response = await apiClient.post("/users/accepted-tokens", payload);
-  return response as UserAcceptedToken;
+  return response as unknown as UserAcceptedToken;
 };
 
 export const removeUserAcceptedToken = async (id: string): Promise<void> => {

--- a/features/user/hooks/use-update-profile.ts
+++ b/features/user/hooks/use-update-profile.ts
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "@/lib/constants";
 import { useMutation } from "@tanstack/react-query";
-import { getUser, updateUser } from "../api/client";
+import { getUser, updateUser, getUserAcceptedTokens, addUserAcceptedToken, removeUserAcceptedToken } from "../api/client";
 import { toast } from "sonner";
 
 export const useUpdateUser = () => {
@@ -24,5 +24,31 @@ export const useGetUser = () => {
   return useQuery({
     queryKey: [QueryKeys.USER],
     queryFn: getUser,
+  });
+};
+
+const ACCEPTED_TOKENS_KEY = ["user-accepted-tokens"];
+
+export const useGetUserAcceptedTokens = () => {
+  return useQuery({
+    queryKey: ACCEPTED_TOKENS_KEY,
+    queryFn: getUserAcceptedTokens,
+    staleTime: 0,
+  });
+};
+
+export const useAddUserAcceptedToken = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: addUserAcceptedToken,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ACCEPTED_TOKENS_KEY }),
+  });
+};
+
+export const useRemoveUserAcceptedToken = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: removeUserAcceptedToken,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ACCEPTED_TOKENS_KEY }),
   });
 };


### PR DESCRIPTION
- Fixed duplicate useQueries import and duplicate balanceRateQueries in settle-debts-modal.tsx
  - Fixed AxiosResponse cast error in getUserAcceptedTokens / addUserAcceptedToken

  UI: Activity Pages
  - Removed red/green price colors from group activity tab → all amounts white
  - Removed red/green price colors from organization activity tab → all amounts white (including the missed INVOICE_RAISED cyan case)

  Splits Page (Group)
  - Hide Settle, Notify, Delete buttons and payment status from users not involved in a split
  - Restrict Notify button to payer only

  Settings: Accept Payments
  - Wired up "Accept Payments In" dropdown to GET/POST/DELETE /users/accepted-tokens API
  - Made dropdown single-select (mode="single")
  - Added Save button matching app button style (cyan background)
  - Fixed staleTime: 0 so tokens always load fresh on page mount
  - Fixed backend raw SQL column casing (t."logoUrl", sc."logoUrl") for PostgreSQL
  - Fixed $executeRaw → $queryRaw for INSERT/UPDATE with RETURNING *

  Organization Dashboard (Non-admin card)
  - Removed Streams stat for non-admin members
  - Replaced Invoices stat with Active Invoices (user's own raised invoices, not PAID/CLEARED/DECLINED)

  Organization Invoices
  - Removed DRAFT status badge from invoice rows
  - Moved DRAFT invoices to Active section (not History)
  - Admin can Clear invoices directly from Active and Awaiting Approval sections
  - Added Mark paid and Reject buttons for admin on all active invoices
  - Fixed shared loading spinner — now per-invoice (only clicked row shows spinner)
  - Updated backend to allow clearing and marking DRAFT/SENT/OVERDUE invoices as paid