### PR TITLE
fix(auth): derive session state from the API, not the cookie hint

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -91,9 +91,12 @@ export default function Page() {
     return <DashboardScreen kind={isResolvingWorkspace ? null : workspace.kind} />;
   }
 
-  // "loading" cannot reach here — AuthProvider holds the spinner for "/" whenever
-  // a session cookie exists — but if that ever changes, showing the create screen
-  // to a signed-in user is the wrong default, so wait rather than guess.
+  // "loading" IS reachable here, and normally so: "/" is public, so AuthProvider
+  // does not hold its own spinner for a visitor with no server-visible cookie —
+  // which, until AUTH_COOKIE_DOMAIN is set on the backend, is every visitor.
+  // We genuinely do not know yet which screen is right, and showing the guest
+  // console to a signed-in user is the failure this whole file exists to
+  // prevent, so wait for GET /api/users/me rather than guess.
   if (status === "loading") return <ScreenSpinner />;
 
   return <CreateRequestExperience />;

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -55,11 +55,23 @@ export function AuthProvider({
   // dashboard or the create screen.)
   const isRoot = pathname === "/";
   const isPublicPage = isPublicRoute(pathname); // includes "/"
-  // No session cookie => nobody to fetch. "/" used to fire GET /api/users/me
-  // for every anonymous visitor and 401, which is noise on a page that is
-  // no-account by design. /pay/* and /invite/* opt out entirely: they are
-  // chrome-free and render nothing that depends on who is looking.
-  const skipFetch = isAuthPage || (isPublicPage && !isRoot) || !hasSession;
+  // `hasSession` is a HINT, never the authority. It is the Next server looking
+  // for the session cookie on the app's OWN origin — and the cookie is set by
+  // the backend on a different host, so unless crossSubDomainCookies is enabled
+  // (backend/src/lib/auth.ts: only when AUTH_COOKIE_DOMAIN is set, which it is
+  // NOT in production today) the app origin never sees it and `hasSession` is
+  // false for EVERYONE, signed in or not.
+  //
+  // This used to read `|| !hasSession`, which skipped the fetch entirely and
+  // let the UI conclude "anonymous" without ever asking. Every signed-in user
+  // was therefore shown the guest console and could not get out of it: sign in,
+  // get bounced to "/", get told you are a guest, forever.
+  //
+  // Only GET /api/users/me can answer this, because only the browser sends that
+  // cookie cross-origin. So we always ask, on every route that renders anything
+  // identity-dependent. /pay/* and /invite/* still opt out: they are chrome-free
+  // and render the same thing for everyone.
+  const skipFetch = isAuthPage || (isPublicPage && !isRoot);
   const neverGate = isAuthPage || (isPublicPage && !hasSession);
   const { data: user, isPending, isError, error } = useGetUser({ enabled: !skipFetch });
   const posthog = usePostHog();
@@ -95,28 +107,32 @@ export function AuthProvider({
   // The one place that decides how much the UI is allowed to assume — see
   // contexts/session.tsx. `!user` has FOUR different meanings and the screens
   // below must not collapse them into "signed out".
-  const status: SessionStatus = !hasSession
-    ? // No cookie: there is nothing to wait for and nothing that can fail.
-      "anonymous"
+  // Derived from the ANSWER, not from the cookie hint. Ordering matters: the
+  // query result wins wherever we have one, and `hasSession` is consulted only
+  // on routes that deliberately never ask.
+  const status: SessionStatus = skipFetch
+    ? // This route opted out of the fetch (/login, /pay/*, /invite/*). Nothing
+      // here renders a locked or gated surface, so fall back to the cookie hint
+      // rather than reporting a "loading" that would never resolve — a disabled
+      // query stays `isPending` forever.
+      hasSession
+      ? "authenticated"
+      : "anonymous"
     : user
       ? "authenticated"
       : sessionRejected
-        ? // Cookie present but the server rejected it — same as having none.
+        ? // 401 — no session behind the request, whether or not a cookie was
+          // sent. This is the real "signed out", and the only thing that should
+          // ever produce a locked console.
           "anonymous"
         : isError
-          ? // A cookie exists and the fetch failed for some OTHER reason (500,
-            // network, backend restarting). Not a signed-out visitor — a
-            // signed-in one whose backend hiccuped. Telling them to sign in
-            // would be a lie, and a sticky one (staleTime 5min, no refetch on
-            // focus), so screens show an error with a way out instead.
+          ? // The fetch failed for some OTHER reason (500, network, backend
+            // restarting). Not a signed-out visitor — possibly a signed-in one
+            // whose backend hiccuped. Telling them to sign in would be a lie,
+            // and a sticky one (staleTime 5min, no refetch on focus), so screens
+            // show an error with a way out instead.
             "error"
-          : skipFetch
-            ? // Cookie present, but this route opted out of the fetch (/pay/*,
-              // /invite/*). Nothing there renders a locked or gated surface, so
-              // trust the cookie rather than reporting a "loading" that would
-              // never resolve — a disabled query stays `isPending` forever.
-              "authenticated"
-            : "loading";
+          : "loading";
 
   // `skipFetch` must be part of this test: react-query reports a DISABLED query
   // as `isPending` forever, so gating on `isPending` alone would hang a


### PR DESCRIPTION
## The bug

Signing in on app.splito.io drops you back on the guest request page, still signed out. Reported in production immediately after #25 shipped.

## Root cause

`hasSession` is the Next server looking for the session cookie **on the app's own origin**. The backend sets that cookie on a different host, and cross-subdomain sharing is only enabled when `AUTH_COOKIE_DOMAIN` is set:

```js
// backend/src/lib/auth.ts:47-55
...(process.env.NODE_ENV === "production" && env.AUTH_COOKIE_DOMAIN
  ? { crossSubDomainCookies: { enabled: true, domain: env.AUTH_COOKIE_DOMAIN } }
  : {}),
```

**That variable is not set in production** — confirmed by reading the live Secrets Manager store `splito/backend/env`, not a local `.env`. So `app.splito.io` never sees the cookie and `hasSession` is `false` for everyone, signed in or not.

That was survivable before #25: `hasSession` only suppressed a prefetch, and each screen fetched its own data cross-origin, where the browser *does* send the cookie. The API was the source of truth.

#25 made the entire UI gate on `hasSession`. A signed-in user resolves to `"anonymous"`, and because `skipFetch` also keyed off it, the app never asked the API — so it could never recover. Sign in, land on `/`, get told you're a guest, forever.

Related: the comment on `auth.ts:47` says the cookie is shared with "the **api.splito.io** backend". That host does not exist — the backend is `server.splito.io`. Likely why nobody noticed the variable was never set.

## The fix

- `skipFetch` no longer includes `|| !hasSession`. Every route rendering anything identity-dependent asks `GET /api/users/me`, because only the browser can send that cookie cross-origin.
- `status` is derived from the **answer**: `200` → authenticated, `401` → anonymous, other error → error, in flight → loading. `hasSession` is consulted only on routes that deliberately never ask (`/login`, `/pay/*`, `/invite/*`).

`hasSession` is now a hint, never the authority. The 401→anonymous and error-vs-anonymous distinctions from #25 are preserved.

## Cost

Anonymous visitors get a brief spinner on `/` while that one call resolves — `/` is public so AuthProvider doesn't hold its own gate, and the page waits rather than guessing. Setting `AUTH_COOKIE_DOMAIN=.splito.io` on the backend makes the hint truthful again and removes the spinner; worth doing separately.

## Verified

- `npx tsc --noEmit` clean
- `pnpm build` passes, all routes generated

**Not verified: the signed-in path.** I have no credentials for a production account, so I could not click through a real login. Please open this PR's Vercel preview deployment and sign in there before merging — that exercises the exact failure end to end.