### PR TITLE
feat(pay): recognise signed-in payers and pre-select their saved wallet

### DIFF
--- a/app/pay/[token]/page.tsx
+++ b/app/pay/[token]/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/pay/amount-hero";
 import { PayerPicker } from "@/components/pay/payer-picker";
 import { WalletConnect, type ConnectedWallet } from "@/components/pay/wallet-connect";
+import { usePayerIdentity } from "@/components/pay/use-payer-identity";
 import { SourcePicker } from "@/components/pay/source-picker";
 import { QuotePanel } from "@/components/pay/quote-panel";
 import { SummaryPanel } from "@/components/pay/summary-panel";
@@ -570,6 +571,30 @@ export default function PayRequestPage() {
 
   const payerShare = request?.payers.find((p) => p.payerId === selectedPayerId)?.shareAmount;
 
+  /**
+   * The ONLY two places this page knows about accounts. Both fail open: a
+   * guest, a failed lookup, or a signed-in payer with nothing saved on this
+   * chain all land back on the untouched anonymous flow. See
+   * components/pay/use-payer-identity.ts — in particular why the page has to
+   * ask for the session itself rather than read useSessionStatus().
+   *
+   * Nothing here is passed to the public API. `payerId` is still the only
+   * thing that identifies who paid; the payment is submitted through the
+   * unauthenticated public router exactly as before.
+   */
+  const { name: payerName, savedAddress } = usePayerIdentity(
+    request?.destinationChain ?? null
+  );
+
+  // Narrowed to the two chains this app can actually sign on (pay-wallet.ts).
+  // The backend may know more chains than we have adapters for, and suggesting
+  // a wallet we could never sign with would be a dead end.
+  const savedWallet = useMemo(() => {
+    const chain = request?.destinationChain;
+    if (!savedAddress || (chain !== "stellar" && chain !== "solana")) return null;
+    return { chain, address: savedAddress } as const;
+  }, [request?.destinationChain, savedAddress]);
+
   // "Paid"/"already-paid" is the design's separate full-page receipt state
   // (.design/splito-finance.dc.html:1578-1623) — no top header row, more top
   // padding instead. Every other phase gets the guest-checkout header
@@ -586,8 +611,11 @@ export default function PayRequestPage() {
         >
           <Image src="/logo.svg" alt="Splito" width={88} height={22} className="h-[22px] w-auto opacity-85" />
           <div className="flex-1" />
+          {/* "guest" stays the literal, unconditional fallback: it is what a
+              stranger sees, what a failed session lookup sees, and what a
+              still-loading one sees. Only a resolved name replaces it. */}
           <span className="text-[12px]" style={{ color: T.dim }}>
-            Paying as guest
+            {payerName ? `Paying as ${payerName}` : "Paying as guest"}
           </span>
           <Link
             href="/"
@@ -654,7 +682,10 @@ export default function PayRequestPage() {
             <div className="flex flex-col gap-4">
               {phase === "connect-wallet" && (
                 <Card className="p-6">
-                  <WalletConnect onConnected={handleWalletConnected} />
+                  <WalletConnect
+                    onConnected={handleWalletConnected}
+                    savedWallet={savedWallet}
+                  />
                 </Card>
               )}
 

--- a/components/pay/use-payer-identity.ts
+++ b/components/pay/use-payer-identity.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useSession } from "@/lib/auth";
+
+/**
+ * Who is looking at /pay/[token] — for the only two things the public payer
+ * flow is allowed to personalise: the header line ("Paying as <name>") and
+ * which wallet to SUGGEST.
+ *
+ * Everything in here FAILS OPEN, by design. /pay is the no-account flow
+ * (.plans/2026-08-06-request-money.md "NO AUTH, EVER"): an anonymous visitor —
+ * or a signed-in one whose lookup 401s, 500s, or never answers — must get
+ * exactly the guest page, "Paying as guest" plus the plain connect buttons.
+ * Nothing on this page is ever gated, blocked, or spinnered on the answer, and
+ * neither lookup here can surface an error to the payer.
+ *
+ * Three deliberate choices:
+ *
+ * 1. The page has to ask for itself. components/AuthProvider.tsx sets
+ *    `skipFetch` for every public route except "/", so on /pay it never fires
+ *    GET /users/me — which means useAuthStore().user is null and
+ *    useSessionStatus() reports "anonymous" here for EVERYONE, signed in or
+ *    not. Reading either of those would have made this feature silently dead.
+ *
+ * 2. The wallet lookup goes to the AUTHENTICATED endpoint
+ *    `GET /api/multichain/accounts` (backend/src/routes/multichain.routes.ts,
+ *    the same one the settings Wallets tab uses), never to the public request
+ *    router. That router is unauthenticated on purpose and says so in its own
+ *    header — "No getSession anywhere on this router" — and teaching it to read
+ *    a session is what would quietly turn the stranger's pay screen into an
+ *    account-aware one. The payment itself still submits through the public
+ *    route, completely unchanged.
+ *
+ * 3. It does NOT call `getUserWallets()` from features/wallets/api/client.ts,
+ *    even though that helper hits this exact endpoint: it fires a
+ *    `toast.error("Failed to fetch wallet accounts")` on every failure, and a
+ *    red toast on a payment page is precisely the payer-visible regression this
+ *    must never introduce. Same endpoint, silent client.
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+/** The subset of a ChainAccount row this page needs. */
+interface PayerWallet {
+  chainId: string;
+  address: string;
+  isDefault: boolean;
+}
+
+/** Resolves to `[]` for every failure mode — 401, 5xx, network, bad JSON. */
+async function fetchPayerWallets(): Promise<PayerWallet[]> {
+  try {
+    const response = await fetch(`${API_URL}/api/multichain/accounts`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+    });
+    if (!response.ok) return [];
+    const payload = await response.json();
+    const accounts = (payload as { accounts?: unknown } | null)?.accounts;
+    return Array.isArray(accounts) ? (accounts as PayerWallet[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export interface PayerIdentity {
+  /** Display name of the signed-in visitor. Null for a guest — render "guest". */
+  name: string | null;
+  /** Their saved address on `chain`, when one is unambiguous. Null otherwise. */
+  savedAddress: string | null;
+}
+
+/**
+ * @param chain the request's destination chain, or null while it loads.
+ */
+export function usePayerIdentity(chain: string | null): PayerIdentity {
+  // better-auth's own hook, the one lib/auth.ts exports for this. It answers
+  // 200-with-null for an anonymous visitor rather than 401, so the guest path
+  // produces no error state anywhere.
+  const { data: session } = useSession();
+  const user = session?.user ?? null;
+
+  const { data: wallets } = useQuery({
+    // Keyed by user so signing out (or in, as someone else) cannot serve the
+    // previous visitor's addresses from cache.
+    queryKey: ["pay", "payer-wallets", user?.id ?? null],
+    queryFn: fetchPayerWallets,
+    // A guest must never generate this request at all.
+    enabled: !!user,
+    staleTime: 1000 * 60 * 5,
+    retry: false,
+  });
+
+  const savedAddress = useMemo(() => {
+    if (!chain || !wallets?.length) return null;
+    const onChain = wallets.filter(
+      (w) => typeof w?.address === "string" && w.address && w.chainId === chain
+    );
+    if (!onChain.length) return null;
+    // The default for this chain wins. Failing that, a single wallet on the
+    // chain is unambiguous enough to suggest. Two non-default wallets IS a
+    // real choice, so suggest nothing and let them pick — and never write a
+    // default back to make the ambiguity go away.
+    const preferred =
+      onChain.find((w) => w.isDefault) ?? (onChain.length === 1 ? onChain[0] : null);
+    return preferred?.address ?? null;
+  }, [wallets, chain]);
+
+  const name =
+    typeof user?.name === "string" && user.name.trim() ? user.name.trim() : null;
+
+  return { name, savedAddress };
+}

--- a/components/pay/wallet-connect.tsx
+++ b/components/pay/wallet-connect.tsx
@@ -16,6 +16,16 @@ export interface ConnectedWallet {
   stellarKit?: StellarWalletsKit;
 }
 
+/** "GABCDEF…UVWXYZ" — recognisable at a glance, never the full string. */
+function shortAddress(address: string): string {
+  return address.length > 16 ? `${address.slice(0, 6)}…${address.slice(-6)}` : address;
+}
+
+const CHAIN_LABEL: Record<PayWalletChain, string> = {
+  stellar: "Stellar",
+  solana: "Solana",
+};
+
 /**
  * Lowest-intimidation wallet step. Destinations in scope are Stellar and
  * Solana only (contract §0.1) — offer whichever wallet the payer already
@@ -23,8 +33,25 @@ export interface ConnectedWallet {
  */
 export function WalletConnect({
   onConnected,
+  savedWallet = null,
 }: {
   onConnected: (wallet: ConnectedWallet) => void;
+  /**
+   * The signed-in payer's saved address for this request's destination chain,
+   * when exactly one is unambiguous — see use-payer-identity.ts. Null for a
+   * guest, and when it is null this component renders EXACTLY what it always
+   * did, down to the button styling.
+   *
+   * It is a pre-selection, not a shortcut. Paying requires a signature and a
+   * signature requires the live wallet (Stellar Wallets Kit / Phantom), so a
+   * stored address can never stand in for connecting — see pay-wallet.ts,
+   * where signing needs the `StellarWalletsKit` instance the connect step
+   * builds, and where Phantom refuses to sign for an address it isn't
+   * currently unlocked to. What this DOES remove is the "which chain am I
+   * paying from?" decision, and it tells the payer up front which of their
+   * accounts we expect — instead of making them work it out from scratch.
+   */
+  savedWallet?: { chain: PayWalletChain; address: string } | null;
 }) {
   const [connecting, setConnecting] = useState<PayWalletChain | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -66,13 +93,63 @@ export function WalletConnect({
       <p className="text-[12.5px] mb-4" style={{ color: T.dim }}>
         Pay from wherever your money already is.
       </p>
+
+      {/* The saved-wallet block and the demotion below it are BOTH gated on
+          `savedWallet`. A guest renders the original two-button grid with the
+          original styling — this whole branch is invisible to them. */}
+      {savedWallet && (
+        <div className="mb-5">
+          <button
+            type="button"
+            onClick={savedWallet.chain === "stellar" ? handleStellar : handleSolana}
+            disabled={connecting !== null}
+            className="w-full flex items-center justify-center gap-2 rounded-xl py-3.5 text-[13.5px] font-extrabold transition-all hover:opacity-90 disabled:opacity-50"
+            style={{ background: A, color: "#0a0a0a" }}
+          >
+            {connecting === savedWallet.chain ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : null}
+            Continue with your saved wallet
+          </button>
+          <p
+            className="text-[11.5px] mt-2 text-center font-mono truncate"
+            style={{ color: T.dim }}
+          >
+            {CHAIN_LABEL[savedWallet.chain]} · {shortAddress(savedWallet.address)}
+          </p>
+          {/* Said plainly, because the button above does NOT skip the wallet:
+              it opens the same connect step, already pointed at the right
+              chain. Promising less friction than that would be a lie the
+              signature prompt immediately exposes. */}
+          <p className="text-[11.5px] mt-1.5 text-center" style={{ color: T.muted }}>
+            You&rsquo;ll still approve the payment in your wallet.
+          </p>
+          <p
+            className="text-[11px] font-bold tracking-[0.08em] uppercase mt-5 mb-2.5"
+            style={{ color: T.muted }}
+          >
+            Or use a different wallet
+          </p>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
         <button
           type="button"
           onClick={handleStellar}
           disabled={connecting !== null}
-          className="flex items-center justify-center gap-2 rounded-xl py-3.5 text-[13.5px] font-extrabold transition-all hover:opacity-90 disabled:opacity-50"
-          style={{ background: A, color: "#0a0a0a" }}
+          className={
+            savedWallet
+              ? "flex items-center justify-center gap-2 rounded-xl py-3.5 text-[13.5px] font-extrabold border transition-all hover:bg-white/5 disabled:opacity-50"
+              : "flex items-center justify-center gap-2 rounded-xl py-3.5 text-[13.5px] font-extrabold transition-all hover:opacity-90 disabled:opacity-50"
+          }
+          // With a saved wallet suggested above, the accent belongs to THAT
+          // button — two primaries would be two "do this first"s.
+          style={
+            savedWallet
+              ? { borderColor: "rgba(255,255,255,0.14)", color: T.bright }
+              : { background: A, color: "#0a0a0a" }
+          }
         >
           {connecting === "stellar" ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
           Connect Stellar wallet


### PR DESCRIPTION
## What

The public request-payment page `/pay/[token]` treated every visitor as anonymous. A signed-in visitor now:

1. Sees **"Paying as `<their name>`"** instead of the hardcoded "Paying as guest".
2. Gets their **saved wallet pre-selected** for the request's destination chain, instead of picking from bare connect buttons.

**App-only — no backend changes.** `git diff --stat` in `backend/` is empty.

## Why it was broken

"Paying as guest" was a literal string at `app/pay/[token]/page.tsx:588-591`, and `useSession` was never imported anywhere under `app/pay/`. "Back to app" is a plain `<Link href="/">`, not a session tell. The page simply could not distinguish a signed-in visitor from a stranger.

## Approach

Reuses the existing session-guarded **`GET /api/multichain/accounts`** (`backend/src/routes/multichain.routes.ts`), the same endpoint the Settings Wallets tab uses. **The public request router was not touched** — its anonymity is deliberate and documented (`public-request.routes.ts:18-21`: *"Fully public — the pay screen for someone who has never used the product"*), and the payment still submits through it unchanged.

Two non-obvious traps, recorded so the next person doesn't hit them:

- **`AuthProvider` sets `skipFetch` for `/pay`**, so `useAuthStore().user` is null and `useSessionStatus()` returns `"anonymous"` there **for everyone**, signed in or not. Reading either would have made this silently dead. The page asks for its own session.
- **`useUserWallets()` could not be reused as-is** — no `enabled` flag (a guest fires the request and gets retried 401s) and its client calls `toast.error(...)` on failure, i.e. a red error toast on a stranger's payment page. `use-payer-identity.ts` does its own silent fetch against the same endpoint, gated on session, resolving to `[]` on every failure.

`features/wallets/hooks/use-wallets.ts` was **not** modified — no conflict with #29.

## On "pre-select" vs "prefill"

Signing requires the live `StellarWalletsKit` instance that connect constructs, so a stored address structurally cannot replace connecting. The saved wallet is the pre-selected primary option, labeled with its chain and truncated address, other chains demoted to secondary — and the UI says so out loud: *"You'll still approve the payment in your wallet."*

## Verified — 4/5, with the fifth stated honestly

| # | Scenario | Result |
|---|---|---|
| 1 | Signed in + saved Stellar wallet | **Pass.** "Paying as Priya Testpayer", address pre-selected, `accounts → 200` |
| 2 | Signed in, no wallet on chain | **Pass.** Name shown, normal connect buttons, `{"accounts":[]}` |
| 3 | **Anonymous — the regression check** | **Pass, actually run signed out** (separate browser instance, `cookies` returned `[]`). "Paying as guest", original buttons, **zero calls** to the wallets endpoint, no console errors, public-router traffic identical |
| 4 | Two wallets, one default | **Pass.** Picked the default. Two-wallets-no-default suggests nothing, as specified |
| 5 | Full pay flow past step 1 | **Not completed — see below** |

**Scenario 5 was not verified end to end.** Headless Chrome has no wallet extension, so the Stellar kit modal lists Freighter/Rabet/LOBSTR/Hana/Klever as "Not available" and no signature is reachable. What was confirmed: the saved-wallet button opens the **Stellar** kit (correct chain), and `POST /api/public/requests/:token/quote` with that address returns **200** with a full quote and unsigned tx — the exact call made right after connect. This diff touches only header copy and `WalletConnect` props; nothing in the quote/sign/submit path changed.

## One behaviour change for guests

The page now issues one extra `GET /api/auth/get-session`, which returns `200` with `null` for anonymous visitors. No 401, no error state, no toast, nothing rendered differently.

`pnpm exec tsc --noEmit` clean.

## Out of scope, deliberately

Attributing the payment to the signed-in account, any `paidByUserId`/schema change, request history, and a dedicated in-app "pay what I owe" page. Note that for non-group requests `payerId` is a throwaway shadow `User` row minted at request creation, so real attribution needs its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxsYSH8yNJxsjKgzvtZQGY