### PR TITLE
feat(treasury): read-only Expenses section and Net hero for Treasury Log

### DIFF
--- a/app/treasury/page.tsx
+++ b/app/treasury/page.tsx
@@ -5,11 +5,12 @@ import { Loader2 } from "lucide-react";
 import { useActiveWorkspace, useIsResolvingWorkspace } from "@/contexts/workspace";
 import { BusinessOnly, WorkspaceResolving } from "@/components/shell/business-only";
 import { useGetStreamsByOrganization } from "@/features/business/hooks/use-streams";
+import { useGetExpensesByOrganization } from "@/features/business/hooks/use-org-expenses";
 import { useWorkspaceTreasury } from "@/features/workspaces/hooks/use-workspace-summary";
 import { formatCurrency } from "@/utils/formatters";
 import { LogIncomeModal } from "@/components/log-income-modal";
 import { Row } from "@/components/shell/row";
-import { Card, HeroCard, Eyebrow, Btn, Icons, T, TYPE, getUserColor, G as G_ACCENT } from "@/lib/splito-design";
+import { Card, HeroCard, Eyebrow, Btn, Icons, T, TYPE, getUserColor, G as G_ACCENT, R } from "@/lib/splito-design";
 import { GatedScreen } from "@/components/shell/locked-feature";
 
 /** "Received 1 Aug" — the trailing date on a stream row (design line 1229). */
@@ -17,13 +18,21 @@ function formatReceivedDate(date: Date): string {
   return `Received ${date.toLocaleDateString("en-GB", { day: "numeric", month: "short" })}`;
 }
 
+/** "Spent 1 Aug" — the trailing date on an expense row. */
+function formatSpentDate(date: Date): string {
+  return `Spent ${date.toLocaleDateString("en-GB", { day: "numeric", month: "short" })}`;
+}
+
 /**
- * Treasury (design 1208–1234, `isTreasury`): the hero "Received" total plus the
- * income-stream list, business workspaces only. Data comes from the same
- * income-stream endpoints the legacy `/organization/[id]` layout used
- * (features/business/hooks/use-streams.ts, `/api/organizations/:id/streams`) — the
- * hero total instead reads `workspaces/:id/summary`'s `treasury` field so it
- * always agrees with the dashboard rather than being summed here separately.
+ * Treasury Log (design 1208–1234, `isTreasury`): the hero net total plus the
+ * income-stream and expense lists, business workspaces only. Both halves are
+ * organization-scoped and symmetric: `/api/organizations/:id/streams` and
+ * `/api/organizations/:id/expenses`. The expense list is deliberately
+ * READ-ONLY — logging an outgoing is not a Treasury Log action.
+ *
+ * The hero reads both totals off `workspaces/:id/summary`'s `treasury` field
+ * rather than summing the rendered lists, so it always agrees with the
+ * dashboard and stays correct if either list ever paginates.
  */
 function TreasuryScreen() {
   const workspace = useActiveWorkspace();
@@ -41,19 +50,30 @@ function TreasuryScreen() {
     isLoading: treasuryLoading,
     isError: treasuryError,
   } = useWorkspaceTreasury(workspace.id, { enabled: isBusiness });
+  const {
+    data: expenses,
+    isLoading: expensesLoading,
+    isError: expensesError,
+  } = useGetExpensesByOrganization(workspace.id, { enabled: isBusiness });
 
   if (isResolving) return <WorkspaceResolving />;
 
   if (!isBusiness) {
     return (
       <BusinessOnly
-        screen="Treasury"
+        screen="Treasury Log"
         blurb="Income streams are logged against a business, not a personal account."
       />
     );
   }
 
   const streamCount = treasury?.streamCount ?? streams?.length ?? 0;
+  // Both halves come from the summary, so a failed expense LIST fetch no
+  // longer makes the expense total unknown — the old client-side sum had to
+  // fall back to income-only because an errored list silently read as a
+  // confident 0. `?? 0` here is only the treasury-not-loaded case, which the
+  // `treasuryError` branch below renders as "—" rather than a number.
+  const netTotal = (treasury?.streamsTotal ?? 0) - (treasury?.expensesTotal ?? 0);
 
   return (
     <div className="fade-up p-4 lg:p-0" style={{ maxWidth: 1000 }}>
@@ -74,14 +94,14 @@ function TreasuryScreen() {
           }}
         />
         <div style={{ position: "relative", maxWidth: 420 }}>
-          <Eyebrow>Received</Eyebrow>
+          <Eyebrow>Net</Eyebrow>
           {treasuryLoading ? (
             <div style={{ margin: "10px 0 5px" }}>
               <Loader2 className="h-6 w-6 animate-spin" style={{ color: T.muted }} />
             </div>
           ) : (
             <p style={{ margin: "8px 0 5px", color: T.white, lineHeight: 1, ...TYPE.hero }}>
-              {treasuryError ? "—" : formatCurrency(treasury?.streamsTotal ?? 0, treasury?.currency ?? "USD")}
+              {treasuryError ? "—" : formatCurrency(netTotal, treasury?.currency ?? "USD")}
             </p>
           )}
           <p style={{ margin: 0, fontSize: 12.5, color: T.sub }}>
@@ -160,6 +180,63 @@ function TreasuryScreen() {
         onClose={() => setIsLogIncomeOpen(false)}
         organizationId={workspace.id}
       />
+
+      <div className="flex items-center gap-2.5" style={{ marginTop: 26, marginBottom: 12 }}>
+        <Eyebrow color={T.soft}>Expenses</Eyebrow>
+      </div>
+
+      <Card style={{ padding: 0 }}>
+        {expensesLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-5 w-5 animate-spin" style={{ color: T.muted }} />
+          </div>
+        ) : expensesError ? (
+          <div style={{ padding: "56px 22px", textAlign: "center" }}>
+            <p style={{ fontSize: 13.5, fontWeight: 700, color: T.bright, margin: 0 }}>
+              Couldn&apos;t load your expenses
+            </p>
+          </div>
+        ) : !expenses || expenses.length === 0 ? (
+          <div style={{ padding: "56px 22px", textAlign: "center" }}>
+            <p style={{ fontSize: 13.5, fontWeight: 700, color: T.bright, margin: 0 }}>
+              Nothing logged yet
+            </p>
+            <p style={{ fontSize: 12, color: T.sub, margin: "6px 0 0" }}>
+              Expenses logged against this business will show up here.
+            </p>
+          </div>
+        ) : (
+          expenses.map((expense, i) => (
+            <Row
+              key={expense.id}
+              noDivider={i === expenses.length - 1}
+              leading={
+                <span
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    flexShrink: 0,
+                    background: getUserColor(expense.name),
+                  }}
+                />
+              }
+              title={expense.name}
+              meta={expense.description || undefined}
+              trailing={
+                <div className="flex items-center" style={{ gap: 14 }}>
+                  <span style={{ ...TYPE.rowAmount, color: R }}>
+                    −{formatCurrency(expense.amount, expense.currency)}
+                  </span>
+                  <span style={{ fontSize: 11.5, fontWeight: 600, color: T.dim, width: 96, textAlign: "right" }}>
+                    {formatSpentDate(new Date(expense.spentDate))}
+                  </span>
+                </div>
+              }
+            />
+          ))
+        )}
+      </Card>
     </div>
   );
 }
@@ -176,7 +253,7 @@ function TreasuryScreen() {
 export default function TreasuryPage() {
   return (
     <GatedScreen
-      title="Treasury"
+      title="Treasury Log"
       reason="Sign in to see your treasury"
       blurb="What has come in, where it came from, and what it settled into."
     >

--- a/components/dashboard/business-dashboard.tsx
+++ b/components/dashboard/business-dashboard.tsx
@@ -112,7 +112,7 @@ function OrgDashboard({ summary, streams }: { summary: WorkspaceSummary; streams
                 color: T.muted,
               }}
             >
-              Open treasury
+              Open treasury log
             </Link>
           </div>
           {allocation.length > 0 && (

--- a/components/log-income-modal.tsx
+++ b/components/log-income-modal.tsx
@@ -13,7 +13,7 @@ import { A, T, Btn, RADIUS, SHADOW, HERO_SURFACE, BORDER } from "@/lib/splito-de
  * "Log income received" — the create half of the treasury income-stream flow
  * (design 1218, `.abtn` "Log income"). Edit/delete live on the legacy
  * `/organization/[id]` layout for now; this is scoped to the create action
- * the Treasury screen exposes.
+ * the Treasury Log screen exposes.
  */
 export function LogIncomeModal({
   isOpen,

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -38,7 +38,7 @@ const SHORT_LABEL: Record<string, string> = {
   "/groups": "Groups",
   "/people": "People",
   "/members": "Members",
-  "/treasury": "Treasury",
+  "/treasury": "Treasury Log",
   "/settings": "Settings",
 };
 

--- a/components/shell/business-only.tsx
+++ b/components/shell/business-only.tsx
@@ -5,7 +5,7 @@ import { Eyebrow, T, card } from "@/lib/splito-design";
 
 /**
  * The shared empty state for the three org-only screens — Approvals, Members,
- * Treasury (.design/INDEX.md §5). They are absent from `NAV_PERSONAL`
+ * Treasury Log (.design/INDEX.md §5). They are absent from `NAV_PERSONAL`
  * (lib/shell-nav.ts) but are still real top-level routes, so a personal
  * workspace can reach them by typed URL and must land on this instead of the
  * real screen.

--- a/features/business/api/client.ts
+++ b/features/business/api/client.ts
@@ -144,6 +144,24 @@ export const IncomeStreamSchema = z.object({
 });
 export type IncomeStream = z.infer<typeof IncomeStreamSchema>;
 
+/**
+ * A treasury outgoing, the mirror of `IncomeStream`. NOT the group-scoped
+ * `Expense` in features/expenses — that one belongs to bill-splitting and
+ * carries participants and shares.
+ */
+export const OrganizationExpenseSchema = z.object({
+  id: z.string(),
+  organizationId: z.string(),
+  name: z.string(),
+  currency: z.string(),
+  amount: z.number(),
+  description: z.string().nullable(),
+  spentDate: z.coerce.date(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+export type OrganizationExpense = z.infer<typeof OrganizationExpenseSchema>;
+
 export type Invoice = z.infer<typeof InvoiceSchema>;
 
 export const getAllOrganizations = async () => {
@@ -392,6 +410,33 @@ export const updateStream = async (
 
 export const deleteStream = async (organizationId: string, streamId: string) => {
   await apiClient.delete(`/organizations/${organizationId}/streams/${streamId}`);
+};
+
+// Treasury outgoings (admin only) — the mirror of the stream calls above.
+export const getExpensesByOrganization = async (organizationId: string) => {
+  const response = await apiClient.get(`/organizations/${organizationId}/expenses`);
+  return OrganizationExpenseSchema.array().parse(response);
+};
+
+export const createOrganizationExpense = async (
+  organizationId: string,
+  payload: { name: string; currency?: string; amount: number; description?: string | null; spentDate?: string }
+) => {
+  const response = await apiClient.post(`/organizations/${organizationId}/expenses`, payload);
+  return OrganizationExpenseSchema.parse(response);
+};
+
+export const updateOrganizationExpense = async (
+  organizationId: string,
+  expenseId: string,
+  payload: { name?: string; currency?: string; amount?: number; description?: string | null; spentDate?: string }
+) => {
+  const response = await apiClient.put(`/organizations/${organizationId}/expenses/${expenseId}`, payload);
+  return OrganizationExpenseSchema.parse(response);
+};
+
+export const deleteOrganizationExpense = async (organizationId: string, expenseId: string) => {
+  await apiClient.delete(`/organizations/${organizationId}/expenses/${expenseId}`);
 };
 
 // Contracts

--- a/features/business/hooks/use-org-expenses.ts
+++ b/features/business/hooks/use-org-expenses.ts
@@ -1,0 +1,75 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getExpensesByOrganization,
+  createOrganizationExpense,
+  updateOrganizationExpense,
+  deleteOrganizationExpense,
+} from "../api/client";
+import { QueryKeys } from "@/lib/constants";
+
+/**
+ * Treasury outgoings for a business workspace — the mirror of use-streams.ts.
+ * Not to be confused with `useGetExpenses` in features/expenses, which reads
+ * the group-scoped bill-splitting list off `/groups/:id/expenses`.
+ */
+export const useGetExpensesByOrganization = (
+  organizationId: string,
+  options?: { enabled?: boolean }
+) => {
+  return useQuery({
+    queryKey: [QueryKeys.ORGANIZATION_EXPENSES, organizationId],
+    queryFn: () => getExpensesByOrganization(organizationId),
+    enabled: !!organizationId && (options?.enabled !== false),
+  });
+};
+
+export const useCreateOrganizationExpense = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      organizationId,
+      payload,
+    }: {
+      organizationId: string;
+      payload: Parameters<typeof createOrganizationExpense>[1];
+    }) => createOrganizationExpense(organizationId, payload),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.ORGANIZATION_EXPENSES, variables.organizationId],
+      });
+    },
+  });
+};
+
+export const useUpdateOrganizationExpense = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      organizationId,
+      expenseId,
+      payload,
+    }: {
+      organizationId: string;
+      expenseId: string;
+      payload: Parameters<typeof updateOrganizationExpense>[2];
+    }) => updateOrganizationExpense(organizationId, expenseId, payload),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.ORGANIZATION_EXPENSES, variables.organizationId],
+      });
+    },
+  });
+};
+
+export const useDeleteOrganizationExpense = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ organizationId, expenseId }: { organizationId: string; expenseId: string }) =>
+      deleteOrganizationExpense(organizationId, expenseId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.ORGANIZATION_EXPENSES, variables.organizationId],
+      });
+    },
+  });
+};

--- a/features/workspaces/api/client.ts
+++ b/features/workspaces/api/client.ts
@@ -97,6 +97,8 @@ export const WorkspaceSummarySchema = z.object({
   treasury: z.object({
     streamsTotal: z.number(),
     streamCount: z.number().int().nonnegative(),
+    expensesTotal: z.number(),
+    expenseCount: z.number().int().nonnegative(),
     currency: z.string(),
   }),
   recentActivity: z.array(

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,6 +16,10 @@ export const QueryKeys = {
   INVOICES: "invoices",
   ORGANIZATION_ACTIVITY: "organization-activity",
   STREAMS: "streams",
+  // Org treasury outgoings. Distinct from EXPENSES, which is the group-scoped
+  // bill-splitting list — sharing a key would cross-invalidate two unrelated
+  // resources.
+  ORGANIZATION_EXPENSES: "organization-expenses",
   CONTRACTS: "contracts",
   WORKSPACE_SUMMARY: "workspace-summary",
 } as const;

--- a/lib/shell-nav.ts
+++ b/lib/shell-nav.ts
@@ -59,7 +59,7 @@ const BUSINESS_NAV: NavGroup[] = [
     label: "Business",
     items: [
       { href: "/members", label: "Members", dot: B },
-      { href: "/treasury", label: "Treasury", dot: P },
+      { href: "/treasury", label: "Treasury Log", dot: P },
     ],
   },
   {
@@ -123,7 +123,7 @@ const BUSINESS_META: Record<string, MetaFactory> = {
   "/approvals": () => ({ title: "Needs approval", subtitle: "Waiting on you before it can be paid" }),
   "/create": () => ({ title: "New request", subtitle: "Bill a client, or pay someone out" }),
   "/members": () => ({ title: "Members", subtitle: "Who's here, and on what terms" }),
-  "/treasury": () => ({ title: "Treasury", subtitle: "What's come in, and where it came from" }),
+  "/treasury": () => ({ title: "Treasury Log", subtitle: "What's come in, what's gone out, and where it stands" }),
   "/settings": () => ({ title: "Settings", subtitle: "Workspace settings and defaults" }),
 };
 


### PR DESCRIPTION
## Why

Companion to Splitoio/backend#35, which restores `OrganizationExpense` after commit `c95847f` split business workspaces off `Group` and left expenses behind on the old model — the Treasury page's expense fetch was 404ing for every business workspace.

**Backend PR merges first: Splitoio/backend#35.**

## What

- `/treasury` is now "Treasury Log": Net hero (income − expenses, using the server-side `treasury.expensesTotal`), the existing Income section unchanged, and a new **read-only** Expenses section below it — no log button, no modal, a deliberate product decision.
- New `features/business/hooks/use-org-expenses.ts` + `OrganizationExpenseSchema` and four client functions in `features/business/api/client.ts`, mirroring the stream equivalents. Its own `ORGANIZATION_EXPENSES` query key so it can't cross-invalidate the bill-splitting `EXPENSES` key.
- Label rename "Treasury" → "Treasury Log" in `lib/shell-nav.ts` (nav label + topbar title + subtitle), `components/mobile-nav.tsx` (`SHORT_LABEL`), `app/treasury/page.tsx` (`BusinessOnly screen=`), and `components/dashboard/business-dashboard.tsx` ("Open treasury log"). Routes, hrefs, the `lib/workspace.ts` redirect table, and icon-map keys are all unchanged. `"Treasury balance"` on the dashboard was deliberately left alone as a metric label.

## Verification

Verified in the running app:
- `GET /organizations/:id/expenses` returns 200 where it previously 404'd.
- Net arithmetic confirmed against real data (5000 − 1664.50 → hero rendered $3,335.50).
- Labels render without truncation in sidebar, topbar, and mobile nav at 375px.
- `tsc --noEmit` clean in both repos.

Not verified: the expenses **error** state was never forced, so that branch is unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxsYSH8yNJxsjKgzvtZQGY
