### PR TITLE
feat(invites): warn the admin when an invite email could not be delivered

### DIFF
--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -280,8 +280,16 @@ function MembersScreen() {
     createInvite.mutate(
       { organizationId, payload: { email: trimmedEmail, role } },
       {
-        onSuccess: () => {
-          toast.success(`Invite sent to ${trimmedEmail}`);
+        onSuccess: (invite) => {
+          if (invite.emailDelivered === false) {
+            toast.warning(
+              invite.deliveryError ??
+                `Invite created, but the email to ${trimmedEmail} couldn't be sent — share the link manually`
+            );
+            if (invite.inviteUrl) void copyLink(invite.inviteUrl);
+          } else {
+            toast.success(`Invite sent to ${trimmedEmail}`);
+          }
           closeInvite();
         },
         onError: (err: unknown) => toast.error(errMsg(err, "Failed to invite")),
@@ -342,6 +350,14 @@ function MembersScreen() {
   const handleResend = (invite: OrganizationInvite) => {
     resend.mutate(invite.id, {
       onSuccess: (updated) => {
+        if (updated.emailDelivered === false) {
+          toast.warning(
+            updated.deliveryError ??
+              "New link created, but the email couldn't be sent — share the link manually"
+          );
+          if (updated.inviteUrl) void copyLink(updated.inviteUrl);
+          return;
+        }
         toast.success(
           invite.kind === "email"
             ? "Invite re-sent — the previous link has stopped working"

--- a/features/business/api/client.ts
+++ b/features/business/api/client.ts
@@ -67,6 +67,14 @@ export const OrganizationInviteSchema = z.object({
     .nullable(),
   /** Only returned by create/resend — the list never leaks the token. */
   inviteUrl: z.string().optional(),
+  /**
+   * Only returned by create/resend, and only when the invite has an email
+   * (link-only invites never attempt delivery). `false` means the invite row
+   * is still valid — the admin just needs to share `inviteUrl` manually.
+   */
+  emailDelivered: z.boolean().optional(),
+  /** User-facing reason, present only when `emailDelivered` is `false`. */
+  deliveryError: z.string().optional(),
 });
 export type OrganizationInvite = z.infer<typeof OrganizationInviteSchema>;
 


### PR DESCRIPTION
Fixes the app half of queue ticket **#19**.

## Why

The Members page fired an unconditional success toast on invite create and resend, so an admin was told "invite sent" even when no email went out. The backend now reports delivery status; this renders it.

## Changes

- **`features/business/api/client.ts`** — `OrganizationInviteSchema` gains `emailDelivered: z.boolean().optional()` and `deliveryError: z.string().optional()`.
- **`app/members/page.tsx`** — `handleSubmitInvite` and `handleResend` gate their success toast on `emailDelivered !== false`. When delivery failed, they raise a `toast.warning` carrying the backend's `deliveryError` (with a local fallback) and auto-copy the invite link via the existing `copyLink` helper, since the whole point is that the admin now has to share it manually.

`toast.warning` (sonner) matches the convention already used in `components/add-member-modal.tsx`. No new dependency, no new notification pattern. Link-only invites — which never get the delivery fields — are unchanged.

## Merge order

**Merge `Splitoio/backend#38` first.** It introduces the `emailDelivered` / `deliveryError` fields this PR reads. Both fields are optional in the zod schema, so this degrades to today's behaviour if it lands first, but backend-first is the correct order.

## Verification

`npx tsc --noEmit` clean.

QA'd end-to-end in a browser against a local stack with `RESEND_API_KEY` unset: inviting by email raised the warning toast *"Email delivery is not configured. Share the invite link directly."* instead of a success toast, Resend behaved identically, and the invites still appeared in the pending list with working `/invite/<token>` pages.

Two things reviewers should know:
- The auto-copy raises a second `error` toast ("Couldn't copy") under headless Chrome, which has no clipboard permission. That is a test-environment artifact, but the resulting two-toast stack is worth an eye in a real browser.
- `pnpm lint` / `next lint` is broken in this checkout independently of this change (no resolvable `eslint.config.js`) — it was already failing on unrelated commits, so lint was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUXdG88s2bocjrcUvfooe1