### PR TITLE
fix(settings): surface settlement preference save/update errors

### DIFF
--- a/api-helpers/client.ts
+++ b/api-helpers/client.ts
@@ -82,7 +82,16 @@ apiClient.interceptors.response.use(
       data: error.response?.data,
       name: error.response?.data?.name || "ApiError",
     };
-    console.log("error", normalizedError);
+    // Diagnostic only, and deliberately console.log rather than console.error:
+    // per the comment below, a 401 here is the EXPECTED answer for an anonymous
+    // visitor browsing the logged-out console, and Next dev echoes console.error
+    // to the server terminal with a code frame — which would render normal
+    // behaviour as a crash on every page load.
+    //
+    // This is NOT a user-facing surface. Every caller that can fail visibly must
+    // handle the rejection itself (a mutation `onError`, a try/catch); a line in
+    // the console is not "handled".
+    console.log("[api] request failed", normalizedError);
     // Handle 401 (Unauthorized) responses - this is the only place we redirect.
     //
     // Two things produce a 401 and they mean opposite things:

--- a/features/user/hooks/use-update-profile.ts
+++ b/features/user/hooks/use-update-profile.ts
@@ -85,6 +85,18 @@ export const useGetUserSettlementPreference = (userId: string | null) => {
   });
 };
 
+/**
+ * `onError` is load-bearing, not decoration. The settings modal closes itself in
+ * its own `onSuccess` callback, so a failed save left the modal open with the
+ * button snapping back from "Saving…" to "Save preference" and NOTHING else —
+ * the rejection was normalized to an ApiError by the axios interceptor and then
+ * only console.log'd. The user saw a no-op.
+ *
+ * `error.message` is already the server's message (api-helpers/client.ts derives
+ * it from body.details ?? body.error ?? body.message), so this surfaces
+ * "Invalid wallet address for Stellar" rather than a generic string. Do NOT
+ * close the modal here — the input is still on screen for the user to correct.
+ */
 export const useSaveSettlementPreference = () => {
   const queryClient = useQueryClient();
   return useMutation({
@@ -93,6 +105,11 @@ export const useSaveSettlementPreference = () => {
       queryClient.invalidateQueries({ queryKey: SETTLEMENT_PREF_KEY });
       queryClient.invalidateQueries({ queryKey: ACCEPTED_TOKENS_KEY });
       queryClient.invalidateQueries({ queryKey: [WALLET_QUERY_KEYS.WALLETS] });
+    },
+    onError: (error) => {
+      toast.error("Error saving settlement preference", {
+        description: error.message || "Unknown error",
+      });
     },
   });
 };
@@ -115,6 +132,14 @@ export const useUpdateSettlementWallet = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: SETTLEMENT_PREF_KEY });
       queryClient.invalidateQueries({ queryKey: [WALLET_QUERY_KEYS.WALLETS] });
+    },
+    // Same modal, same silent-failure shape as useSaveSettlementPreference above
+    // — the "edit wallet" mode of SettlementPrefModal hits this path and hit the
+    // same server-side address validation.
+    onError: (error) => {
+      toast.error("Error updating wallet address", {
+        description: error.message || "Unknown error",
+      });
     },
   });
 };


### PR DESCRIPTION
Companion to backend PR https://github.com/Splitoio/backend/pull/34 — **that backend PR merges first.** It fixes `validateAddress` rejecting valid-but-unfunded Stellar addresses; this PR makes sure a failure like that (or any other) is no longer silent in the UI.

## The bug

`setPrefModalOpen(false)` lives only inside `onSuccess`. Neither the call site (`app/settings/settings-page-content.tsx`) nor the mutation config had an `onError`. So any failure settled the mutation silently: the button flipped back from "Saving..." to idle, no toast fired, the modal stayed open, nothing persisted — and there was no indication anything had gone wrong.

## The fix

- `features/user/hooks/use-update-profile.ts` — added `onError` to `useSaveSettlementPreference`, following the `useUpdateUser` convention already in this file: `toast.error(title, { description: error.message || "Unknown error" })`. Added the same `onError` to `useUpdateSettlementWallet` — same modal (edit-wallet mode), same silent-failure shape.
- `api-helpers/client.ts` — relabelled the interceptor's diagnostic log, deliberately keeping it `console.log` rather than `console.error`. I tried upgrading it to `console.error` and reverted: an anonymous 401 here is the *expected* answer for a logged-out visitor, but Next 16 echoes browser `console.error` to the server terminal with a code frame, so every expected anonymous 401 rendered as a fake crash on page load. Left a comment recording why.

## Verification (running app)

- Save now returns 200, modal closes, toast fires, and the preference survives a page reload — a fresh `/settings` shows "USDC on Stellar Testnet / GCWHWZ7L…JPPFSY".
- Error path: a bogus address gives 400 with a visible toast reading the server's message verbatim; modal stays open with the input intact.
- `tsc --noEmit` clean.