### PR TITLE
feat: surface pending org invites in-app via /notifications

### DIFF
--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  useAcceptInvite,
+  useDeclineInvite,
+  useMyInvites,
+} from "@/features/business/hooks/use-invites";
+import type { MyInvite } from "@/features/business/api/client";
+import { A, Btn, Card, Eyebrow, T, avatarChip, initialsFrom } from "@/lib/splito-design";
+import { Row } from "@/components/shell/row";
+import { formatRelativeTime } from "@/lib/utils";
+import { GatedScreen } from "@/components/shell/locked-feature";
+
+/**
+ * `/notifications` — the in-app surface for org invitations. Before this
+ * route existed, the emailed `/invite/<token>` link was the ONLY way in; the
+ * topbar bell (components/topbar.tsx) and the sidebar's Notifications item
+ * (lib/shell-nav.ts) both point here, badged off the same `useMyInvites()`
+ * cache this page reads.
+ *
+ * Accept reuses the same `useAcceptInvite()` mutation `/invite/[token]` uses
+ * — one membership-creating code path. Reject is invitee-scoped
+ * (`POST /invites/:id/decline`), distinct from the admin-only revoke on the
+ * Members screen (`useRevokeInvite`).
+ */
+
+const ROLE_LABEL: Record<string, string> = { OWNER: "Owner", ADMIN: "Admin", MEMBER: "Member" };
+
+function errMsg(e: unknown, fallback: string): string {
+  const m = (e as { message?: string } | null)?.message;
+  return typeof m === "string" && m.trim() ? m : fallback;
+}
+
+function InviteRow({ invite, noDivider }: { invite: MyInvite; noDivider: boolean }) {
+  // A dedicated mutation instance per row, not one shared across the list —
+  // `isPending` is then scoped to THIS invite for free, with no need to check
+  // "is the in-flight mutation's argument this row's id" the way the shared
+  // accept/decline modal on the Members screen has to.
+  const accept = useAcceptInvite();
+  const decline = useDeclineInvite();
+  const busy = accept.isPending || decline.isPending;
+  const inviter = invite.invitedByName ?? invite.invitedByEmail ?? "Someone";
+
+  return (
+    <Row
+      noDivider={noDivider}
+      leading={<span style={avatarChip(A, 38, 13)}>{initialsFrom(invite.organizationName)}</span>}
+      title={invite.organizationName}
+      meta={`${ROLE_LABEL[invite.role] ?? invite.role} · Invited by ${inviter} · ${formatRelativeTime(invite.createdAt)}`}
+      trailing={
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/invite/${encodeURIComponent(invite.token)}`}
+            style={{ fontSize: 12, fontWeight: 700, color: T.soft }}
+          >
+            View
+          </Link>
+          <Btn
+            variant="ghost"
+            disabled={busy}
+            onClick={() =>
+              decline.mutate(invite.id, {
+                onSuccess: () => toast.success(`Declined the invite to ${invite.organizationName}`),
+                onError: (err) => toast.error(errMsg(err, "Couldn't decline that invite")),
+              })
+            }
+          >
+            {decline.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Reject"}
+          </Btn>
+          <Btn
+            variant="primary"
+            disabled={busy}
+            onClick={() =>
+              accept.mutate(invite.token, {
+                onSuccess: (result) =>
+                  toast.success(
+                    result.alreadyMember
+                      ? `You're already in ${result.organizationName}`
+                      : `Welcome to ${result.organizationName}`
+                  ),
+                onError: (err) => toast.error(errMsg(err, "Couldn't accept that invite")),
+              })
+            }
+          >
+            {accept.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Accept"}
+          </Btn>
+        </div>
+      }
+    />
+  );
+}
+
+function NotificationsScreen() {
+  const { data: invites, isPending, isError, refetch } = useMyInvites();
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 sm:p-7">
+      <Eyebrow color={T.soft}>Pending invites</Eyebrow>
+      <Card style={{ padding: 0, marginTop: 12 }}>
+        {isPending ? (
+          <div className="flex items-center justify-center" style={{ padding: "32px 20px" }}>
+            <Loader2 className="h-5 w-5 animate-spin" style={{ color: T.muted }} />
+          </div>
+        ) : isError ? (
+          <div style={{ padding: "24px 20px", textAlign: "center" }}>
+            <p style={{ fontSize: 13, color: T.muted, margin: 0 }}>Couldn&apos;t load your invites.</p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              style={{
+                marginTop: 10,
+                fontSize: 12,
+                fontWeight: 700,
+                color: A,
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        ) : invites.length === 0 ? (
+          <p style={{ padding: "24px 20px", fontSize: 13, color: T.muted, textAlign: "center", margin: 0 }}>
+            No pending invitations right now.
+          </p>
+        ) : (
+          invites.map((invite, i) => (
+            <InviteRow key={invite.id} invite={invite} noDivider={i === invites.length - 1} />
+          ))
+        )}
+      </Card>
+    </div>
+  );
+}
+
+export default function NotificationsPage() {
+  return (
+    <GatedScreen
+      title="Notifications"
+      reason="Sign in to see your invitations"
+      blurb="Organization invites addressed to you land here."
+    >
+      <NotificationsScreen />
+    </GatedScreen>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -28,6 +28,7 @@ import { LockedFeature } from "@/components/shell/locked-feature";
 import { useIsLocked, useSessionStatus } from "@/contexts/session";
 import { useMobileMenu } from "@/contexts/mobile-menu";
 import { useAuthStore } from "@/stores/authStore";
+import { useMyInvites } from "@/features/business/hooks/use-invites";
 import {
   useActiveWorkspace,
   useSetActiveWorkspace,
@@ -107,7 +108,7 @@ function WorkspaceSwitcherButton({
 export function Sidebar() {
   const pathname = usePathname();
   const { isOpen, close } = useMobileMenu();
-  const { user } = useAuthStore();
+  const { user, isAuthenticated } = useAuthStore();
   // The lock is for a genuinely signed-out visitor only. A signed-in user whose
   // GET /api/users/me failed also leaves the store empty, and showing
   // them "Guest session" + a padlocked switcher would be a lie the 5-minute
@@ -132,7 +133,21 @@ export function Sidebar() {
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, []);
 
-  const navGroups = navGroupsFor(activeWorkspace.kind, isWorkspaceAdmin(activeWorkspace));
+  // Pending invites are addressed to the account, not the active workspace —
+  // one query drives both the sidebar badge and the topbar bell dot.
+  const { data: myInvites } = useMyInvites({ enabled: isAuthenticated });
+  const pendingInviteCount = myInvites?.length ?? 0;
+
+  const navGroups = navGroupsFor(activeWorkspace.kind, isWorkspaceAdmin(activeWorkspace)).map(
+    (group) => ({
+      ...group,
+      items: group.items.map((item) =>
+        item.href === "/notifications" && pendingInviteCount > 0
+          ? { ...item, badge: pendingInviteCount }
+          : item
+      ),
+    })
+  );
   const wsColor = activeWorkspace.color || A;
   // The cap is the server's verdict (`GET /api/workspaces`), not local
   // arithmetic — the row is disabled with a reason rather than failing on submit.

--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -6,6 +6,8 @@ import { Icons, O, RADIUS, T, TYPE, A } from "@/lib/splito-design";
 import { pageMetaFor } from "@/lib/shell-nav";
 import { useActiveWorkspace } from "@/contexts/workspace";
 import { usePageActionsRenderer, usePageTitleOverride } from "@/contexts/page-title";
+import { useAuthStore } from "@/stores/authStore";
+import { useMyInvites } from "@/features/business/hooks/use-invites";
 
 /**
  * Sticky app header (design 123–139): the current screen's title and subtitle,
@@ -17,12 +19,18 @@ import { usePageActionsRenderer, usePageTitleOverride } from "@/contexts/page-ti
  * to override title/subtitle with its own data once loaded. No override falls
  * back to pageMetaFor()'s static section title.
  */
-export function Topbar({ hasUnread = false }: { hasUnread?: boolean }) {
+export function Topbar() {
   const pathname = usePathname() ?? "/";
   const workspace = useActiveWorkspace();
   const override = usePageTitleOverride();
   const renderActions = usePageActionsRenderer();
   const meta = pageMetaFor(pathname, workspace);
+  const { isAuthenticated } = useAuthStore();
+  // Same query/cache as the sidebar's Notifications badge
+  // (features/business/hooks/use-invites.ts) — one fetch, two surfaces
+  // agreeing on the same count.
+  const { data: myInvites } = useMyInvites({ enabled: isAuthenticated });
+  const hasUnread = (myInvites?.length ?? 0) > 0;
   const title = override?.title ?? meta.title;
   // An empty-string override is how a screen says "no subtitle at all" (as
   // opposed to `undefined`, which falls back to the static section subtitle).
@@ -50,15 +58,13 @@ export function Topbar({ hasUnread = false }: { hasUnread?: boolean }) {
         {/* This screen's own actions, if it published any — usePageActions(). */}
         {renderActions ? renderActions() : null}
 
-        {/* There is no notifications surface yet — no route, no endpoint, and
-            `hasUnread` is never set true. Gated visibly rather than left looking
-            live, since a bell that swallows every click reads as broken. */}
-        <button
-          type="button"
-          disabled
-          aria-disabled="true"
-          aria-label="Notifications — coming soon"
-          title="Notifications are coming soon"
+        {/* `/notifications` (app/notifications/page.tsx) lists pending org
+            invitations addressed to this account; `hasUnread` mirrors the
+            sidebar badge off the same `useMyInvites()` cache. */}
+        <Link
+          href="/notifications"
+          aria-label={hasUnread ? "Notifications — unread invites" : "Notifications"}
+          title="Notifications"
           className="abtn relative flex items-center justify-center transition-all"
           style={{
             width: 36,
@@ -67,8 +73,6 @@ export function Topbar({ hasUnread = false }: { hasUnread?: boolean }) {
             background: "rgba(255,255,255,0.04)",
             border: "1px solid rgba(255,255,255,0.09)",
             color: T.muted,
-            opacity: 0.55,
-            cursor: "not-allowed",
           }}
         >
           {Icons.bell({ size: 16 })}
@@ -85,7 +89,7 @@ export function Topbar({ hasUnread = false }: { hasUnread?: boolean }) {
               }}
             />
           )}
-        </button>
+        </Link>
 
         <Link
           href="/create"

--- a/features/business/api/client.ts
+++ b/features/business/api/client.ts
@@ -304,6 +304,35 @@ export const acceptInvite = async (token: string) => {
   return AcceptInviteResultSchema.parse(response);
 };
 
+/**
+ * `GET /api/invites/mine` — the signed-in user's own pending invites, already
+ * filtered server-side to PENDING + non-expired + addressed to the caller's
+ * email. Drives the in-app notifications surface; `lookupInvite` above stays
+ * the public, token-scoped read for the `/invite/[token]` landing page.
+ */
+export const MyInviteSchema = z.object({
+  id: z.string(),
+  token: z.string(),
+  organizationId: z.string(),
+  organizationName: z.string(),
+  role: OrgRoleSchema,
+  invitedByName: z.string().nullable(),
+  invitedByEmail: z.string().nullable(),
+  createdAt: z.coerce.date(),
+  expiresAt: z.coerce.date(),
+});
+export type MyInvite = z.infer<typeof MyInviteSchema>;
+
+export const getMyInvites = async () => {
+  const response = await apiClient.get("/invites/mine");
+  return z.object({ invites: MyInviteSchema.array() }).parse(response).invites;
+};
+
+/** Invitee-scoped — the invited person turning an offer down, not an org admin revoking it. */
+export const declineInvite = async (inviteId: string) => {
+  await apiClient.post(`/invites/${inviteId}/decline`, {});
+};
+
 export const createInvoice = async (payload: {
   organizationId: string;
   amount: number;

--- a/features/business/hooks/use-invites.ts
+++ b/features/business/hooks/use-invites.ts
@@ -2,6 +2,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   acceptInvite,
   createOrganizationInvite,
+  declineInvite,
+  getMyInvites,
   getOrganizationInvites,
   lookupInvite,
   resendInvite,
@@ -81,9 +83,45 @@ export const useAcceptInvite = () => {
     mutationFn: (token: string) => acceptInvite(token),
     onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: [QueryKeys.BUSINESS_ORGANIZATIONS] });
+      // An accepted invite drops off `/invites/mine` server-side, so the
+      // notifications list and its badge/bell-dot must refetch too.
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.MY_INVITES] });
       // The workspace switcher must know the new workspace before we switch to
       // it, or the context resolves `active` to the personal fallback.
       await queryClient.invalidateQueries({ queryKey: [QueryKeys.WORKSPACES] });
+    },
+  });
+};
+
+/**
+ * The signed-in user's own pending invites — powers the notifications route
+ * plus the bell/badge counts in the shell. Callers gate `enabled` on
+ * `isAuthenticated` themselves (see useWorkspaces) since the shell mounts for
+ * signed-out visitors too and this endpoint requires a session.
+ */
+export const useMyInvites = (options?: { enabled?: boolean }) => {
+  return useQuery({
+    queryKey: [QueryKeys.MY_INVITES],
+    queryFn: getMyInvites,
+    enabled: options?.enabled ?? true,
+  });
+};
+
+/**
+ * Invitee-scoped decline. Invalidates the same caches as useAcceptInvite —
+ * declining seats nobody, so BUSINESS_ORGANIZATIONS/WORKSPACES won't actually
+ * change, but the workspace switcher's query still races the invite list on
+ * every mutation here and staying symmetric means neither branch can drift
+ * out of sync with the other later.
+ */
+export const useDeclineInvite = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (inviteId: string) => declineInvite(inviteId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.MY_INVITES] });
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.BUSINESS_ORGANIZATIONS] });
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.WORKSPACES] });
     },
   });
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,6 +13,11 @@ export const QueryKeys = {
   BUSINESS_ORGANIZATIONS: "business-organizations",
   ORGANIZATION_MEMBERS: "organization-members",
   ORGANIZATION_INVITES: "organization-invites",
+  // The signed-in user's own pending invites (`GET /api/invites/mine`) — a
+  // DIFFERENT cache from ORGANIZATION_INVITES, which is one org's invite list
+  // seen by an admin managing that org. This one drives the notifications
+  // bell/badge and is scoped to the caller's email, not an organizationId.
+  MY_INVITES: "my-invites",
   INVOICES: "invoices",
   ORGANIZATION_ACTIVITY: "organization-activity",
   STREAMS: "streams",

--- a/lib/shell-nav.ts
+++ b/lib/shell-nav.ts
@@ -42,7 +42,10 @@ const PERSONAL_NAV: NavGroup[] = [
   },
   {
     label: "Account",
-    items: [{ href: "/settings", label: "Settings", dot: T.dim }],
+    items: [
+      { href: "/notifications", label: "Notifications", dot: A },
+      { href: "/settings", label: "Settings", dot: T.dim },
+    ],
   },
 ];
 
@@ -64,7 +67,10 @@ const BUSINESS_NAV: NavGroup[] = [
   },
   {
     label: "Account",
-    items: [{ href: "/settings", label: "Settings", dot: T.dim }],
+    items: [
+      { href: "/notifications", label: "Notifications", dot: A },
+      { href: "/settings", label: "Settings", dot: T.dim },
+    ],
   },
 ];
 
@@ -114,6 +120,7 @@ const PERSONAL_META: Record<string, MetaFactory> = {
   "/create": () => ({ title: "New request", subtitle: "Ask in any currency, get paid in the one you want" }),
   "/groups": () => ({ title: "Groups", subtitle: "Running tabs with the people you see often" }),
   "/people": () => ({ title: "People", subtitle: "Everyone you've requested from or paid" }),
+  "/notifications": () => ({ title: "Notifications", subtitle: "Workspace invitations addressed to you" }),
   "/settings": () => ({ title: "Settings", subtitle: "Your account and how you get paid" }),
 };
 
@@ -124,6 +131,7 @@ const BUSINESS_META: Record<string, MetaFactory> = {
   "/create": () => ({ title: "New request", subtitle: "Bill a client, or pay someone out" }),
   "/members": () => ({ title: "Members", subtitle: "Who's here, and on what terms" }),
   "/treasury": () => ({ title: "Treasury Log", subtitle: "What's come in, what's gone out, and where it stands" }),
+  "/notifications": () => ({ title: "Notifications", subtitle: "Workspace invitations addressed to you" }),
   "/settings": () => ({ title: "Settings", subtitle: "Workspace settings and defaults" }),
 };
 


### PR DESCRIPTION
## Summary
An invited user had no in-app way to discover an org invitation. The invite row and the `/invite/<token>` accept page already existed, but nothing surfaced the invite to the invitee — if the notification email was missed, the workspace simply never appeared in their switcher.

- New `/notifications` route: sign-in gate, loading, error-with-retry, empty state, and invite cards (org / role / inviter / relative time) with Accept, Reject, View actions. Per-row pending state so double-clicks can't double-fire.
- "Notifications" nav item added to the Account group of both PERSONAL_NAV and BUSINESS_NAV — an invite targets the account's email, not the active workspace, so gating it to one workspace kind would hide invites depending on which workspace you last switched to.
- Sidebar badge shows the live pending count (only rendered when > 0).
- Topbar bell un-disabled: now a `Link` to `/notifications` with unread state read from the same shared query; removed the never-passed `hasUnread` prop and the stale "no notifications surface yet" comment.
- New `useMyInvites()` / `useDeclineInvite()` hooks (`features/business/hooks/use-invites.ts`), backed by a new `MyInviteSchema` + `getMyInvites()`/`declineInvite()` in `features/business/api/client.ts`, and a new `QueryKeys.MY_INVITES`.
- Accept and decline both invalidate `MY_INVITES`, `BUSINESS_ORGANIZATIONS`, and `WORKSPACES` — the last is what the workspace switcher reads, so an accepted workspace appears with no page reload.

## Merge order
**Merge Splitoio/backend#37 BEFORE this PR** — this route calls `GET /api/invites/mine` and `POST /api/invites/:inviteId/decline`, introduced there.

## Known gap (pre-existing, unrelated to this branch)
`pnpm run lint` cannot run at all right now — Next 16.2.1 removed the `next lint` subcommand and ESLint 9 won't read the legacy `.eslintrc.json`. Not something this PR attempts to fix.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Manual QA through the running app with three throwaway accounts:
  - Invite card + nav badge + bell all render for a real pending invite
  - Accept makes the new workspace appear in the switcher with no reload
  - Reject creates no membership
  - View opens `/invite/<token>`
  - An uninvited third account never sees the invite
  - Direct backend calls confirmed 404 / 409 / idempotent-200 for the decline gate