### PR TITLE
fix(create): prefill the receive address from the user's saved wallet

### DIFF
--- a/components/create/create-request-experience.tsx
+++ b/components/create/create-request-experience.tsx
@@ -36,7 +36,7 @@
 // contract linking, approval) are rendered as visibly gated/disabled rather
 // than wired to fake data — see comments below.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
 import { useQuery } from "@tanstack/react-query";
@@ -45,7 +45,7 @@ import { useWallet } from "@/hooks/useWallet";
 import { useAuthStore } from "@/stores/authStore";
 import { useIsLocked } from "@/contexts/session";
 import { LockedFeature, LockedButton } from "@/components/shell/locked-feature";
-import { useGetSettlementPreference } from "@/features/user/hooks/use-update-profile";
+import { useUserWallets } from "@/features/wallets/hooks/use-wallets";
 import { useActiveWorkspace } from "@/contexts/workspace";
 import { PERSONAL_WORKSPACE_ID } from "@/lib/workspace";
 import { formatCurrency } from "@/utils/formatters";
@@ -205,12 +205,22 @@ function CreateForm({
   //                      signed out; a failed /users/me must never say it)
   const isLocked = useIsLocked();
   const { isConnected, address, walletType } = useWallet();
-  // Only tells the user whether Settings has an address on file for the
-  // selected chain — this form has never prefilled from it (only from a
-  // connected wallet, see canPrefillWallet below), and this doesn't add that.
-  // Gated: an anonymous visitor has no settlement preferences and the request
-  // would 401 for nothing.
-  const { data: settlementPrefs = [] } = useGetSettlementPreference({ enabled: isAuthenticated });
+  // The saved wallets from Settings → Wallets, and the source of truth for
+  // "do I have an address on file for this chain?".
+  //
+  // This used to ask GET /users/settlement-preference instead, which was wrong:
+  // that endpoint returns [] whenever the user has no UserAcceptedToken rows,
+  // *even when a ChainAccount exists* (user.controller.ts, the
+  // `acceptedTokens.length === 0` early return). A wallet added through
+  // Settings → Wallets / "Connect a wallet" writes a ChainAccount and no
+  // accepted-token row, so a user with a perfectly good Stellar address was
+  // told "No Stellar address on file". The wallet list is a strict superset —
+  // saveSettlementPreference writes a ChainAccount too — so reading it here
+  // makes Settings and this form agree by construction.
+  //
+  // Gated: an anonymous visitor has no wallets and getUserWallets toasts on a
+  // 401, so the request must not fire signed out.
+  const { data: walletData } = useUserWallets({ enabled: isAuthenticated });
 
   const [kind, setKind] = useState<Kind>("request"); // "request" is the landing state — split is never the default
   const [amount, setAmount] = useState("");
@@ -285,9 +295,30 @@ function CreateForm({
 
   const canPrefillWallet =
     dest.chain === "stellar" && walletType === "stellar" && isConnected && !!address;
-  const hasSettlementAddress = settlementPrefs.some(
-    (p) => p.chainId === dest.chain && !!p.wallet?.address
+
+  // "The default wallet for this chain, else the only wallet for this chain."
+  // Deliberately not "the default, full stop": a wallet added through Settings →
+  // Wallets is created with isDefault false (see addUserChainAccountController),
+  // so a user with exactly one Stellar address would otherwise have no usable
+  // receive address at all. With several wallets and none flagged default we
+  // stay out of it rather than guess — the helper text then points at Settings.
+  const chainWallets = (walletData?.accounts ?? []).filter(
+    (w) => w.chainId === dest.chain && !!w.address
   );
+  const savedAddress =
+    chainWallets.find((w) => w.isDefault)?.address ??
+    (chainWallets.length === 1 ? chainWallets[0].address : undefined);
+  const hasSettlementAddress = chainWallets.length > 0;
+
+  // Prefill the receive field from the saved wallet, but never fight the user:
+  // once the field has been edited by hand it is theirs, and re-selecting a
+  // chain won't clobber it. Clearing the field by hand counts as an edit, so
+  // this does not immediately refill it.
+  const [addressTouched, setAddressTouched] = useState(false);
+  useEffect(() => {
+    if (addressTouched) return;
+    setDestinationAddress(savedAddress ?? "");
+  }, [savedAddress, addressTouched]);
 
   // The design's "Bills against a contract" block, gated to business
   // workspaces. There is no contract-linking API for Requests yet (the
@@ -838,6 +869,8 @@ function CreateForm({
               // Editing the address is the user acting on the error, so retire it.
               onChange={(e) => {
                 setDestinationAddress(e.target.value);
+                // The field is the user's from here on — stop prefilling into it.
+                setAddressTouched(true);
                 if (addressRejected) setSubmitError(null);
               }}
               placeholder={dest.chain === "stellar" ? "G..." : "Solana wallet address"}
@@ -878,7 +911,12 @@ function CreateForm({
         {canPrefillWallet && address !== destinationAddress && (
           <button
             type="button"
-            onClick={() => setDestinationAddress(address ?? "")}
+            onClick={() => {
+              setDestinationAddress(address ?? "");
+              // An explicit choice of address, same as typing one — the saved
+              // wallet must not overwrite it on the next render.
+              setAddressTouched(true);
+            }}
             className="text-[12px] font-semibold -mt-3 mb-5 block"
             style={{ color: A }}
           >

--- a/features/wallets/hooks/use-wallets.ts
+++ b/features/wallets/hooks/use-wallets.ts
@@ -17,11 +17,15 @@ export const WALLET_QUERY_KEYS = {
   CHAINS: "chains",
 };
 
-// Hook to fetch all user's wallets
-export const useUserWallets = () => {
+// Hook to fetch all user's wallets.
+// `enabled` is opt-out gating for callers that render signed out: getUserWallets
+// toasts on failure, so an unauthenticated fetch would 401 and surface a bogus
+// "Failed to fetch wallet accounts" toast. Defaults to on for existing callers.
+export const useUserWallets = (options?: { enabled?: boolean }) => {
   return useQuery<{ accounts: Wallet[] }>({
     queryKey: [WALLET_QUERY_KEYS.WALLETS],
     queryFn: getUserWallets,
+    enabled: options?.enabled ?? true,
     staleTime: 1000 * 60 * 5, // 5 minutes
     select: (data) => {
       // Handle cases where the API returns an object with accounts array


### PR DESCRIPTION
## The bug

Reported by the owner: Settings → Wallets clearly showed a saved Stellar wallet (`GBYBRO4V…QWRMGV`), but the create-request page's "STELLAR ADDRESS TO RECEIVE AT" field was empty and read **"No Stellar address on file — add one in Settings, or type it in above."**

## Root cause — the wrong data source, not a flag

Proved against the live API, same user, same moment:

```
GET /api/multichain/accounts         -> the Stellar wallet, "isDefault": false
GET /api/users/settlement-preference -> []
```

`getSettlementPreference` (`backend/src/controllers/user.controller.ts:520-528`) reads `userAcceptedToken` **first** and early-returns `[]` when there are none — even when a `ChainAccount` exists. Wallets added via Settings → Wallets go through `addUserChainAccountController`, which writes a `ChainAccount` and **no** accepted-token row. So the wallet was invisible to the endpoint this page was asking.

Settings reads `useUserWallets` → `GET /api/multichain/accounts`, which is why it displayed the wallet fine.

Two hypotheses that turned out **not** to be the cause, recorded so nobody re-investigates them:
- **`isDefault: false`** — true of the row, but `getSettlementPreference` uses `findFirst` with no `isDefault` filter, so the flag alone did not hide it.
- **Chain-id mismatch** — killed. Stored `chainId` is exactly `stellar`; the page compares `"stellar"`. "Stellar Testnet" is only `SupportedChain.name`.

Separately: the form never prefilled from Settings at all, only from a connected web3 wallet.

## Changes

- Read the wallet list instead of the settlement preference; resolve as **default for the chain, else the only wallet for the chain**. No mutation of user data to force a default.
- Prefill via effect, guarded by an `addressTouched` flag so a typed address is never clobbered.
- `features/wallets/hooks/use-wallets.ts` — optional `enabled` (defaults true) so a signed-out page doesn't 401-and-toast. Additive only.

## Verified in the running app — 5/5

| # | Scenario | Result |
|---|---|---|
| 1 | Sole wallet, `isDefault=false` (the reported bug) | Prefills, helper text gone |
| 2 | Wallet flagged default | Prefills |
| 3 | Two wallets, one default | The **default** prefills |
| 4 | No wallet | Helper text shows, manual typing works |
| 5 | Create with prefilled address | Live link; DB stores the prefilled address |

Scenario 5 needed a funded testnet account and settled in XLM — USDC requires a trustline, which is a real backend check, not a bug.

`pnpm exec tsc --noEmit` clean.

## Depends on

**[Splitoio/backend#36](https://github.com/Splitoio/backend/pull/36) — already merged.**

## Known, not fixed here

`getSettlementPreference`'s early return still hides wallets from everything else reading it — `components/settle-debts-modal.tsx:105` and `app/groups/[id]/layout.tsx:47` consume that endpoint and may have the same blind spot. Untested, filed separately rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxsYSH8yNJxsjKgzvtZQGY